### PR TITLE
Stop ObjectDisposedException exception when disposing listener

### DIFF
--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -53,6 +53,9 @@ namespace Halibut.Transport
             {
                 try
                 {
+                    if (isStopped)
+                        return;
+
                     var client = listener.EndAcceptTcpClient(r);
                     if (isStopped)
                         return;


### PR DESCRIPTION
This will stop the ObjectDisposedException when disposing the listener. No point attempting EndAcceptTcpClient if the listener is already disposed.