### PR TITLE
Allow custom friendly html page, one per runtime.

### DIFF
--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -12,6 +12,8 @@ namespace Halibut
 {
     public class HalibutRuntime : IDisposable
     {
+        public static readonly string DefaultFriendlyHtmlPageContent = "<html><body><p>Hello!</p></body></html>";
+
         readonly ConcurrentDictionary<Uri, PendingRequestQueue> queues = new ConcurrentDictionary<Uri, PendingRequestQueue>();
         readonly X509Certificate2 serverCertficiate;
         readonly List<SecureListener> listeners = new List<SecureListener>();
@@ -21,7 +23,8 @@ namespace Halibut
         readonly LogFactory logs = new LogFactory();
         readonly ConnectionPool<ServiceEndPoint, SecureConnection> pool = new ConnectionPool<ServiceEndPoint, SecureConnection>();
         readonly PollingClientCollection pollingClients = new PollingClientCollection();
-        
+        string friendlyHtmlPageContent = DefaultFriendlyHtmlPageContent;
+
         public HalibutRuntime(X509Certificate2 serverCertficiate) : this(new NullServiceFactory(), serverCertficiate)
         {
         }
@@ -54,7 +57,7 @@ namespace Halibut
 
         public int Listen(IPEndPoint endpoint)
         {
-            var listener = new SecureListener(endpoint, serverCertficiate, ListenerHandler, VerifyThumbprintOfIncomingClient, logs);
+            var listener = new SecureListener(endpoint, serverCertficiate, ListenerHandler, VerifyThumbprintOfIncomingClient, logs, () => friendlyHtmlPageContent);
             listeners.Add(listener);
             return listener.Start();
         }
@@ -138,6 +141,11 @@ namespace Halibut
         public void Route(ServiceEndPoint to, ServiceEndPoint via)
         {
             routeTable.TryAdd(to.BaseUri, via);
+        }
+
+        public void SetFriendlyHtmlPageContent(string html)
+        {
+            friendlyHtmlPageContent = html ?? DefaultFriendlyHtmlPageContent;
         }
 
         public void Dispose()

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -19,17 +19,19 @@ namespace Halibut.Transport
         readonly Action<MessageExchangeProtocol> protocolHandler;
         readonly Predicate<string> verifyClientThumbprint;
         readonly ILogFactory logFactory;
+        readonly Func<string> getFriendlyHtmlPageContent;
         ILog log;
         TcpListener listener;
         bool isStopped;
 
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory)
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent)
         {
             this.endPoint = endPoint;
             this.serverCertificate = serverCertificate;
             this.protocolHandler = protocolHandler;
             this.verifyClientThumbprint = verifyClientThumbprint;
             this.logFactory = logFactory;
+            this.getFriendlyHtmlPageContent = getFriendlyHtmlPageContent;
 
             EnsureCertificateIsValidForListening(serverCertificate);
         }
@@ -121,9 +123,9 @@ namespace Halibut.Transport
             }
         }
 
-        static void SendFriendlyHtmlPage(Stream stream)
+        void SendFriendlyHtmlPage(Stream stream)
         {
-            var message = "<html><body><p>Hello!</p></body></html>";
+            var message = getFriendlyHtmlPageContent();
             var writer = new StreamWriter(stream, new UTF8Encoding(false));
             writer.WriteLine("HTTP/1.0 200 OK");
             writer.WriteLine("Content-Type: text/html; charset=utf-8");


### PR DESCRIPTION
To better support Tentacle and Octopus it makes sense to provide a more tailored message depending on the host process. This will make it easier to determine who is responding to your HTTPS requests when troubleshooting.