### PR TITLE
Reliably close stream/socket in failure mode.

### DIFF
--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -223,6 +223,18 @@ namespace Halibut.Tests
             }
         }
 
+        [Test]
+        [Timeout(5000)]
+        [Description("Connecting over a non-secure connection should cause the socket to be closed by the server. The socket used to be held open indefinitely for any failure to establish an SslStream.")]
+        public void ConnectingOverHttpShouldFailQuickly()
+        {
+            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            {
+                var listenPort = octopus.Listen();
+                Assert.Throws<WebException>(() => DownloadStringIgnoringCertificateValidation("http://localhost:" + listenPort));
+            }
+        }
+
         static string DownloadStringIgnoringCertificateValidation(string uri)
         {
             using (var webClient = new WebClient())


### PR DESCRIPTION
Being more defensive about closing the socket. For example when we failed to establish an SslStream (say a clear HTTP request) we would hold the socket open indefinitely. Now we expect everything to be perfect for the Stream to be held open.