### PR TITLE
Use HalbutClientException consistently to make debugging easier

### DIFF
--- a/source/Halibut/HalibutClientException.cs
+++ b/source/Halibut/HalibutClientException.cs
@@ -4,7 +4,13 @@ namespace Halibut
 {
     public class HalibutClientException : Exception
     {
-        public HalibutClientException(string message, Exception inner) : base(message, inner)
+        public HalibutClientException(string message)
+            : base(message)
+        {
+        }
+
+        public HalibutClientException(string message, Exception inner)
+            : base(message, inner)
         {
         }
 

--- a/source/Halibut/Transport/TcpClientExtensions.cs
+++ b/source/Halibut/Transport/TcpClientExtensions.cs
@@ -22,7 +22,7 @@ namespace Halibut.Transport
                 {
                 }
 
-                throw new Exception("The client was unable to establish the initial connection within " + HalibutLimits.TcpClientConnectTimeout);
+                throw new HalibutClientException("The client was unable to establish the initial connection within " + HalibutLimits.TcpClientConnectTimeout);
             }
 
             client.EndConnect(connectResult);


### PR DESCRIPTION
During debugging against an unreliable connection the debugger can be set to not break on a thrown `HalibutClientException`. This works for most problems encountered but not for this one exception here which comes out as a plain `Exception`. Changing this to a `HalbiutClientException` makes debugging easier.