### PR TITLE
Throw HalibutClientException with helpful message instead of an NRE

### DIFF
--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -76,6 +76,9 @@ namespace Halibut.ServiceModel
 
         static void EnsureNotError(ResponseMessage responseMessage)
         {
+            if (responseMessage == null)
+                throw new HalibutClientException("No response was received from the endpoint within the allowed time.");
+
             if (responseMessage.Error == null)
                 return;
 


### PR DESCRIPTION
Throw HalibutClientException with helpful message instead of an unhandled exception if we fail to get a response from the endpoint.

This was causing the upgrade Tentacle task for write out a warning about the unhandled NRE being rethrown when upgrading polling Tentacles

![image](https://cloud.githubusercontent.com/assets/1035315/11202244/e95ac7ee-8d31-11e5-9109-3b3f616391a6.png)
