### PR TITLE
Increase timeouts

### DIFF
--- a/source/Halibut/Diagnostics/HalibutLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutLimits.cs
@@ -23,13 +23,13 @@ namespace Halibut.Diagnostics
         public static TimeSpan PollingRequestQueueTimeout = TimeSpan.FromMinutes(2);
         public static TimeSpan PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromMinutes(10);
         public static TimeSpan RetryListeningSleepInterval = TimeSpan.FromSeconds(1);
-        public static TimeSpan ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(60);
+        public static TimeSpan ConnectionErrorRetryTimeout = TimeSpan.FromMinutes(5);
         public static TimeSpan TcpClientSendTimeout = TimeSpan.FromMinutes(10);
         public static TimeSpan TcpClientReceiveTimeout = TimeSpan.FromMinutes(10);
         public static TimeSpan TcpClientPooledConnectionTimeout = TimeSpan.FromMinutes(9);
-        public static TimeSpan TcpClientHeartbeatSendTimeout = TimeSpan.FromSeconds(30);
-        public static TimeSpan TcpClientHeartbeatReceiveTimeout = TimeSpan.FromSeconds(30);
-        public static TimeSpan TcpClientConnectTimeout = TimeSpan.FromSeconds(30);
+        public static TimeSpan TcpClientHeartbeatSendTimeout = TimeSpan.FromSeconds(60);
+        public static TimeSpan TcpClientHeartbeatReceiveTimeout = TimeSpan.FromSeconds(60);
+        public static TimeSpan TcpClientConnectTimeout = TimeSpan.FromSeconds(60);
         public static TimeSpan PollingQueueWaitTimeout = TimeSpan.FromSeconds(30);
     }
 }


### PR DESCRIPTION
Increasing some default timeouts in an attempt to make connections more robust.

Connects to https://github.com/OctopusDeploy/Issues/issues/1977