### PR TITLE
Connection pool is cleared if two consecutive errors are received.

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="FailureModesFixture.cs" />
     <Compile Include="LocalDataStreamFixture.cs" />
     <Compile Include="ProtocolFixture.cs" />
+    <Compile Include="SecureClientFixture.cs" />
     <Compile Include="TestServices\SupportedServices.cs" />
     <Compile Include="TestServices\EchoService.cs" />
     <Compile Include="TestServices\IEchoService.cs" />

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Transport;
+using Halibut.Transport.Protocol;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    [TestFixture]
+    public class SecureClientFixture
+    {
+        ServiceEndPoint endpoint;
+        HalibutRuntime tentacle;
+        ILog log;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            tentacle = new HalibutRuntime(services, Certificates.TentacleListening);
+            var tentaclePort = tentacle.Listen();
+            tentacle.Trust(Certificates.OctopusPublicThumbprint);
+            endpoint = new ServiceEndPoint("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+            log = new InMemoryConnectionLog(endpoint.ToString());
+            HalibutLimits.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            tentacle.Dispose();
+        }
+
+        [Test]
+        public void SecureClientClearsPoolWhenAllConnectionsCorrupt()
+        {
+            var pool = new ConnectionPool<ServiceEndPoint, IConnection>();
+            var stream = Substitute.For<IMessageExchangeStream>();
+            stream.When(x => x.IdentifyAsClient()).Do(x => { throw new ConnectionInitializationFailedException(""); });
+            for (int i = 0; i < SecureClient.RetryCountLimit; i++)
+            {
+                var connection = Substitute.For<IConnection>();
+                connection.Protocol.Returns(new MessageExchangeProtocol(stream));
+                pool.Return(endpoint, connection);
+            }
+
+            var request = new RequestMessage
+            {
+                Destination = endpoint,
+                ServiceName = "IEchoService",
+                MethodName = "SayHello",
+                Params = new object[] { "Fred" }
+            };
+
+            var secureClient = new SecureClient(endpoint, Certificates.Octopus, log, pool);
+            ResponseMessage response = null;
+            secureClient.ExecuteTransaction((mep) => response = mep.ExchangeAsClient(request));
+
+            // The pool should be cleared after the second failure
+            stream.Received(2).IdentifyAsClient();
+            // And a new valid connection should then be made
+            Assert.AreEqual("Fred...", response.Result);
+        }
+    }
+}

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -58,6 +58,7 @@
     <Compile Include="ServiceModel\HalibutProxy.cs" />
     <Compile Include="DataStream.cs" />
     <Compile Include="Transport\DiscoveryClient.cs" />
+    <Compile Include="Transport\IConnection.cs" />
     <Compile Include="Transport\IPooledResource.cs" />
     <Compile Include="Transport\Protocol\InMemoryDataStreamReceiver.cs" />
     <Compile Include="Transport\Protocol\ServerError.cs" />

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -21,7 +21,7 @@ namespace Halibut
         readonly ConcurrentDictionary<Uri, ServiceEndPoint> routeTable = new ConcurrentDictionary<Uri, ServiceEndPoint>();
         readonly ServiceInvoker invoker;
         readonly LogFactory logs = new LogFactory();
-        readonly ConnectionPool<ServiceEndPoint, SecureConnection> pool = new ConnectionPool<ServiceEndPoint, SecureConnection>();
+        readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new ConnectionPool<ServiceEndPoint, IConnection>();
         readonly PollingClientCollection pollingClients = new PollingClientCollection();
         string friendlyHtmlPageContent = DefaultFriendlyHtmlPageContent;
 

--- a/source/Halibut/Transport/IConnection.cs
+++ b/source/Halibut/Transport/IConnection.cs
@@ -1,0 +1,9 @@
+﻿using Halibut.Transport.Protocol;
+
+namespace Halibut.Transport
+{
+    public interface IConnection : IPooledResource
+    {
+        MessageExchangeProtocol Protocol { get; } 
+    }
+}

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -6,7 +6,7 @@ using Halibut.Transport.Protocol;
 
 namespace Halibut.Transport
 {
-    public class SecureConnection : IPooledResource
+    public class SecureConnection : IConnection
     {
         readonly TcpClient client;
         readonly SslStream stream;


### PR DESCRIPTION
This is an attempt to address the following scenario (witnessed in the wild):

The connection pool for a particular endpoint is full (5 slots taken).  Something (chief suspect would be a proxy, firewall, etc) decides that the connections have been open for too long, and kills all 5 pooled connections, unbeknownst to Halibut.  When the next message is sent, it is retried 5 times, but all 5 retries are using pooled, dead connections.

Connects to OctopusDeploy/Issues#1977