### PR TITLE
Adding ability for DataStream to handle packages over 2GB

### DIFF
--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -32,7 +32,16 @@ namespace Halibut
 
         public IDataStreamReceiver Receiver()
         {
-            return receiver ?? new InMemoryDataStreamReceiver(writer);
+            if (receiver != null)
+                return receiver;
+
+            // Use a FileStream for packages over 2GB, or you risk running into OutOfMemory
+            // exceptions with MemoryStream.
+            var maxMemoryStreamLength = 2147483648;
+            if (Length >= maxMemoryStreamLength)
+                return new TemporaryFileDataStreamReceiver(writer);
+            else
+                return new InMemoryDataStreamReceiver(writer);
         }
 
         public bool Equals(DataStream other)

--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.Remoting.Messaging;
 using System.Text;
 using Halibut.Transport.Protocol;
 using Newtonsoft.Json;
@@ -37,7 +36,7 @@ namespace Halibut
 
             // Use a FileStream for packages over 2GB, or you risk running into OutOfMemory
             // exceptions with MemoryStream.
-            var maxMemoryStreamLength = 2147483648;
+            var maxMemoryStreamLength = Int32.MaxValue; // Int32 on purpose, don't use int alias or this will change the behaviour on 64-bit systems.
             if (Length >= maxMemoryStreamLength)
                 return new TemporaryFileDataStreamReceiver(writer);
             else

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Diagnostics\HalibutLimits.cs" />
     <Compile Include="HalibutRuntime.cs" />
     <Compile Include="ServiceModel\NullServiceFactory.cs" />
+    <Compile Include="Transport\Protocol\TemporaryFileDataStreamReceiver.cs" />
     <Compile Include="Transport\Protocol\TemporaryFileStream.cs" />
     <Compile Include="Transport\SecureListener.cs" />
     <Compile Include="Transport\PollingClient.cs" />

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -226,7 +226,6 @@ namespace Halibut.Transport.Protocol
 
             ((IDataStreamInternal)dataStream).Received(tempFile);
         }
-
         
         static TemporaryFileStream CopyStreamToFile(Guid id, long length, BinaryReader reader)
         {

--- a/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
@@ -23,14 +23,20 @@ namespace Halibut.Transport.Protocol
         public void Read(Action<Stream> reader)
         {
             var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 65536))
+            try
             {
-                writer(fileStream);
-                fileStream.Seek(0, SeekOrigin.Begin);
-                reader(fileStream);
+                using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 65536))
+                {
+                    writer(fileStream);
+                    fileStream.Seek(0, SeekOrigin.Begin);
+                    reader(fileStream);
+                }
             }
-            if (File.Exists(path))
-                File.Delete(path);
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.IO;
+
+namespace Halibut.Transport.Protocol
+{
+    public class TemporaryFileDataStreamReceiver : IDataStreamReceiver
+    {
+        readonly Action<Stream> writer;
+
+        public TemporaryFileDataStreamReceiver(Action<Stream> writer)
+        {
+            this.writer = writer;
+        }
+
+        public void SaveTo(string filePath)
+        {
+            using (var file = new FileStream(filePath, FileMode.Create))
+            {
+                writer(file);
+            }
+        }
+
+        public void Read(Action<Stream> reader)
+        {
+            using (var tempFiles = new TempFileCollection())
+            {
+                string file = tempFiles.AddExtension("txt");
+                using (var fileStream = new FileStream(file, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 65536))
+                {
+                    writer(fileStream);
+                    fileStream.Seek(0, SeekOrigin.Begin);
+                    reader(fileStream);
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.CodeDom.Compiler;
 using System.IO;
 
 namespace Halibut.Transport.Protocol
@@ -23,16 +22,15 @@ namespace Halibut.Transport.Protocol
 
         public void Read(Action<Stream> reader)
         {
-            using (var tempFiles = new TempFileCollection())
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 65536))
             {
-                string file = tempFiles.AddExtension("txt");
-                using (var fileStream = new FileStream(file, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 65536))
-                {
-                    writer(fileStream);
-                    fileStream.Seek(0, SeekOrigin.Begin);
-                    reader(fileStream);
-                }
+                writer(fileStream);
+                fileStream.Seek(0, SeekOrigin.Begin);
+                reader(fileStream);
             }
+            if (File.Exists(path))
+                File.Delete(path);
         }
     }
 }


### PR DESCRIPTION
Adding ability for DataStream to handle packages over 2GB (as MemoryStream maxes out at 2GB).

Fixes OctopusDeploy/Issues#2434