### PR TITLE
Improve the exception message if we get a thumbprint mismatch

### DIFF
--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -44,7 +44,7 @@ namespace Halibut.Diagnostics
         void SendToTrace(LogEvent logEvent, LogLevel level)
         {
             var logger = LogProvider.GetLogger("Halibut");
-            logger.Log(level, () => "{0,-30} {1,4}  {2}{3}", logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, logEvent.Error == null ? "" : Environment.NewLine + logEvent.Error);
+            logger.Log(level, () => "{0,-30} {1,4}  {2}", logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage);
         }
     }
 }

--- a/source/Halibut/Transport/ClientCertificateValidator.cs
+++ b/source/Halibut/Transport/ClientCertificateValidator.cs
@@ -1,29 +1,29 @@
 using System;
 using System.Net.Security;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Halibut.Transport
 {
     class ClientCertificateValidator
     {
-        readonly string expectedThumbprint;
+        readonly ServiceEndPoint endPoint;
 
-        public ClientCertificateValidator(string expectedThumbprint)
+        public ClientCertificateValidator(ServiceEndPoint endPoint)
         {
-            this.expectedThumbprint = expectedThumbprint;
+            this.endPoint = endPoint;
         }
 
         public bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
         {
-            var provided = new X509Certificate2(certificate.Export(X509ContentType.Cert)).Thumbprint;
+            var providedCert = new X509Certificate2(certificate.Export(X509ContentType.Cert));
+            var providedThumbprint = providedCert.Thumbprint;
 
-            if (provided == expectedThumbprint)
+            if (providedThumbprint == endPoint.RemoteThumbprint)
             {
                 return true;
             }
 
-            throw new AuthenticationException(string.Format("The server presented an unexpected security certificate. We expected the server to present a certificate with the thumbprint '{0}'. Instead, it presented a certificate with a thumbprint of '{1}'. This usually happens when the client has been configured to expect the server to have the wrong certificate, or when the certificate on the server has been regenerated and the client has not been updated. It may also happen if someone is performing a man-in-the-middle attack on the remote machine, or if a proxy server is intercepting requests. Please check the certificate used on the server, and verify that the client has been configured correctly.", expectedThumbprint, provided));
+            throw new UnexpectedCertificateException(providedCert, endPoint);
         }
     }
 }

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -114,7 +114,7 @@ namespace Halibut.Transport
         {
             log.Write(EventType.OpeningNewConnection, "Opening a new connection");
 
-            var certificateValidator = new ClientCertificateValidator(serviceEndpoint.RemoteThumbprint);
+            var certificateValidator = new ClientCertificateValidator(serviceEndpoint);
             var client = CreateConnectedTcpClient(serviceEndpoint);
             log.Write(EventType.Diagnostic, "Connection established");
 

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -63,14 +63,14 @@ namespace Halibut.Transport
                 }
                 catch (AuthenticationException aex)
                 {
-                    log.WriteException(EventType.Error, aex.Message, aex);
+                    log.WriteException(EventType.Error, $"Authentication failed while setting up connection to {(serviceEndpoint == null ? "(Null EndPoint)" : serviceEndpoint.BaseUri.ToString())}", aex);
                     lastError = aex;
                     retryAllowed = false;
                     break;
                 }
                 catch (SocketException sex)
                 {
-                    log.WriteException(EventType.Error, sex.Message, sex);
+                    log.WriteException(EventType.Error, $"Socket communication error with connection to  {(serviceEndpoint == null ? "(Null EndPoint)" : serviceEndpoint.BaseUri.ToString())}", sex);
                     lastError = sex;
                     // When the host is not found an immediate retry isn't going to help
                     if (sex.SocketErrorCode == SocketError.HostNotFound)
@@ -80,7 +80,7 @@ namespace Halibut.Transport
                 }
                 catch (ConnectionInitializationFailedException cex)
                 {
-                    log.WriteException(EventType.Error, cex.Message, cex);
+                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {(serviceEndpoint == null ? "(Null EndPoint)" : serviceEndpoint.BaseUri.ToString())}", cex);
                     lastError = cex;
                     retryAllowed = true;
 
@@ -95,7 +95,7 @@ namespace Halibut.Transport
                 }
                 catch (Exception ex)
                 {
-                    log.WriteException(EventType.Error, ex.Message, ex);
+                    log.WriteException(EventType.Error, "Unexpected exception executing transaction.", ex);
                     lastError = ex;
                     Thread.Sleep(retryInterval);
                 }

--- a/source/Halibut/Transport/UnexpectedCertificateException.cs
+++ b/source/Halibut/Transport/UnexpectedCertificateException.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Halibut.Transport
+{
+    class UnexpectedCertificateException : AuthenticationException
+    {
+        public X509Certificate2 ProvidedCert { get; }
+        public string ExpectedThumbprint { get; }
+        public Uri ServerUrl { get; }
+
+        const string Text = "The server at {0} presented an unexpected security certificate. We expected the server to " +
+                            "present a certificate with the thumbprint '{1}'. Instead, it " +
+                            "presented a certificate with a thumbprint of '{2}' and subject " +
+                            "'{3}'. This usually happens when the client has been configured " +
+                            "to expect the server to have the wrong certificate, or when the certificate on the " +
+                            "server has been regenerated and the client has not been updated. It may also happen " +
+                            "if someone is performing a man-in-the-middle attack on the remote machine, or if a " +
+                            "proxy server is intercepting requests. Please check the certificate used on the server, " +
+                            "and verify that the client has been configured correctly.";
+
+        public UnexpectedCertificateException(X509Certificate2 providedCert, ServiceEndPoint endPoint)
+            : base(string.Format(Text, endPoint.BaseUri, endPoint.RemoteThumbprint, providedCert.Thumbprint, providedCert.Subject))
+        {
+            ServerUrl = endPoint.BaseUri;
+            ProvidedCert = providedCert;
+            ExpectedThumbprint = endPoint.RemoteThumbprint;
+        }
+
+        public override string ToString()
+        {
+            //We dont want to log the stack trace here
+            return Message;
+        }
+    }
+}


### PR DESCRIPTION
Fixes OctopusDeploy/Issues#3033