### PR TITLE
Changed the wait for messages to be async.

### DIFF
--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x"))).Wait();
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -86,7 +86,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x"))).Wait();
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -147,7 +147,7 @@ namespace Halibut.Tests
             requestQueue.Dequeue().Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -223,13 +223,13 @@ namespace Halibut.Tests
             queue.Enqueue(new RequestMessage());
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
 
             queue.Enqueue(new RequestMessage());
 
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -321,10 +321,9 @@ namespace Halibut.Tests
                 output.AppendLine("<-- MX-SERVER");
             }
 
-            public Task IdentifyAsServer()
+            public void IdentifyAsServer()
             {
                 output.AppendLine("--> MX-SERVER");
-                return Task.WhenAll();
             }
 
             public RemoteIdentity ReadRemoteIdentity()

--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -162,6 +162,31 @@ namespace Halibut.Tests
         }
 
         [Test]
+        public void ShouldExchangeAsServerOfSubscriberAsync()
+        {
+            stream.SetRemoteIdentity(new RemoteIdentity(RemoteIdentityType.Subscriber, new Uri("poll://12831")));
+            var requestQueue = Substitute.For<IPendingRequestQueue>();
+            var queue = new Queue<RequestMessage>();
+            queue.Enqueue(new RequestMessage());
+            queue.Enqueue(new RequestMessage());
+            requestQueue.DequeueAsync().Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
+            stream.SetNumberOfReads(2);
+
+            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+
+            AssertOutput(@"
+<-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
+--> MX-SERVER
+--> RequestMessage
+<-- ResponseMessage
+<-- NEXT
+--> PROCEED
+--> RequestMessage
+<-- ResponseMessage
+<-- END");
+        }
+
+        [Test]
         public void ShouldExchangeAsSubscriberWithPooling()
         {
             stream.NextReadReturns(new RequestMessage());
@@ -230,6 +255,44 @@ namespace Halibut.Tests
             stream.SetNumberOfReads(1);
 
             protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+
+            AssertOutput(@"
+<-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
+--> MX-SERVER
+--> RequestMessage
+<-- ResponseMessage
+<-- NEXT
+--> PROCEED
+--> RequestMessage
+<-- ResponseMessage
+<-- END
+<-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
+--> MX-SERVER
+--> RequestMessage
+<-- ResponseMessage
+<-- END");
+        }
+
+
+        [Test]
+        public void ShouldExchangeAsServerOfSubscriberWithPoolingAsync()
+        {
+            stream.SetRemoteIdentity(new RemoteIdentity(RemoteIdentityType.Subscriber, new Uri("poll://12831")));
+            var requestQueue = Substitute.For<IPendingRequestQueue>();
+            var queue = new Queue<RequestMessage>();
+            requestQueue.DequeueAsync().Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
+
+            queue.Enqueue(new RequestMessage());
+            queue.Enqueue(new RequestMessage());
+            stream.SetNumberOfReads(2);
+
+            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+
+            queue.Enqueue(new RequestMessage());
+
+            stream.SetNumberOfReads(1);
+
+            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId

--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
@@ -43,7 +44,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x"))).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -85,7 +86,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x"))).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -146,7 +147,7 @@ namespace Halibut.Tests
             requestQueue.Dequeue().Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -222,13 +223,13 @@ namespace Halibut.Tests
             queue.Enqueue(new RequestMessage());
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
 
             queue.Enqueue(new RequestMessage());
 
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -320,9 +321,10 @@ namespace Halibut.Tests
                 output.AppendLine("<-- MX-SERVER");
             }
 
-            public void IdentifyAsServer()
+            public Task IdentifyAsServer()
             {
                 output.AppendLine("--> MX-SERVER");
+                return Task.WhenAll();
             }
 
             public RemoteIdentity ReadRemoteIdentity()

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Transport;
@@ -63,9 +64,9 @@ namespace Halibut
             return listener.Start();
         }
 
-        void ListenerHandler(MessageExchangeProtocol obj)
+        Task ListenerHandler(MessageExchangeProtocol obj)
         {
-            obj.ExchangeAsServer(
+            return obj.ExchangeAsServer(
                 HandleIncomingRequest,
                 id => GetQueue(id.SubscriptionId));
         }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -66,7 +66,7 @@ namespace Halibut
 
         Task ListenerHandler(MessageExchangeProtocol obj)
         {
-            return obj.ExchangeAsServer(
+            return obj.ExchangeAsServerAsync(
                 HandleIncomingRequest,
                 id => GetQueue(id.SubscriptionId));
         }

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.ServiceModel
@@ -7,6 +8,6 @@ namespace Halibut.ServiceModel
     {
         bool IsEmpty { get; }
         void ApplyResponse(ResponseMessage response);
-        RequestMessage Dequeue();
+        Task<RequestMessage> Dequeue();
     }
 }

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -8,6 +8,7 @@ namespace Halibut.ServiceModel
     {
         bool IsEmpty { get; }
         void ApplyResponse(ResponseMessage response);
-        Task<RequestMessage> Dequeue();
+        RequestMessage Dequeue();
+        Task<RequestMessage> DequeueAsync();
     }
 }

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -67,8 +67,9 @@ namespace Halibut.ServiceModel
             if (first != null)
                 return first;
 
-            var cts = new CancellationTokenSource(HalibutLimits.PollingQueueWaitTimeout);
-            hasItems.Wait(cts.Token);
+            using (var cts = new CancellationTokenSource(HalibutLimits.PollingQueueWaitTimeout))
+                hasItems.Wait(cts.Token);
+
             hasItems.Reset();
             return TakeFirst();
         }

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -11,7 +11,7 @@ namespace Halibut.Transport.Protocol
         bool ExpectNextOrEnd();
         void ExpectProceeed();
         void IdentifyAsSubscriber(string subscriptionId);
-        Task IdentifyAsServer();
+        void IdentifyAsServer();
         RemoteIdentity ReadRemoteIdentity();
         void Send<T>(T message);
         T Receive<T>();

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Halibut.Transport.Protocol
 {
@@ -10,7 +11,7 @@ namespace Halibut.Transport.Protocol
         bool ExpectNextOrEnd();
         void ExpectProceeed();
         void IdentifyAsSubscriber(string subscriptionId);
-        void IdentifyAsServer();
+        Task IdentifyAsServer();
         RemoteIdentity ReadRemoteIdentity();
         void Send<T>(T message);
         T Receive<T>();

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -72,7 +72,7 @@ namespace Halibut.Transport.Protocol
 
             for (var i = 0; i < maxAttempts; i++)
             {
-                ReceiveAndProcessRequest(stream, incomingRequestProcessor);                
+                ReceiveAndProcessRequest(stream, incomingRequestProcessor);
             }
         }
 
@@ -89,97 +89,131 @@ namespace Halibut.Transport.Protocol
             stream.ExpectProceeed();
         }
 
-        public async Task ExchangeAsServer(Func<RequestMessage, ResponseMessage> incomingRequestProcessor, Func<RemoteIdentity, IPendingRequestQueue> pendingRequests)
+        public void ExchangeAsServer(Func<RequestMessage, ResponseMessage> incomingRequestProcessor, Func<RemoteIdentity, IPendingRequestQueue> pendingRequests)
         {
             var identity = stream.ReadRemoteIdentity();
-            await stream.IdentifyAsServer();
+            stream.IdentifyAsServer();
             switch (identity.IdentityType)
             {
                 case RemoteIdentityType.Client:
-                    await ProcessClientRequests(incomingRequestProcessor);
+                    ProcessClientRequests(incomingRequestProcessor);
                     break;
                 case RemoteIdentityType.Subscriber:
-                    await ProcessSubscriber(pendingRequests(identity));
+                    ProcessSubscriber(pendingRequests(identity));
                     break;
                 default:
                     throw new ProtocolException("Unexpected remote identity: " + identity.IdentityType);
             }
         }
 
-        Task ProcessClientRequests(Func<RequestMessage, ResponseMessage> incomingRequestProcessor)
+        public async Task ExchangeAsServerAsync(Func<RequestMessage, ResponseMessage> incomingRequestProcessor, Func<RemoteIdentity, IPendingRequestQueue> pendingRequests)
         {
-            return Task.Run(() =>
+            var identity = stream.ReadRemoteIdentity();
+            stream.IdentifyAsServer();
+            switch (identity.IdentityType)
             {
-                while (acceptClientRequests)
-                {
-                    var request = stream.Receive<RequestMessage>();
-                    if (request == null || !acceptClientRequests)
-                        return;
-
-                    var response = InvokeAndWrapAnyExceptions(request, incomingRequestProcessor);
-
-                    if (!acceptClientRequests)
-                        return;
-
-                    stream.Send(response);
-
-                    try
-                    {
-                        if (!acceptClientRequests || !stream.ExpectNextOrEnd())
-                            return;
-                    }
-                    catch (Exception ex) when (ex.IsSocketConnectionTimeout())
-                    {
-                        // We get socket timeout on the Listening side (a Listening Tentacle in Octopus use) as part of normal operation
-                        // if we don't hear from the other end within our TcpRx Timeout.
-                        log.Write(EventType.Diagnostic, "No messages received from client for timeout period. Connection closed and will be re-opened when required");
-                        return;
-                    }
-                    stream.SendProceed();
-                }
-            });
+                case RemoteIdentityType.Client:
+                    ProcessClientRequests(incomingRequestProcessor);
+                    break;
+                case RemoteIdentityType.Subscriber:
+                    await ProcessSubscriberAsync(pendingRequests(identity));
+                    break;
+                default:
+                    throw new ProtocolException("Unexpected remote identity: " + identity.IdentityType);
+            }
         }
 
-        async Task ProcessSubscriber(IPendingRequestQueue pendingRequests)
+        void ProcessClientRequests(Func<RequestMessage, ResponseMessage> incomingRequestProcessor)
+        {
+            while (acceptClientRequests)
+            {
+                var request = stream.Receive<RequestMessage>();
+                if (request == null || !acceptClientRequests)
+                    return;
+
+                var response = InvokeAndWrapAnyExceptions(request, incomingRequestProcessor);
+
+                if (!acceptClientRequests)
+                    return;
+
+                stream.Send(response);
+
+                try
+                {
+                    if (!acceptClientRequests || !stream.ExpectNextOrEnd())
+                        return;
+                }
+                catch (Exception ex) when (ex.IsSocketConnectionTimeout())
+                {
+                    // We get socket timeout on the Listening side (a Listening Tentacle in Octopus use) as part of normal operation
+                    // if we don't hear from the other end within our TcpRx Timeout.
+                    log.Write(EventType.Diagnostic, "No messages received from client for timeout period. Connection closed and will be re-opened when required");
+                    return;
+                }
+                stream.SendProceed();
+            }
+        }
+
+        void ProcessSubscriber(IPendingRequestQueue pendingRequests)
+        {
+            while (true)
+            {
+                var nextRequest = pendingRequests.Dequeue();
+
+                var success = ProcessReceiverInternal(pendingRequests, nextRequest);
+                if (!success)
+                    return;
+            }
+        }
+
+        async Task ProcessSubscriberAsync(IPendingRequestQueue pendingRequests)
         {
             while (true)
             {
                 var nextRequest = await pendingRequests.DequeueAsync();
 
-                try
-                {
-                    stream.Send(nextRequest);
-                    if (nextRequest != null)
-                    {
-                        var response = stream.Receive<ResponseMessage>();
-                        pendingRequests.ApplyResponse(response);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    if (nextRequest != null)
-                    {
-                        var response = ResponseMessage.FromException(nextRequest, ex);
-                        pendingRequests.ApplyResponse(response);
-                    }
-                    break;
-                }
-
-                try
-                {
-                    if (!stream.ExpectNextOrEnd())
-                        break;
-                }
-                catch (Exception ex) when (ex.IsSocketConnectionTimeout())
-                {
-                    // We get socket timeout on the server when the network connection to a polling client drops
-                    // (in Octopus this is the server for a Polling Tentacle)
-                    // In normal operation a client will poll more often than the timeout so we shouldn't see this.
-                    log.Write(EventType.Error, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
-                    break;
-                }
-                stream.SendProceed();
+                var success = ProcessReceiverInternal(pendingRequests, nextRequest);
+                if (!success)
+                    return;
             }
+        }
+
+        bool ProcessReceiverInternal(IPendingRequestQueue pendingRequests, RequestMessage nextRequest)
+        {
+            try
+            {
+                stream.Send(nextRequest);
+                if (nextRequest != null)
+                {
+                    var response = stream.Receive<ResponseMessage>();
+                    pendingRequests.ApplyResponse(response);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (nextRequest != null)
+                {
+                    var response = ResponseMessage.FromException(nextRequest, ex);
+                    pendingRequests.ApplyResponse(response);
+                }
+                return false;
+            }
+
+            try
+            {
+                if (!stream.ExpectNextOrEnd())
+                    return false;
+            }
+            catch (Exception ex) when (ex.IsSocketConnectionTimeout())
+            {
+                // We get socket timeout on the server when the network connection to a polling client drops
+                // (in Octopus this is the server for a Polling Tentacle)
+                // In normal operation a client will poll more often than the timeout so we shouldn't see this.
+                log.Write(EventType.Error, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
+                return false;
+            }
+            stream.SendProceed();
+            return true;
         }
 
         static ResponseMessage InvokeAndWrapAnyExceptions(RequestMessage request, Func<RequestMessage, ResponseMessage> incomingRequestProcessor)

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -144,7 +144,7 @@ namespace Halibut.Transport.Protocol
         {
             while (true)
             {
-                var nextRequest = await pendingRequests.Dequeue();
+                var nextRequest = await pendingRequests.DequeueAsync();
 
                 try
                 {

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization.Formatters;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
@@ -113,13 +114,13 @@ namespace Halibut.Transport.Protocol
             ExpectServerIdentity();
         }
 
-        public void IdentifyAsServer()
+        public async Task IdentifyAsServer()
         {
-            streamWriter.Write("MX-SERVER ");
-            streamWriter.Write(currentVersion);
-            streamWriter.WriteLine();
-            streamWriter.WriteLine();
-            streamWriter.Flush();
+            await streamWriter.WriteAsync("MX-SERVER ");
+            await streamWriter.WriteAsync(currentVersion.ToString());
+            await streamWriter.WriteLineAsync();
+            await streamWriter.WriteLineAsync();
+            await streamWriter.FlushAsync();
         }
 
         public RemoteIdentity ReadRemoteIdentity()

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -114,13 +114,9 @@ namespace Halibut.Transport.Protocol
             ExpectServerIdentity();
         }
 
-        public async Task IdentifyAsServer()
+        public void IdentifyAsServer()
         {
-            await streamWriter.WriteAsync("MX-SERVER ");
-            await streamWriter.WriteAsync(currentVersion.ToString());
-            await streamWriter.WriteLineAsync();
-            await streamWriter.WriteLineAsync();
-            await streamWriter.FlushAsync();
+            streamWriter.FlushAsync();
         }
 
         public RemoteIdentity ReadRemoteIdentity()

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -116,7 +116,11 @@ namespace Halibut.Transport.Protocol
 
         public void IdentifyAsServer()
         {
-            streamWriter.FlushAsync();
+            streamWriter.Write("MX-SERVER ");
+            streamWriter.Write(currentVersion.ToString());
+            streamWriter.WriteLine();
+            streamWriter.WriteLine();
+            streamWriter.Flush();
         }
 
         public RemoteIdentity ReadRemoteIdentity()

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -38,6 +38,12 @@ namespace Halibut.Transport
         ILog log;
         TcpListener listener;
 
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent)
+            : this(endPoint, serverCertificate, h => Task.Run(() => protocolHandler(h)), verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent)
+
+        {
+        }
+
         public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent)
         {
             this.endPoint = endPoint;
@@ -66,7 +72,7 @@ namespace Halibut.Transport
 
             log = logFactory.ForEndpoint(new Uri("listen://" + listener.LocalEndpoint));
             log.Write(EventType.ListenerStarted, "Listener started");
-            Task.Run(async () => await Accept()); 
+            Task.Run(async () => await Accept());
             return ((IPEndPoint)listener.LocalEndpoint).Port;
         }
 
@@ -255,7 +261,7 @@ namespace Halibut.Transport
                 var b = stream.ReadByte();
                 if (b == -1) return builder.ToString();
 
-                var c = (char) b;
+                var c = (char)b;
                 if (c == '\r')
                 {
                     continue;

--- a/source/Halibut/Util/AsyncEx/ExceptionHelpers.cs
+++ b/source/Halibut/Util/AsyncEx/ExceptionHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Runtime.ExceptionServices;
+
+namespace Halibut.Util.AsyncEx
+{
+    internal static class ExceptionHelpers
+    {
+        /// <summary>
+        /// Attempts to prepare the exception for re-throwing by preserving the stack trace. The returned exception should be immediately thrown.
+        /// </summary>
+        /// <param name="exception">The exception. May not be <c>null</c>.</param>
+        /// <returns>The <see cref="Exception"/> that was passed into this method.</returns>
+        public static Exception PrepareForRethrow(Exception exception)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+
+            // The code cannot ever get here. We just return a value to work around a badly-designed API (ExceptionDispatchInfo.Throw):
+            //  https://connect.microsoft.com/VisualStudio/feedback/details/689516/exceptiondispatchinfo-api-modifications (http://www.webcitation.org/6XQ7RoJmO)
+            return exception;
+        }
+    }
+}

--- a/source/Halibut/Util/AsyncEx/Net45/AsyncManualResetEvent.cs
+++ b/source/Halibut/Util/AsyncEx/Net45/AsyncManualResetEvent.cs
@@ -1,4 +1,4 @@
-﻿#if NET45
+﻿#if NET40
 
 using System;
 using System.Diagnostics;

--- a/source/Halibut/Util/AsyncEx/Net45/AsyncManualResetEvent.cs
+++ b/source/Halibut/Util/AsyncEx/Net45/AsyncManualResetEvent.cs
@@ -1,0 +1,150 @@
+﻿#if NET45
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    /// <summary>
+    /// An async-compatible manual-reset event.
+    /// </summary>
+    [DebuggerDisplay("Id = {Id}, IsSet = {GetStateForDebugger}")]
+    [DebuggerTypeProxy(typeof(DebugView))]
+    internal sealed class AsyncManualResetEvent
+    {
+        /// <summary>
+        /// The object used for synchronization.
+        /// </summary>
+        private readonly object _sync;
+
+        /// <summary>
+        /// The current state of the event.
+        /// </summary>
+        private TaskCompletionSource _tcs;
+
+        [DebuggerNonUserCode]
+        private bool GetStateForDebugger
+        {
+            get
+            {
+                return _tcs.Task.IsCompleted;
+            }
+        }
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event.
+        /// </summary>
+        /// <param name="set">Whether the manual-reset event is initially set or unset.</param>
+        public AsyncManualResetEvent(bool set)
+        {
+            _sync = new object();
+            _tcs = new TaskCompletionSource();
+            if (set)
+            {
+                //Enlightenment.Trace.AsyncManualResetEvent_Set(this, _tcs.Task);
+                _tcs.SetResult();
+            }
+            else
+            {
+                //Enlightenment.Trace.AsyncManualResetEvent_Reset(this, _tcs.Task);
+            }
+        }
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event that is initially unset.
+        /// </summary>
+        public AsyncManualResetEvent()
+            : this(false)
+        {
+        }
+
+      
+
+        /// <summary>
+        /// Whether this event is currently set. This member is seldom used; code using this member has a high possibility of race conditions.
+        /// </summary>
+        public bool IsSet
+        {
+            get { lock (_sync) return _tcs.Task.IsCompleted; }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for this event to be set.
+        /// </summary>
+        public Task WaitAsync()
+        {
+            lock (_sync)
+            {
+                var ret = _tcs.Task;
+                //Enlightenment.Trace.AsyncManualResetEvent_Wait(this, ret);
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Synchronously waits for this event to be set. This method may block the calling thread.
+        /// </summary>
+        public void Wait()
+        {
+            WaitAsync().Wait();
+        }
+
+        /// <summary>
+        /// Synchronously waits for this event to be set. This method may block the calling thread.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to cancel the wait. If this token is already canceled, this method will first check whether the event is set.</param>
+        public void Wait(CancellationToken cancellationToken)
+        {
+            var ret = WaitAsync();
+            if (ret.IsCompleted)
+                return;
+            ret.Wait(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the event, atomically completing every task returned by <see cref="WaitAsync"/>. If the event is already set, this method does nothing.
+        /// </summary>
+        public void Set()
+        {
+            lock (_sync)
+            {
+                //Enlightenment.Trace.AsyncManualResetEvent_Set(this, _tcs.Task);
+                _tcs.TrySetResultWithBackgroundContinuations();
+            }
+        }
+
+        /// <summary>
+        /// Resets the event. If the event is already reset, this method does nothing.
+        /// </summary>
+        public void Reset()
+        {
+            lock (_sync)
+            {
+                if (_tcs.Task.IsCompleted)
+                    _tcs = new TaskCompletionSource();
+                //Enlightenment.Trace.AsyncManualResetEvent_Reset(this, _tcs.Task);
+            }
+        }
+
+        // ReSharper disable UnusedMember.Local
+        [DebuggerNonUserCode]
+        private sealed class DebugView
+        {
+            private readonly AsyncManualResetEvent _mre;
+
+            public DebugView(AsyncManualResetEvent mre)
+            {
+                _mre = mre;
+            }
+
+
+            public bool IsSet { get { return _mre.GetStateForDebugger; } }
+
+            public Task CurrentTask { get { return _mre._tcs.Task; } }
+        }
+        // ReSharper restore UnusedMember.Local
+    }
+}
+#endif

--- a/source/Halibut/Util/AsyncEx/Net45/TaskCompletionSource.cs
+++ b/source/Halibut/Util/AsyncEx/Net45/TaskCompletionSource.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    internal sealed class TaskCompletionSource
+    {
+        /// <summary>
+        /// The underlying TCS.
+        /// </summary>
+        private readonly TaskCompletionSource<object> _tcs;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskCompletionSource"/> class.
+        /// </summary>
+        public TaskCompletionSource()
+        {
+            _tcs = new TaskCompletionSource<object>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskCompletionSource"/> class with the specified state.
+        /// </summary>
+        /// <param name="state">The state to use as the underlying <see cref="Task"/>'s <see cref="IAsyncResult.AsyncState"/>.</param>
+        public TaskCompletionSource(object state)
+        {
+            _tcs = new TaskCompletionSource<object>(state);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskCompletionSource"/> class with the specified options.
+        /// </summary>
+        /// <param name="creationOptions">The options to use when creating the underlying <see cref="Task"/>.</param>
+        public TaskCompletionSource(TaskCreationOptions creationOptions)
+        {
+            _tcs = new TaskCompletionSource<object>(creationOptions);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TaskCompletionSource"/> class with the specified state and options.
+        /// </summary>
+        /// <param name="state">The state to use as the underlying <see cref="Task"/>'s <see cref="IAsyncResult.AsyncState"/>.</param>
+        /// <param name="creationOptions">The options to use when creating the underlying <see cref="Task"/>.</param>
+        public TaskCompletionSource(object state, TaskCreationOptions creationOptions)
+        {
+            _tcs = new TaskCompletionSource<object>(state, creationOptions);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Task"/> created by this <see cref="TaskCompletionSource"/>.
+        /// </summary>
+        public Task Task
+        {
+            get { return _tcs.Task; }
+        }
+
+        /// <summary>
+        /// Transitions the underlying <see cref="Task"/> into the <see cref="TaskStatus.Canceled"/> state.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The underlying <see cref="Task"/> has already been completed.</exception>
+        public void SetCanceled()
+        {
+            _tcs.SetCanceled();
+        }
+
+        /// <summary>
+        /// Attempts to transition the underlying <see cref="Task"/> into the <see cref="TaskStatus.Canceled"/> state.
+        /// </summary>
+        /// <returns><c>true</c> if the operation was successful; otherwise, <c>false</c>.</returns>
+        public bool TrySetCanceled()
+        {
+            return _tcs.TrySetCanceled();
+        }
+
+        /// <summary>
+        /// Transitions the underlying <see cref="Task"/> into the <see cref="TaskStatus.Faulted"/> state.
+        /// </summary>
+        /// <param name="exception">The exception to bind to this <see cref="Task"/>. May not be <c>null</c>.</param>
+        /// <exception cref="InvalidOperationException">The underlying <see cref="Task"/> has already been completed.</exception>
+        public void SetException(Exception exception)
+        {
+            _tcs.SetException(exception);
+        }
+
+        /// <summary>
+        /// Transitions the underlying <see cref="Task"/> into the <see cref="TaskStatus.Faulted"/> state.
+        /// </summary>
+        /// <param name="exceptions">The collection of exceptions to bind to this <see cref="Task"/>. May not be <c>null</c> or contain <c>null</c> elements.</param>
+        /// <exception cref="InvalidOperationException">The underlying <see cref="Task"/> has already been completed.</exception>
+        public void SetException(IEnumerable<Exception> exceptions)
+        {
+            _tcs.SetException(exceptions);
+        }
+
+        /// <summary>
+        /// Attempts to transition the underlying <see cref="Task"/> into the <see cref="TaskStatus.Faulted"/> state.
+        /// </summary>
+        /// <param name="exception">The exception to bind to this <see cref="Task"/>. May not be <c>null</c>.</param>
+        /// <returns><c>true</c> if the operation was successful; otherwise, <c>false</c>.</returns>
+        public bool TrySetException(Exception exception)
+        {
+            return _tcs.TrySetException(exception);
+        }
+
+        /// <summary>
+        /// Attempts to transition the underlying <see cref="Task"/> into the <see cref="TaskStatus.Faulted"/> state.
+        /// </summary>
+        /// <param name="exceptions">The collection of exceptions to bind to this <see cref="Task"/>. May not be <c>null</c> or contain <c>null</c> elements.</param>
+        /// <returns><c>true</c> if the operation was successful; otherwise, <c>false</c>.</returns>
+        public bool TrySetException(IEnumerable<Exception> exceptions)
+        {
+            return _tcs.TrySetException(exceptions);
+        }
+
+        /// <summary>
+        /// Transitions the underlying <see cref="Task"/> into the <see cref="TaskStatus.RanToCompletion"/> state.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The underlying <see cref="Task"/> has already been completed.</exception>
+        public void SetResult()
+        {
+            _tcs.SetResult(null);
+        }
+
+        /// <summary>
+        /// Attempts to transition the underlying <see cref="Task"/> into the <see cref="TaskStatus.RanToCompletion"/> state.
+        /// </summary>
+        /// <returns><c>true</c> if the operation was successful; otherwise, <c>false</c>.</returns>
+        public bool TrySetResult()
+        {
+            return _tcs.TrySetResult(null);
+        }
+    }
+}

--- a/source/Halibut/Util/AsyncEx/Net45/TaskCompletionSourceExtensions.cs
+++ b/source/Halibut/Util/AsyncEx/Net45/TaskCompletionSourceExtensions.cs
@@ -1,0 +1,25 @@
+﻿#if NET40
+using System;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    internal static class TaskCompletionSourceExtensions
+    {
+
+        /// <summary>
+        /// Attempts to complete a <see cref="TaskCompletionSource"/>, forcing all continuations onto a threadpool thread even if they specified <c>ExecuteSynchronously</c>.
+        /// </summary>
+        /// <param name="this">The task completion source. May not be <c>null</c>.</param>
+        public static void TrySetResultWithBackgroundContinuations(this TaskCompletionSource @this)
+        {
+            // Set the result on a threadpool thread, so any synchronous continuations will execute in the background.
+            Task.Run(() => @this.TrySetResult());
+
+            // Wait for the TCS task to complete; note that the continuations may not be complete.
+            @this.Task.Wait();
+        }
+
+    }
+}
+#endif

--- a/source/Halibut/Util/AsyncEx/NetStandard/AsyncManualResetEvent.cs
+++ b/source/Halibut/Util/AsyncEx/NetStandard/AsyncManualResetEvent.cs
@@ -1,0 +1,149 @@
+﻿#if !NET40
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+
+    /// <summary>
+    /// An async-compatible manual-reset event.
+    /// </summary>
+    [DebuggerDisplay("Id = {Id}, IsSet = {GetStateForDebugger}")]
+    [DebuggerTypeProxy(typeof(DebugView))]
+    internal sealed class AsyncManualResetEvent
+    {
+        /// <summary>
+        /// The object used for synchronization.
+        /// </summary>
+        private readonly object _mutex;
+
+        /// <summary>
+        /// The current state of the event.
+        /// </summary>
+        private TaskCompletionSource<object> _tcs;
+
+     
+        [DebuggerNonUserCode]
+        private bool GetStateForDebugger
+        {
+            get
+            {
+                return _tcs.Task.IsCompleted;
+            }
+        }
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event.
+        /// </summary>
+        /// <param name="set">Whether the manual-reset event is initially set or unset.</param>
+        public AsyncManualResetEvent(bool set)
+        {
+            _mutex = new object();
+            _tcs = TaskCompletionSourceExtensions.CreateAsyncTaskSource<object>();
+            if (set)
+                _tcs.TrySetResult(null);
+        }
+
+        /// <summary>
+        /// Creates an async-compatible manual-reset event that is initially unset.
+        /// </summary>
+        public AsyncManualResetEvent()
+            : this(false)
+        {
+        }
+
+        /// <summary>
+        /// Whether this event is currently set. This member is seldom used; code using this member has a high possibility of race conditions.
+        /// </summary>
+        public bool IsSet
+        {
+            get { lock (_mutex) return _tcs.Task.IsCompleted; }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for this event to be set.
+        /// </summary>
+        public Task WaitAsync()
+        {
+            lock (_mutex)
+            {
+                return _tcs.Task;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously waits for this event to be set or for the wait to be canceled.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to cancel the wait. If this token is already canceled, this method will first check whether the event is set.</param>
+        public Task WaitAsync(CancellationToken cancellationToken)
+        {
+            var waitTask = WaitAsync();
+            if (waitTask.IsCompleted)
+                return waitTask;
+            return waitTask.WaitAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Synchronously waits for this event to be set. This method may block the calling thread.
+        /// </summary>
+        public void Wait()
+        {
+            WaitAsync().WaitAndUnwrapException();
+        }
+
+        /// <summary>
+        /// Synchronously waits for this event to be set. This method may block the calling thread.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to cancel the wait. If this token is already canceled, this method will first check whether the event is set.</param>
+        public void Wait(CancellationToken cancellationToken)
+        {
+            var ret = WaitAsync();
+            if (ret.IsCompleted)
+                return;
+            ret.WaitAndUnwrapException(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the event, atomically completing every task returned by <see cref="O:Nito.AsyncEx.AsyncManualResetEvent.WaitAsync"/>. If the event is already set, this method does nothing.
+        /// </summary>
+        public void Set()
+        {
+            lock (_mutex)
+            {
+                _tcs.TrySetResult(null);
+            }
+        }
+
+        /// <summary>
+        /// Resets the event. If the event is already reset, this method does nothing.
+        /// </summary>
+        public void Reset()
+        {
+            lock (_mutex)
+            {
+                if (_tcs.Task.IsCompleted)
+                    _tcs = TaskCompletionSourceExtensions.CreateAsyncTaskSource<object>();
+            }
+        }
+
+        // ReSharper disable UnusedMember.Local
+        [DebuggerNonUserCode]
+        private sealed class DebugView
+        {
+            private readonly AsyncManualResetEvent _mre;
+
+            public DebugView(AsyncManualResetEvent mre)
+            {
+                _mre = mre;
+            }
+
+            public bool IsSet { get { return _mre.GetStateForDebugger; } }
+
+            public Task CurrentTask { get { return _mre._tcs.Task; } }
+        }
+        // ReSharper restore UnusedMember.Local
+    }
+}
+#endif

--- a/source/Halibut/Util/AsyncEx/NetStandard/CancellationTokenTaskSource.cs
+++ b/source/Halibut/Util/AsyncEx/NetStandard/CancellationTokenTaskSource.cs
@@ -1,0 +1,45 @@
+﻿#if !NET40
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    internal sealed class CancellationTokenTaskSource<T> : IDisposable
+    {
+        /// <summary>
+        /// The cancellation token registration, if any. This is <c>null</c> if the registration was not necessary.
+        /// </summary>
+        private readonly IDisposable _registration;
+
+        /// <summary>
+        /// Creates a task for the specified cancellation token, registering with the token if necessary.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to observe.</param>
+        public CancellationTokenTaskSource(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                Task = System.Threading.Tasks.Task.FromCanceled<T>(cancellationToken);
+                return;
+            }
+            var tcs = new TaskCompletionSource<T>();
+            _registration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken), useSynchronizationContext: false);
+            Task = tcs.Task;
+        }
+
+        /// <summary>
+        /// Gets the task for the source cancellation token.
+        /// </summary>
+        public Task<T> Task { get; private set; }
+
+        /// <summary>
+        /// Disposes the cancellation token registration, if any. Note that this may cause <see cref="Task"/> to never complete.
+        /// </summary>
+        public void Dispose()
+        {
+            _registration?.Dispose();
+        }
+    }
+}
+#endif

--- a/source/Halibut/Util/AsyncEx/NetStandard/TaskCompletionSourceExtensions.cs
+++ b/source/Halibut/Util/AsyncEx/NetStandard/TaskCompletionSourceExtensions.cs
@@ -1,0 +1,20 @@
+﻿#if !NET40
+using System;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    public static class TaskCompletionSourceExtensions
+    {
+
+        /// <summary>
+        /// Creates a new TCS for use with async code, and which forces its continuations to execute asynchronously.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the TCS.</typeparam>
+        public static TaskCompletionSource<TResult> CreateAsyncTaskSource<TResult>()
+        {
+            return new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+}
+#endif

--- a/source/Halibut/Util/AsyncEx/NetStandard/TaskExtensions.cs
+++ b/source/Halibut/Util/AsyncEx/NetStandard/TaskExtensions.cs
@@ -1,0 +1,138 @@
+﻿#if !NET40
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        /// Asynchronously waits for the task to complete, or for the cancellation token to be canceled.
+        /// </summary>
+        /// <param name="this">The task to wait for. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">The cancellation token that cancels the wait.</param>
+        public static Task WaitAsync(this Task @this, CancellationToken cancellationToken)
+        {
+            if (@this == null)
+                throw new ArgumentNullException(nameof(@this));
+
+            if (!cancellationToken.CanBeCanceled)
+                return @this;
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromCanceled(cancellationToken);
+            return DoWaitAsync(@this, cancellationToken);
+        }
+
+        private static async Task DoWaitAsync(Task task, CancellationToken cancellationToken)
+        {
+            using (var cancelTaskSource = new CancellationTokenTaskSource<object>(cancellationToken))
+                await await Task.WhenAny(task, cancelTaskSource.Task).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        public static void WaitAndUnwrapException(this Task task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        public static void WaitAndUnwrapException(this Task task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException ex)
+            {
+                throw ExceptionHelpers.PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the task.</typeparam>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <returns>The result of the task.</returns>
+        public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            return task.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, unwrapping any exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result of the task.</typeparam>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <returns>The result of the task.</returns>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed, or the <paramref name="task"/> raised an <see cref="OperationCanceledException"/>.</exception>
+        public static TResult WaitAndUnwrapException<TResult>(this Task<TResult> task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+                return task.Result;
+            }
+            catch (AggregateException ex)
+            {
+                throw ExceptionHelpers.PrepareForRethrow(ex.InnerException);
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        public static void WaitWithoutException(this Task task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait();
+            }
+            catch (AggregateException)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Waits for the task to complete, but does not raise task exceptions. The task exception (if any) is unobserved.
+        /// </summary>
+        /// <param name="task">The task. May not be <c>null</c>.</param>
+        /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was cancelled before the <paramref name="task"/> completed.</exception>
+        public static void WaitWithoutException(this Task task, CancellationToken cancellationToken)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+            try
+            {
+                task.Wait(cancellationToken);
+            }
+            catch (AggregateException)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+    }
+}
+#endif

--- a/source/Halibut/Util/AsyncEx/Source.txt
+++ b/source/Halibut/Util/AsyncEx/Source.txt
@@ -1,0 +1,1 @@
+﻿The code in this folder and child folders is modified from https://github.com/StephenCleary/AsyncEx

--- a/source/Halibut/project.json
+++ b/source/Halibut/project.json
@@ -58,7 +58,6 @@
       "buildOptions": {
         "define": [
           "NET40",
-          "NET45",
           "HAS_REAL_PROXY",
           "CAN_GET_SOCKET_HANDLE",
           "HAS_SERIALIZABLE_EXCEPTIONS"

--- a/source/Halibut/project.json
+++ b/source/Halibut/project.json
@@ -58,6 +58,7 @@
       "buildOptions": {
         "define": [
           "NET40",
+          "NET45",
           "HAS_REAL_PROXY",
           "CAN_GET_SOCKET_HANDLE",
           "HAS_SERIALIZABLE_EXCEPTIONS"


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/3190

By making this async, Octopus does not require a new thread for every Tentacle that is connected. This massively reduces the number of threads that are running.