### PR TITLE
Made the wait for the other end to do work async

### DIFF
--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -361,6 +361,8 @@ namespace Halibut.Tests
                 output.AppendLine("--> PROCEED");
             }
 
+            public Task SendProceedAsync() => Task.Run(() => SendProceed());
+
             public bool ExpectNextOrEnd()
             {
                 if (--numberOfReads == 0)
@@ -371,6 +373,8 @@ namespace Halibut.Tests
                 output.AppendLine("<-- NEXT");
                 return true;
             }
+
+            public Task<bool> ExpectNextOrEndAsync() => Task.Run(() => ExpectNextOrEnd());
 
             public void ExpectProceeed()
             {

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -8,7 +8,9 @@ namespace Halibut.Transport.Protocol
         void IdentifyAsClient();
         void SendNext();
         void SendProceed();
+        Task SendProceedAsync();
         bool ExpectNextOrEnd();
+        Task<bool> ExpectNextOrEndAsync();
         void ExpectProceeed();
         void IdentifyAsSubscriber(string subscriptionId);
         void IdentifyAsServer();

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -64,9 +64,31 @@ namespace Halibut.Transport.Protocol
             streamWriter.Flush();
         }
 
+        public async Task SendProceedAsync()
+        {
+            await streamWriter.WriteAsync("PROCEED");
+            await streamWriter.WriteLineAsync();
+            await streamWriter.FlushAsync();
+        }
+
         public bool ExpectNextOrEnd()
         {
             var line = ReadLine();
+            switch (line)
+            {
+                case "NEXT":
+                    return true;
+                case null:
+                case "END":
+                    return false;
+                default:
+                    throw new ProtocolException("Expected NEXT or END, got: " + line);
+            }
+        }
+
+        public async Task<bool> ExpectNextOrEndAsync()
+        {
+            var line = await ReadLineAsync();
             switch (line)
             {
                 case "NEXT":
@@ -96,6 +118,17 @@ namespace Halibut.Transport.Protocol
             while (line == string.Empty)
             {
                 line = streamReader.ReadLine();
+            }
+
+            return line;
+        }
+
+        async Task<string> ReadLineAsync()
+        {
+            var line = await streamReader.ReadLineAsync();
+            while (line == string.Empty)
+            {
+                line = await streamReader.ReadLineAsync();
             }
 
             return line;


### PR DESCRIPTION
After dispatching a command from the mailbox to a polling endpoint, the client (eg OctopusServer) will wait for the server (eg Tentacle) to ask for the next message, or send an end message. The server won't send that message however until has processed the request.

The problem is that if there are many polling endpoints, all waiting for the next message, they consume a thread, leading to thread starvation as the thread pool only increases slows (see #29). In otherwords the thread is sitting idle despite the data transfer having completed.

This is not a problem for listening endpoints.