### PR TITLE
Added logging when the polling loop fails

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -324,6 +324,7 @@ namespace Halibut.Transport
     public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
     {
         public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
         public void Start() { }
     }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -321,6 +321,7 @@ namespace Halibut.Transport
     public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
     {
         public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
         public void Start() { }
     }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -82,19 +82,20 @@ namespace Halibut
         public void Poll(Uri subscription, ServiceEndPoint endPoint)
         {
             ISecureClient client;
+            var log = logs.ForEndpoint(endPoint.BaseUri);
             if (endPoint.IsWebSocketEndpoint)
             {
 #if HAS_SERVICE_POINT_MANAGER
-                client = new SecureWebSocketClient(endPoint, serverCertificate, logs.ForEndpoint(endPoint.BaseUri), pool);
+                client = new SecureWebSocketClient(endPoint, serverCertificate, log, pool);
 #else
                 throw new NotImplementedException("Web Sockets are not available on this platform");
 #endif
             }
             else
             {
-                client = new SecureClient(endPoint, serverCertificate, logs.ForEndpoint(endPoint.BaseUri), pool);
+                client = new SecureClient(endPoint, serverCertificate, log, pool);
             }
-            pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest));
+            pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log));
         }
 
         public ServiceEndPoint Discover(Uri uri)

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -15,6 +15,12 @@ namespace Halibut.Transport
         readonly Thread thread;
         bool working;
 
+        [Obsolete("Use the overload that provides a logger. This remains for backwards compatibility.")]
+        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest)
+            : this(subscription, secureClient, handleIncomingRequest, null)
+        {
+        }
+
         public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, ILog log)
         {
             this.subscription = subscription;
@@ -45,7 +51,7 @@ namespace Halibut.Transport
                 }
                 catch (Exception ex)
                 {
-                    log.WriteException(EventType.Error, "Exception in the polling loop, sleeping for 5 seconds. This may be cause by a network error and usually rectifies itself. Disregard this message unless you are having communication problems.", ex);
+                    log?.WriteException(EventType.Error, "Exception in the polling loop, sleeping for 5 seconds. This may be cause by a network error and usually rectifies itself. Disregard this message unless you are having communication problems.", ex);
                     Thread.Sleep(5000);
                 }
             }

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
 
@@ -10,14 +11,16 @@ namespace Halibut.Transport
         readonly Uri subscription;
         readonly ISecureClient secureClient;
         readonly Func<RequestMessage, ResponseMessage> handleIncomingRequest;
+        readonly ILog log;
         readonly Thread thread;
         bool working;
 
-        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest)
+        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, ILog log)
         {
             this.subscription = subscription;
             this.secureClient = secureClient;
             this.handleIncomingRequest = handleIncomingRequest;
+            this.log = log;
             thread = new Thread(ExecutePollingLoop);
             thread.Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
             thread.IsBackground = true;
@@ -40,8 +43,9 @@ namespace Halibut.Transport
                         protocol.ExchangeAsSubscriber(subscription, handleIncomingRequest);
                     });
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    log.WriteException(EventType.Error, "Exception in the polling loop, sleeping for 5 seconds. This may be cause by a network error and usually rectifies itself. Disregard this message unless you are having communication problems.", ex);
                     Thread.Sleep(5000);
                 }
             }


### PR DESCRIPTION
This may cause a heap more errors int he logs, so lets keep an eye on it and roll back when needed. This could expose the problem we are having with hanging tentacles.