### PR TITLE
Use GitLink to build references to GitHub source into .pdb file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ ipch/
 *.vsp
 *.vspx
 
+# VS Code
+.vscode
+
 # Guidance Automation Toolkit
 *.gpState
 
@@ -62,7 +65,7 @@ _ReSharper*
 # CodeRush
 .cr/
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in

--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,7 @@
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0-beta0007"
+#tool "nuget:?package=gitlink"
 #addin "Cake.FileHelpers"
 
 //////////////////////////////////////////////////////////////////////
@@ -90,11 +91,14 @@ Task("Pack")
     .IsDependentOn("Test")
     .Does(() =>
 {
+    GitLink3("./source/Halibut/bin/Release/net45/Halibut.pdb");
+    GitLink3("./source/Halibut/bin/Release/netstandard1.5/Halibut.pdb");
     DotNetCorePack("./source/Halibut", new DotNetCorePackSettings
     {
         Configuration = configuration,
         OutputDirectory = artifactsDir,
         NoBuild = true,
+        IncludeSource = false,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")
     });
 

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>True</Optimize>
+    <DebugType>pdbonly</DebugType>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
@@ -44,5 +45,15 @@
     <DefineConstants>$(DefineConstants);NET40;HAS_REAL_PROXY;CAN_GET_SOCKET_HANDLE;HAS_SERIALIZABLE_EXCEPTIONS;HAS_WEB_SOCKET_LISTENER;HAS_SERVICE_POINT_MANAGER</DefineConstants>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="$(OutputPath)\net45\Halibut.pdb">
+      <Pack>true</Pack>
+      <PackagePath>lib\net45\</PackagePath>
+    </Content>
+    <Content Include="$(OutputPath)\netstandard1.5\Halibut.pdb">
+      <Pack>true</Pack>
+      <PackagePath>lib\netstandard1.5\</PackagePath>
+    </Content>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds the .pdb file to the nuget package and uses GitLink to embed refs to the repo in the .pdb.  That means, during debugging, VS auto loads the right source from GitHub and allows stepping into and inspection of halibut code when it's used as a NuGet library in another program.

Might also be nice if we served the .pdb on a symbol server.  The above works nicely for development debugging, but looking at crash dumps in VS would be nicer with Hailbut.pdb served off a symbol server.