### PR TITLE
Added LIBLOG_PUBLIC compilation constant

### DIFF
--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);HAS_ASYNC_LOCAL;LIBLOG_PORTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_ASYNC_LOCAL;LIBLOG_PORTABLE;LIBLOG_PUBLIC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
In order to extend LibLog from external libraries, the LibLog class needs to be compiled with the LIBLOG_PUBLIC constant.

This pull requests overwrites https://github.com/OctopusDeploy/Halibut/pull/45
