### PR TITLE
Store log messages in a single place to limit total number in memory

### DIFF
--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x", new LogEventStorage())));
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -86,7 +86,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x", new LogEventStorage())));
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -110,9 +110,9 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
-            
+
             protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
-            
+
             AssertOutput(@"
 --> MX-SUBSCRIBE subscriptionId
 <-- MX-SERVER
@@ -344,7 +344,7 @@ namespace Halibut.Tests
                 numberOfReads = reads;
             }
 
-            public List<object> Sent { get; set; } 
+            public List<object> Sent { get; set; }
 
             public void IdentifyAsClient()
             {
@@ -407,8 +407,8 @@ namespace Halibut.Tests
 
             public T Receive<T>()
             {
-                output.AppendLine("<-- " + typeof(T).Name);     
-                return (T) (nextReadQueue.Count > 0 ? nextReadQueue.Dequeue() : default(T));
+                output.AppendLine("<-- " + typeof(T).Name);
+                return (T)(nextReadQueue.Count > 0 ? nextReadQueue.Dequeue() : default(T));
             }
 
             public override string ToString()

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -138,6 +138,7 @@ namespace Halibut.Diagnostics
     public class HalibutLimits
     {
         public static TimeSpan ConnectionErrorRetryTimeout;
+        public static int LogStorageLimit;
         public static TimeSpan PollingQueueWaitTimeout;
         public static TimeSpan PollingRequestMaximumMessageProcessingTimeout;
         public static TimeSpan PollingRequestQueueTimeout;
@@ -167,7 +168,7 @@ namespace Halibut.Diagnostics
     }
     public class InMemoryConnectionLog : Halibut.Diagnostics.ILog
     {
-        public InMemoryConnectionLog(string endpoint) { }
+        public InMemoryConnectionLog(string endpoint, Halibut.Diagnostics.LogEventStorage logEventStorage) { }
         public IList<Halibut.Diagnostics.LogEvent> GetLogs() { }
         public void Write(Halibut.Diagnostics.EventType type, string message, Object[] args) { }
         public void WriteException(Halibut.Diagnostics.EventType type, string message, Exception ex, Object[] args) { }
@@ -182,6 +183,12 @@ namespace Halibut.Diagnostics
         public DateTimeOffset Time { get; }
         public Halibut.Diagnostics.EventType Type { get; }
         public string ToString() { }
+    }
+    public class LogEventStorage
+    {
+        public LogEventStorage() { }
+        public void AddLog(string endpoint, Halibut.Diagnostics.LogEvent logEvent) { }
+        public IList<Halibut.Diagnostics.LogEvent> GetLogs(string endpoint) { }
     }
     public class LogFactory : Halibut.Diagnostics.ILogFactory
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -138,6 +138,7 @@ namespace Halibut.Diagnostics
     public class HalibutLimits
     {
         public static TimeSpan ConnectionErrorRetryTimeout;
+        public static int LogStorageLimit;
         public static TimeSpan PollingQueueWaitTimeout;
         public static TimeSpan PollingRequestMaximumMessageProcessingTimeout;
         public static TimeSpan PollingRequestQueueTimeout;
@@ -167,7 +168,7 @@ namespace Halibut.Diagnostics
     }
     public class InMemoryConnectionLog : Halibut.Diagnostics.ILog
     {
-        public InMemoryConnectionLog(string endpoint) { }
+        public InMemoryConnectionLog(string endpoint, Halibut.Diagnostics.LogEventStorage logEventStorage) { }
         public IList<Halibut.Diagnostics.LogEvent> GetLogs() { }
         public void Write(Halibut.Diagnostics.EventType type, string message, Object[] args) { }
         public void WriteException(Halibut.Diagnostics.EventType type, string message, Exception ex, Object[] args) { }
@@ -182,6 +183,12 @@ namespace Halibut.Diagnostics
         public DateTimeOffset Time { get; }
         public Halibut.Diagnostics.EventType Type { get; }
         public string ToString() { }
+    }
+    public class LogEventStorage
+    {
+        public LogEventStorage() { }
+        public void AddLog(string endpoint, Halibut.Diagnostics.LogEvent logEvent) { }
+        public IList<Halibut.Diagnostics.LogEvent> GetLogs(string endpoint) { }
     }
     public class LogFactory : Halibut.Diagnostics.ILogFactory
     {

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -25,7 +25,7 @@ namespace Halibut.Tests
             var tentaclePort = tentacle.Listen();
             tentacle.Trust(Certificates.OctopusPublicThumbprint);
             endpoint = new ServiceEndPoint("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
-            log = new InMemoryConnectionLog(endpoint.ToString());
+            log = new InMemoryConnectionLog(endpoint.ToString(), new LogEventStorage());
             HalibutLimits.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
         }
 

--- a/source/Halibut/Diagnostics/HalibutLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutLimits.cs
@@ -9,13 +9,16 @@ namespace Halibut.Diagnostics
         {
             var settings = System.Configuration.ConfigurationManager.AppSettings;
 
-            var fields = typeof (HalibutLimits).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            var fields = typeof(HalibutLimits).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
             foreach (var field in fields)
             {
                 var value = settings.Get("Halibut." + field.Name);
                 if (string.IsNullOrWhiteSpace(value)) continue;
-                var time = TimeSpan.Parse(value);
-                field.SetValue(null, time);
+
+                if (TimeSpan.TryParse(value, out var time))
+                    field.SetValue(null, time);
+                else if (Int32.TryParse(value, out var number))
+                    field.SetValue(null, number);
             }
         }
 
@@ -31,6 +34,7 @@ namespace Halibut.Diagnostics
         public static TimeSpan TcpClientHeartbeatReceiveTimeout = TimeSpan.FromSeconds(60);
         public static TimeSpan TcpClientConnectTimeout = TimeSpan.FromSeconds(60);
         public static TimeSpan PollingQueueWaitTimeout = TimeSpan.FromSeconds(30);
+        public static int LogStorageLimit = 5000;
 
         // After a client/server message exchange is complete, the client returns
         // the connection to the pool but the server continues to block and reads

--- a/source/Halibut/Diagnostics/LogEventStorage.cs
+++ b/source/Halibut/Diagnostics/LogEventStorage.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Halibut.Diagnostics
+{
+    public class LogEventStorage
+    {
+        static readonly LogEvent[] EmptyLogs = new LogEvent[0];
+
+        readonly ConcurrentDictionary<string, Queue<LogEvent>> events = new ConcurrentDictionary<string, Queue<LogEvent>>();
+        readonly Queue<string> lastLogEndpoint = new Queue<string>();
+
+        public LogEventStorage()
+        {
+        }
+
+        public IList<LogEvent> GetLogs(string endpoint)
+        {
+            if (events.TryGetValue(endpoint, out var logs))
+                return logs.ToArray();
+
+            return EmptyLogs;
+        }
+
+        public void AddLog(string endpoint, LogEvent logEvent)
+        {
+            lock (events)
+            {
+                var logs = events.GetOrAdd(endpoint, e => new Queue<LogEvent>());
+                logs.Enqueue(logEvent);
+                lastLogEndpoint.Enqueue(endpoint);
+
+                while (lastLogEndpoint.Count > HalibutLimits.LogStorageLimit)
+                {
+                    var endPointToDeleteFrom = lastLogEndpoint.Dequeue();
+                    if (events.TryGetValue(endPointToDeleteFrom, out var oldLogs))
+                    {
+                        oldLogs.Dequeue();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut/Diagnostics/LogFactory.cs
+++ b/source/Halibut/Diagnostics/LogFactory.cs
@@ -7,6 +7,7 @@ namespace Halibut.Diagnostics
 {
     public class LogFactory : ILogFactory
     {
+        readonly LogEventStorage logEventStorage = new LogEventStorage();
         readonly ConcurrentDictionary<string, InMemoryConnectionLog> events = new ConcurrentDictionary<string, InMemoryConnectionLog>();
         readonly HashSet<Uri> endpoints = new HashSet<Uri>();
         readonly HashSet<string> prefixes = new HashSet<string>();
@@ -28,14 +29,14 @@ namespace Halibut.Diagnostics
             endpoint = NormalizeEndpoint(endpoint);
             lock (endpoints)
                 endpoints.Add(endpoint);
-            return events.GetOrAdd(endpoint.ToString(), e => new InMemoryConnectionLog(endpoint.ToString()));
+            return events.GetOrAdd(endpoint.ToString(), e => new InMemoryConnectionLog(endpoint.ToString(), logEventStorage));
         }
 
         public ILog ForPrefix(string prefix)
         {
             lock (prefixes)
                 prefixes.Add(prefix);
-            return events.GetOrAdd(prefix, e => new InMemoryConnectionLog(prefix));
+            return events.GetOrAdd(prefix, e => new InMemoryConnectionLog(prefix, logEventStorage));
         }
 
         static Uri NormalizeEndpoint(Uri endpoint)


### PR DESCRIPTION
Log messages are stored in the `InMemoryConnectionLog` and are limited to 100, but there's a `InMemoryConnectionLog` for each endpoint, which can lead to a memory leak when there's a lot of endpoints.

Fixes OctopusDeploy/Issues#4824