### PR TITLE
Removed logging format objects to improve memory

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -40,7 +40,7 @@ namespace Halibut
         public static string DefaultFriendlyHtmlPageContent;
         public HalibutRuntime(X509Certificate2 serverCertificate) { }
         public HalibutRuntime(Halibut.ServiceModel.IServiceFactory serviceFactory, X509Certificate2 serverCertificate) { }
-        public Halibut.Diagnostics.LogFactory Logs { get; }
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
         public static bool OSSupportsWebSockets { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
@@ -67,7 +67,7 @@ namespace Halibut
     }
     public interface IHalibutRuntime : IDisposable
     {
-        public Halibut.Diagnostics.LogFactory Logs { get; }
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Uri uri) { }
@@ -165,18 +165,10 @@ namespace Halibut.Diagnostics
         public Uri[] GetEndpoints() { }
         public String[] GetPrefixes() { }
     }
-    public class InMemoryConnectionLog : Halibut.Diagnostics.ILog
-    {
-        public InMemoryConnectionLog(string endpoint) { }
-        public IList<Halibut.Diagnostics.LogEvent> GetLogs() { }
-        public void Write(Halibut.Diagnostics.EventType type, string message, Object[] args) { }
-        public void WriteException(Halibut.Diagnostics.EventType type, string message, Exception ex, Object[] args) { }
-    }
     public class LogEvent
     {
         public LogEvent(Halibut.Diagnostics.EventType type, string message, Exception error, Object[] formatArguments) { }
         public Exception Error { get; }
-        public Object[] FormatArguments { get; }
         public string FormattedMessage { get; }
         public string Message { get; }
         public DateTimeOffset Time { get; }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -40,7 +40,7 @@ namespace Halibut
         public static string DefaultFriendlyHtmlPageContent;
         public HalibutRuntime(X509Certificate2 serverCertificate) { }
         public HalibutRuntime(Halibut.ServiceModel.IServiceFactory serviceFactory, X509Certificate2 serverCertificate) { }
-        public Halibut.Diagnostics.LogFactory Logs { get; }
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
         public static bool OSSupportsWebSockets { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
@@ -67,7 +67,7 @@ namespace Halibut
     }
     public interface IHalibutRuntime : IDisposable
     {
-        public Halibut.Diagnostics.LogFactory Logs { get; }
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Uri uri) { }
@@ -165,18 +165,10 @@ namespace Halibut.Diagnostics
         public Uri[] GetEndpoints() { }
         public String[] GetPrefixes() { }
     }
-    public class InMemoryConnectionLog : Halibut.Diagnostics.ILog
-    {
-        public InMemoryConnectionLog(string endpoint) { }
-        public IList<Halibut.Diagnostics.LogEvent> GetLogs() { }
-        public void Write(Halibut.Diagnostics.EventType type, string message, Object[] args) { }
-        public void WriteException(Halibut.Diagnostics.EventType type, string message, Exception ex, Object[] args) { }
-    }
     public class LogEvent
     {
         public LogEvent(Halibut.Diagnostics.EventType type, string message, Exception error, Object[] formatArguments) { }
         public Exception Error { get; }
-        public Object[] FormatArguments { get; }
         public string FormattedMessage { get; }
         public string Message { get; }
         public DateTimeOffset Time { get; }

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -6,11 +6,11 @@ using Halibut.Logging;
 
 namespace Halibut.Diagnostics
 {
-    public class InMemoryConnectionLog : ILog
+    internal class InMemoryConnectionLog : ILog
     {
         readonly string endpoint;
         readonly ConcurrentQueue<LogEvent> events = new ConcurrentQueue<LogEvent>();
-        
+
         public InMemoryConnectionLog(string endpoint)
         {
             this.endpoint = endpoint;

--- a/source/Halibut/Diagnostics/LogEvent.cs
+++ b/source/Halibut/Diagnostics/LogEvent.cs
@@ -4,59 +4,26 @@ namespace Halibut.Diagnostics
 {
     public class LogEvent
     {
-        private readonly EventType type;
-        private readonly string message;
-        private readonly Exception error;
-        private readonly object[] formatArguments;
-        private readonly DateTimeOffset time;
-        private readonly Lazy<string> formattedMessage;
-
         public LogEvent(EventType type, string message, Exception error, object[] formatArguments)
         {
-            this.type = type;
-            this.message = message;
-            this.error = error;
-            this.formatArguments = formatArguments;
-            time = DateTimeOffset.UtcNow;
-            formattedMessage = new Lazy<string>(FormatMessage);
-        }
-
-        public EventType Type
-        {
-            get { return type; }
-        }
-
-        public string Message
-        {
-            get { return message; }
-        }
-
-        public string FormattedMessage
-        {
-            get { return formattedMessage.Value; }
-        }
-
-        public Exception Error
-        {
-            get { return error; }
-        }
-
-        public object[] FormatArguments
-        {
-            get { return formatArguments; }
-        }
-
-        public DateTimeOffset Time
-        {
-            get { return time; }
-        }
-
-        string FormatMessage()
-        {
-            return formatArguments == null || formatArguments.Length == 0
+            Type = type;
+            Message = message;
+            Error = error;
+            Time = DateTimeOffset.UtcNow;
+            FormattedMessage = formatArguments == null || formatArguments.Length == 0
                 ? Message
-                : string.Format(message, formatArguments);
+                : string.Format(Message, formatArguments);
         }
+
+        public EventType Type { get; }
+
+        public string Message { get; }
+
+        public string FormattedMessage { get; }
+
+        public Exception Error { get; }
+
+        public DateTimeOffset Time { get; }
 
         public override string ToString()
         {

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -38,7 +38,7 @@ namespace Halibut
             invoker = new ServiceInvoker(serviceFactory);
         }
 
-        public LogFactory Logs
+        public ILogFactory Logs
         {
             get { return logs; }
         }
@@ -87,7 +87,7 @@ namespace Halibut
             {
 #if SUPPORTS_WEB_SOCKET_CLIENT
                 client = new SecureWebSocketClient(endPoint, serverCertificate, log, pool);
-#else 
+#else
                 throw new NotSupportedException("The netstandard build of this library cannot act as the client in a WebSocket polling setup");
 #endif
             }
@@ -180,7 +180,7 @@ namespace Halibut
             lock (trustedThumbprints)
             {
                 trustedThumbprints.Clear();
-                foreach(var thumbprint in thumbprints)
+                foreach (var thumbprint in thumbprints)
                     trustedThumbprints.Add(thumbprint);
             }
         }

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -7,7 +7,7 @@ namespace Halibut
 {
     public interface IHalibutRuntime : IDisposable
     {
-        LogFactory Logs { get; }
+        ILogFactory Logs { get; }
         int Listen();
         int Listen(int port);
         int Listen(IPEndPoint endpoint);


### PR DESCRIPTION
Redo of PR #54 

Instead of implementing a limit on log messages this just takes out the object array used in the formatted message. Hopefully this will improve memory performance enough.

Fixes OctopusDeploy/Issues#4824