### PR TITLE
Simplified connection pool with single top-level lock

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -296,7 +296,7 @@ namespace Halibut.Transport
         public void Clear(TKey key, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
         public int GetTotalConnectionCount() { }
-        public void Return(TKey key, TPooledResource resource) { }
+        public void Return(TKey endPoint, TPooledResource resource) { }
         public TPooledResource Take(TKey endPoint) { }
     }
     public class DiscoveryClient

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -290,7 +290,7 @@ namespace Halibut.Transport
         public void Clear(TKey key, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
         public int GetTotalConnectionCount() { }
-        public void Return(TKey key, TPooledResource resource) { }
+        public void Return(TKey endPoint, TPooledResource resource) { }
         public TPooledResource Take(TKey endPoint) { }
     }
     public class DiscoveryClient

--- a/source/Halibut/Transport/ConnectionPool.cs
+++ b/source/Halibut/Transport/ConnectionPool.cs
@@ -63,6 +63,8 @@ namespace Halibut.Transport
                 {
                     DestroyConnection(connection, log);
                 }
+
+                connections.Clear();
             }
         }
 


### PR DESCRIPTION
Simplified concurrency in the pool by just using a top-level lock