### PR TITLE
Increased the number of polling connections when long data transfers occurs

### DIFF
--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -111,7 +111,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
+            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), () => { }, 5);
 
             AssertOutput(@"
 --> MX-SUBSCRIBE subscriptionId
@@ -192,11 +192,11 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
+            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), () => { }, 5);
 
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
+            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), () => { }, 5);
 
             AssertOutput(@"
 --> MX-SUBSCRIBE subscriptionId
@@ -410,10 +410,10 @@ namespace Halibut.Tests
                 Sent.Add(message);
             }
 
-            public T Receive<T>()
+            public T Receive<T>(Action longTransferCallback = null)
             {
                 output.AppendLine("<-- " + typeof(T).Name);
-                return (T)(nextReadQueue.Count > 0 ? nextReadQueue.Dequeue() : default(T));
+                return (T) (nextReadQueue.Count > 0 ? nextReadQueue.Dequeue() : default(T));
             }
 
             public override string ToString()

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -57,7 +57,11 @@ namespace Halibut.Tests
 
             var secureClient = new SecureClient(endpoint, Certificates.Octopus, log, pool);
             ResponseMessage response = null;
-            secureClient.ExecuteTransaction((mep) => response = mep.ExchangeAsClient(request));
+            secureClient.ExecuteTransaction((mep) =>
+            {
+                response = mep.ExchangeAsClient(request);
+                return true;
+            });
 
             // The pool should be cleared after the second failure
             stream.Received(2).IdentifyAsClient();

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -147,6 +147,7 @@ namespace Halibut
             client.ExecuteTransaction(protocol =>
             {
                 response = protocol.ExchangeAsClient(request);
+                return true;
             });
             return response;
         }

--- a/source/Halibut/Transport/ISecureClient.cs
+++ b/source/Halibut/Transport/ISecureClient.cs
@@ -6,6 +6,6 @@ namespace Halibut.Transport
     public interface ISecureClient
     {
         ServiceEndPoint ServiceEndpoint { get; }
-        void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler);
+        void ExecuteTransaction(Func<MessageExchangeProtocol, bool> protocolHandler);
     }
 }

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
@@ -13,7 +17,9 @@ namespace Halibut.Transport
         readonly Func<RequestMessage, ResponseMessage> handleIncomingRequest;
         readonly ILog log;
         readonly Thread thread;
+        readonly ConcurrentDictionary<Thread, MessageExchangeProtocol> runningExchanges = new ConcurrentDictionary<Thread, MessageExchangeProtocol>();
         bool working;
+        int longRunningTransferCount;
 
         [Obsolete("Use the overload that provides a logger. This remains for backwards compatibility.")]
         public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest)
@@ -28,7 +34,7 @@ namespace Halibut.Transport
             this.handleIncomingRequest = handleIncomingRequest;
             this.log = log;
             thread = new Thread(ExecutePollingLoop);
-            thread.Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
+            thread.Name = "Polling loop for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
             thread.IsBackground = true;
         }
 
@@ -40,20 +46,61 @@ namespace Halibut.Transport
 
         private void ExecutePollingLoop(object ignored)
         {
+            var timeSinceLastRampUp = new Stopwatch();
             while (working)
             {
-                try
+                var completed = runningExchanges.Keys.Where(t => !t.IsAlive).ToArray();
+                foreach (var item in completed)
+                    runningExchanges.TryRemove(item, out _);
+
+                Console.WriteLine(runningExchanges.Count);
+
+                var longRunning = Interlocked.Exchange(ref longRunningTransferCount, 0);
+
+                if (longRunning > 0 || runningExchanges.Count == 0)
                 {
-                    secureClient.ExecuteTransaction(protocol =>
-                    {
-                        protocol.ExchangeAsSubscriber(subscription, handleIncomingRequest);
-                    });
+                    StartNewExchangeThread();
+                    timeSinceLastRampUp.Restart();
                 }
-                catch (Exception ex)
+                
+                if(timeSinceLastRampUp.Elapsed > TimeSpan.FromMinutes(2))
                 {
-                    log?.WriteException(EventType.Error, "Exception in the polling loop, sleeping for 5 seconds. This may be cause by a network error and usually rectifies itself. Disregard this message unless you are having communication problems.", ex);
-                    Thread.Sleep(5000);
+                    // Slowly ramp down the number of connections
+                    var protocol = runningExchanges.Values.Where(p => p != null && !p.StopExchangeAsSubscriberOnceNoMessagesAreLeft).Skip(1).FirstOrDefault();
+                    if (protocol != null)
+                        protocol.StopExchangeAsSubscriberOnceNoMessagesAreLeft = true;
                 }
+
+                Thread.Sleep(5000);
+            }
+        }
+
+        void StartNewExchangeThread()
+        {
+            Thread exchangeThread = null;
+
+            exchangeThread = new Thread(() => Run(p => runningExchanges[exchangeThread] = p))
+            {
+                Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription,
+                IsBackground = true
+            };
+            runningExchanges[exchangeThread] = null;
+            exchangeThread.Start();
+        }
+
+        void Run(Action<MessageExchangeProtocol> gotProtocolCallback)
+        {
+            try
+            {
+                secureClient.ExecuteTransaction(protocol =>
+                {
+                    gotProtocolCallback(protocol);
+                    return protocol.ExchangeAsSubscriber(subscription, handleIncomingRequest, () => Interlocked.Increment(ref longRunningTransferCount));
+                });
+            }
+            catch (Exception ex)
+            {
+                log?.WriteException(EventType.Error, "Exception in the polling loop, sleeping for 5 seconds. This may be cause by a network error and usually rectifies itself. Disregard this message unless you are having communication problems.", ex);
             }
         }
 

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -17,6 +17,6 @@ namespace Halibut.Transport.Protocol
         void IdentifyAsServer();
         RemoteIdentity ReadRemoteIdentity();
         void Send<T>(T message);
-        T Receive<T>();
+        T Receive<T>(Action longTransferCallback = null);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -189,12 +189,15 @@ namespace Halibut.Transport.Protocol
             log.Write(EventType.Diagnostic, "Sent: {0}", message);
         }
 
-        public T Receive<T>()
+        public T Receive<T>(Action longTransferCallback = null)
         {
             using (var capture = StreamCapture.New())
             {
                 var result = ReadBsonMessage<T>();
-                ReadStreams(capture);
+                
+                using(longTransferCallback == null ? null : new Timer(_ => longTransferCallback(), null, TimeSpan.FromSeconds(5), TimeSpan.Zero))
+                    ReadStreams(capture);
+                
                 log.Write(EventType.Diagnostic, "Received: {0}", result);
                 return result;
             }


### PR DESCRIPTION
Resolves https://github.com/OctopusDeploy/Issues/issues/3034

TODO

- [ ] Make amount of time that needs to elapse configurable
- [ ] Make API backwards compatible