### PR TITLE
Use Pending to check for clients

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
     <AssemblyName>Halibut.Tests</AssemblyName>
     <PackageId>Halibut.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -30,7 +30,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.6" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -11,7 +11,6 @@ using Halibut.Transport.Protocol;
 
 namespace Halibut.Transport
 {
-
     public class SecureWebSocketListener : IDisposable
     {
         readonly string endPoint;
@@ -74,9 +73,9 @@ namespace Halibut.Transport
 
         async Task Accept()
         {
-            while (!cts.IsCancellationRequested)
+            using (cts.Token.Register(listener.Stop))
             {
-                using (cts.Token.Register(listener.Stop))
+                while (!cts.IsCancellationRequested)
                 {
                     try
                     {
@@ -94,7 +93,6 @@ namespace Halibut.Transport
                             SendFriendlyHtmlPage(context.Response);
                             context.Response.Close();
                         }
-
                     }
                     catch (Exception ex)
                     {
@@ -234,7 +232,6 @@ namespace Halibut.Transport
         public void Dispose()
         {
             cts.Cancel();
-            listener?.Stop();
             log.Write(EventType.ListenerStopped, "Listener stopped");
         }
     }


### PR DESCRIPTION
In windows the call to `listener.Stop` causes an exception to be raised in the blocking call to `listener.AcceptTcpClient()` but in Linux and Mac, it does not throw!

This behaviour change causes `SecureListener.Dispose` to hang in those OSs