### PR TITLE
Ignore access exceptions when attempting to correct ACL

### DIFF
--- a/source/Halibut/Transport/Protocol/TemporaryFileStream.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileStream.cs
@@ -53,7 +53,7 @@ namespace Halibut.Transport.Protocol
             }
             catch (UnauthorizedAccessException ex)
             {
-                log.Write(EventType.Security, $"Ignoring an unauthorized access issue: {ex.Message}. {nameof(TemporaryFileStream)} assumes that filesystem permissions allow full control to the executing user for {filePath}. Update those permissions to remove this log.");
+                log?.Write(EventType.Security, $"Ignoring an unauthorized access issue: {ex.Message}. {nameof(TemporaryFileStream)} assumes that filesystem permissions allow full control to the executing user for {filePath}. Update those permissions to remove this log.");
             }
         }
 

--- a/source/Halibut/Transport/Protocol/TemporaryFileStream.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileStream.cs
@@ -51,9 +51,9 @@ namespace Halibut.Transport.Protocol
                 fileInfo.SetAccessControl(fileSecurity);
 #pragma warning restore PC001 // API not supported on all platforms
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
-                // ignored, user has likely disallowed full control over their artifact directory 
+                log.Write(EventType.Security, $"Ignoring an unauthorized access issue: {ex.Message}. {nameof(TemporaryFileStream)} assumes that filesystem permissions allow full control to the executing user for {filePath}. Update those permissions to remove this log.");
             }
         }
 

--- a/source/Halibut/Transport/Protocol/TemporaryFileStream.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileStream.cs
@@ -39,15 +39,22 @@ namespace Halibut.Transport.Protocol
 
         void SetFilePermissionsToInheritFromParent(string filePath)
         {
-            var fileInfo = new FileInfo(filePath);
+            try
+            {
+                var fileInfo = new FileInfo(filePath);
 #pragma warning disable PC001 // API not supported on all platforms
-            var fileSecurity = fileInfo.GetAccessControl();
+                var fileSecurity = fileInfo.GetAccessControl();
 
-            //When isProtected (first param) is false, SetAccessRuleProtection changes the permissions of the file to allow inherited permissions. 
-            //preserveInheritance (second param) is ignored when isProtected is false.
-            fileSecurity.SetAccessRuleProtection(false, false);
-            fileInfo.SetAccessControl(fileSecurity);
+                //When isProtected (first param) is false, SetAccessRuleProtection changes the permissions of the file to allow inherited permissions. 
+                //preserveInheritance (second param) is ignored when isProtected is false.
+                fileSecurity.SetAccessRuleProtection(false, false);
+                fileInfo.SetAccessControl(fileSecurity);
 #pragma warning restore PC001 // API not supported on all platforms
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // ignored, user has likely disallowed full control over their artifact directory 
+            }
         }
 
         public void Read(Action<Stream> reader)


### PR DESCRIPTION
These exceptions can cause deployments to fail when Server uses this code to write out artifacts to disk.

Fixes: https://github.com/OctopusDeploy/Issues/issues/5433