### PR TITLE
Add method to dispose all connections to an endpoint

### DIFF
--- a/source/Halibut.Tests/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/ConnectionManagerFixture.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.Transport;
+using Halibut.Transport.Protocol;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    [TestFixture]
+    public class ConnectionManagerFixture
+    {
+        IConnection connection;
+        IConnectionFactory connectionFactory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var stream = Substitute.For<IMessageExchangeStream>();
+            connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, new MessageExchangeProtocol(stream));
+            connectionFactory = Substitute.For<IConnectionFactory>();
+            connectionFactory.EstablishNewConnection(Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>()).Returns(connection);
+        }
+
+        [Test]
+        public void ReleasedConnectionsAreNotActive()
+        {
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            var connectionManager = new ConnectionManager();
+
+            connectionManager.AcquireConnection(connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == connection);
+
+            connectionManager.ReleaseConnection(serviceEndpoint, connection);
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void DisposedConnectionsAreRemovedFromActive()
+        {
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            var connectionManager = new ConnectionManager();
+
+            connectionManager.AcquireConnection(connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == connection);
+
+            connection.Dispose();
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void DisconnectDisposesActiveConnections()
+        {
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            var connectionManager = new ConnectionManager();
+            
+            connectionManager.AcquireConnection(connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == connection);
+
+            connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
+        }
+    }
+}

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -300,6 +300,15 @@ namespace Halibut.ServiceModel
 }
 namespace Halibut.Transport
 {
+    public class ConnectionManager : IDisposable
+    {
+        public ConnectionManager() { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public void ReleaseConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Transport.IConnection connection) { }
+    }
     public class ConnectionPool<TKey, TPooledResource>
     {
         public ConnectionPool() { }
@@ -317,6 +326,10 @@ namespace Halibut.Transport
     public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
     {
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+    }
+    public interface IConnectionFactory
+    {
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -338,7 +351,7 @@ namespace Halibut.Transport
     public class SecureClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
         public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
     }
@@ -372,6 +385,11 @@ namespace Halibut.Transport
     {
         public static void ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout) { }
         public static void ConnectWithTimeout(TcpClient client, string host, int port, TimeSpan timeout) { }
+    }
+    public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
+    {
+        public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -307,6 +307,7 @@ namespace Halibut.Transport
         public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
+        public IReadOnlyCollection<Halibut.Transport.IConnection> GetActiveConnections(Halibut.ServiceEndPoint serviceEndPoint) { }
         public void ReleaseConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Transport.IConnection connection) { }
     }
     public class ConnectionPool<TKey, TPooledResource>
@@ -325,11 +326,12 @@ namespace Halibut.Transport
     }
     public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
     {
+        event EventHandler OnDisposed
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
     }
     public interface IConnectionFactory
     {
-        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -357,6 +359,7 @@ namespace Halibut.Transport
     }
     public class SecureConnection : Halibut.Transport.IConnection, Halibut.Transport.IPooledResource, IDisposable
     {
+        event EventHandler OnDisposed
         public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
         public void Dispose() { }
@@ -389,7 +392,7 @@ namespace Halibut.Transport
     public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
     {
         public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
-        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -44,6 +44,7 @@ namespace Halibut
         public static bool OSSupportsWebSockets { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Uri uri) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public void Dispose() { }
@@ -70,6 +71,7 @@ namespace Halibut
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Uri uri) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public bool IsTrusted(string remoteThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs.orig
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs.orig
@@ -300,6 +300,15 @@ namespace Halibut.ServiceModel
 }
 namespace Halibut.Transport
 {
+    public class ConnectionManager : IDisposable
+    {
+        public ConnectionManager() { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public void ReleaseConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Transport.IConnection connection) { }
+    }
     public class ConnectionPool<TKey, TPooledResource>
     {
         public ConnectionPool() { }
@@ -317,6 +326,10 @@ namespace Halibut.Transport
     public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
     {
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+    }
+    public interface IConnectionFactory
+    {
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -338,7 +351,7 @@ namespace Halibut.Transport
     public class SecureClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
         public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
     }
@@ -372,6 +385,11 @@ namespace Halibut.Transport
     {
         public static void ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout) { }
         public static void ConnectWithTimeout(TcpClient client, string host, int port, TimeSpan timeout) { }
+    }
+    public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
+    {
+        public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs.orig
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs.orig
@@ -1,0 +1,572 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Halibut
+{
+    public class DataStream : IEquatable<Halibut.DataStream>
+    {
+        public DataStream() { }
+        public DataStream(long length, Action<Stream> writer) { }
+        public Guid Id { get; set; }
+        public long Length { get; set; }
+        public bool Equals(Halibut.DataStream other) { }
+        public bool Equals(Object obj) { }
+        public static Halibut.DataStream FromBytes(Byte[] data) { }
+        public static Halibut.DataStream FromStream(Stream source, Action<int> updateProgress) { }
+        public static Halibut.DataStream FromStream(Stream source) { }
+        public static Halibut.DataStream FromString(string text) { }
+        public static Halibut.DataStream FromString(string text, Encoding encoding) { }
+        public int GetHashCode() { }
+        public Halibut.IDataStreamReceiver Receiver() { }
+    }
+    public class HalibutClientException : Exception, ISerializable
+    {
+        public HalibutClientException(string message) { }
+        public HalibutClientException(string message, Exception inner) { }
+        public HalibutClientException(string message, string serverException) { }
+    }
+    public class HalibutRuntime : Halibut.IHalibutRuntime, IDisposable
+    {
+        public static string DefaultFriendlyHtmlPageContent;
+        public HalibutRuntime(X509Certificate2 serverCertificate) { }
+        public HalibutRuntime(Halibut.ServiceModel.IServiceFactory serviceFactory, X509Certificate2 serverCertificate) { }
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
+        public static bool OSSupportsWebSockets { get; }
+        public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
+        public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
+        public Halibut.ServiceEndPoint Discover(Uri uri) { }
+        public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
+        public void Dispose() { }
+        public bool IsTrusted(string remoteThumbprint) { }
+        public int Listen() { }
+        public int Listen(int port) { }
+        public int Listen(IPEndPoint endpoint) { }
+        public void ListenWebSocket(string endpoint) { }
+        public void Poll(Uri subscription, Halibut.ServiceEndPoint endPoint) { }
+        public void RemoveTrust(string clientThumbprint) { }
+        public void Route(Halibut.ServiceEndPoint to, Halibut.ServiceEndPoint via) { }
+        public void SetFriendlyHtmlPageContent(string html) { }
+        public void SetFriendlyHtmlPageHeaders(IEnumerable<KeyValuePair<string, string>> headers) { }
+        public void Trust(string clientThumbprint) { }
+        public void TrustOnly(IReadOnlyList<string> thumbprints) { }
+    }
+    public interface IDataStreamReceiver
+    {
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public interface IHalibutRuntime : IDisposable
+    {
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
+        public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
+        public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
+        public Halibut.ServiceEndPoint Discover(Uri uri) { }
+        public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
+        public bool IsTrusted(string remoteThumbprint) { }
+        public int Listen() { }
+        public int Listen(int port) { }
+        public int Listen(IPEndPoint endpoint) { }
+        public void ListenWebSocket(string endpoint) { }
+        public void Poll(Uri subscription, Halibut.ServiceEndPoint endPoint) { }
+        public void RemoveTrust(string clientThumbprint) { }
+        public void Route(Halibut.ServiceEndPoint to, Halibut.ServiceEndPoint via) { }
+        public void SetFriendlyHtmlPageContent(string html) { }
+        public void Trust(string clientThumbprint) { }
+        public void TrustOnly(IReadOnlyList<string> thumbprints) { }
+    }
+    public class ProxyDetails : IEquatable<Halibut.ProxyDetails>
+    {
+        public ProxyDetails(string host, int port, Halibut.Transport.Proxy.ProxyType type) { }
+        public ProxyDetails(string host, int port, Halibut.Transport.Proxy.ProxyType type, string userName, string password) { }
+        public string Host { get; }
+        public string Password { get; }
+        public int Port { get; }
+        public Halibut.Transport.Proxy.ProxyType Type { get; }
+        public string UserName { get; }
+        public bool Equals(Halibut.ProxyDetails other) { }
+        public bool Equals(Object obj) { }
+        public int GetHashCode() { }
+    }
+    public class ServiceEndPoint : IEquatable<Halibut.ServiceEndPoint>
+    {
+        public ServiceEndPoint(string baseUri, string remoteThumbprint) { }
+        public ServiceEndPoint(Uri baseUri, string remoteThumbprint) { }
+        public ServiceEndPoint(Uri baseUri, string remoteThumbprint, Halibut.ProxyDetails proxy) { }
+        public Uri BaseUri { get; }
+        public TimeSpan ConnectionErrorRetryTimeout { get; set; }
+        public bool IsWebSocketEndpoint { get; }
+        public TimeSpan PollingRequestMaximumMessageProcessingTimeout { get; set; }
+        public TimeSpan PollingRequestQueueTimeout { get; set; }
+        public Halibut.ProxyDetails Proxy { get; }
+        public string RemoteThumbprint { get; }
+        public int RetryCountLimit { get; set; }
+        public TimeSpan RetryListeningSleepInterval { get; set; }
+        public TimeSpan TcpClientConnectTimeout { get; set; }
+        public bool Equals(Halibut.ServiceEndPoint other) { }
+        public bool Equals(Object obj) { }
+        public int GetHashCode() { }
+        public static bool IsWebSocketAddress(Uri baseUri) { }
+        public string ToString() { }
+    }
+}
+namespace Halibut.Diagnostics
+{
+    public enum EventType
+    {
+        OpeningNewConnection = 0,
+        UsingExistingConnectionFromPool = 1,
+        Security = 2,
+        MessageExchange = 3,
+        Diagnostic = 4,
+        ClientDenied = 5,
+        Error = 6,
+        ListenerStarted = 7,
+        ListenerAcceptedClient = 8,
+        ListenerStopped = 9,
+        SecurityNegotiation = 10,
+        FileTransfer = 11
+    }
+    public static class ExceptionExtensions
+    {
+        public static bool IsSocketConnectionReset(Exception exception) { }
+        public static bool IsSocketConnectionTimeout(Exception exception) { }
+        public static bool IsSocketTimeout(Exception exception) { }
+        public static Exception UnpackFromContainers(Exception error) { }
+    }
+    public class HalibutLimits
+    {
+        public static TimeSpan ConnectionErrorRetryTimeout;
+        public static TimeSpan PollingQueueWaitTimeout;
+        public static TimeSpan PollingRequestMaximumMessageProcessingTimeout;
+        public static TimeSpan PollingRequestQueueTimeout;
+        public static int RetryCountLimit;
+        public static TimeSpan RetryListeningSleepInterval;
+        public static TimeSpan TcpClientConnectTimeout;
+        public static TimeSpan TcpClientHeartbeatReceiveTimeout;
+        public static TimeSpan TcpClientHeartbeatSendTimeout;
+        public static TimeSpan TcpClientPooledConnectionTimeout;
+        public static TimeSpan TcpClientReceiveTimeout;
+        public static TimeSpan TcpClientSendTimeout;
+        public HalibutLimits() { }
+        public static TimeSpan SafeTcpClientPooledConnectionTimeout { get; }
+    }
+    public interface ILog
+    {
+        public IList<Halibut.Diagnostics.LogEvent> GetLogs() { }
+        public void Write(Halibut.Diagnostics.EventType type, string message, Object[] args) { }
+        public void WriteException(Halibut.Diagnostics.EventType type, string message, Exception ex, Object[] args) { }
+    }
+    public interface ILogFactory
+    {
+        public Halibut.Diagnostics.ILog ForEndpoint(Uri endpoint) { }
+        public Halibut.Diagnostics.ILog ForPrefix(string endPoint) { }
+        public Uri[] GetEndpoints() { }
+        public String[] GetPrefixes() { }
+    }
+    public class LogEvent
+    {
+        public LogEvent(Halibut.Diagnostics.EventType type, string message, Exception error, Object[] formatArguments) { }
+        public Exception Error { get; }
+        public string FormattedMessage { get; }
+        public string Message { get; }
+        public DateTimeOffset Time { get; }
+        public Halibut.Diagnostics.EventType Type { get; }
+        public string ToString() { }
+    }
+    public class LogFactory : Halibut.Diagnostics.ILogFactory
+    {
+        public LogFactory() { }
+        public Halibut.Diagnostics.ILog ForEndpoint(Uri endpoint) { }
+        public Halibut.Diagnostics.ILog ForPrefix(string prefix) { }
+        public Uri[] GetEndpoints() { }
+        public String[] GetPrefixes() { }
+    }
+}
+namespace Halibut.Logging
+{
+    public interface ILogProvider
+    {
+        public Halibut.Logging.Logger GetLogger(string name) { }
+        public IDisposable OpenMappedContext(string key, string value) { }
+        public IDisposable OpenNestedContext(string message) { }
+    }
+    public sealed class Logger : MulticastDelegate, ICloneable, ISerializable
+    {
+        public Logger(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Halibut.Logging.LogLevel logLevel, Func<string> messageFunc, Exception exception, Object[] formatParameters, AsyncCallback callback, Object @object) { }
+        public bool EndInvoke(IAsyncResult result) { }
+        public bool Invoke(Halibut.Logging.LogLevel logLevel, Func<string> messageFunc, Exception exception, Object[] formatParameters) { }
+    }
+    public enum LogLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Info = 2,
+        Warn = 3,
+        Error = 4,
+        Fatal = 5
+    }
+    public static class LogProvider
+    {
+        public static string DisableLoggingEnvironmentVariable;
+        internal static Halibut.Logging.ILogProvider CurrentLogProvider {  }
+        public static bool IsDisabled { get; set; }
+        static Action<Halibut.Logging.ILogProvider> OnCurrentLogProviderSet {  }
+        public static void SetCurrentLogProvider(Halibut.Logging.ILogProvider logProvider) { }
+    }
+}
+namespace Halibut.Portability
+{
+    public static class TypeExtensions
+    {
+        public static Assembly Assembly(Type type) { }
+        public static bool IsValueType(Type type) { }
+    }
+}
+namespace Halibut.ServiceModel
+{
+    public class DelegateServiceFactory : Halibut.ServiceModel.IServiceFactory
+    {
+        public DelegateServiceFactory() { }
+        public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
+        public void Register<TContract>(Func<TContract> implementation) { }
+    }
+    public class HalibutProxy : DispatchProxy
+    {
+        public HalibutProxy() { }
+        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint) { }
+        protected Object Invoke(MethodInfo targetMethod, Object[] args) { }
+    }
+    public interface IPendingRequestQueue
+    {
+        public bool IsEmpty { get; }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
+        public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
+    }
+    public interface IPollingClient : IDisposable
+    {
+        public void Start() { }
+    }
+    public interface IServiceFactory
+    {
+        public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
+    }
+    public interface IServiceInvoker
+    {
+        public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+    }
+    public interface IServiceLease : IDisposable
+    {
+        public Object Service { get; }
+    }
+    public class NullServiceFactory : Halibut.ServiceModel.IServiceFactory
+    {
+        public NullServiceFactory() { }
+        public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
+    }
+    public class PendingRequestQueue : Halibut.ServiceModel.IPendingRequestQueue
+    {
+        public PendingRequestQueue(Halibut.Diagnostics.ILog log) { }
+        public bool IsEmpty { get; }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
+        public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
+        public Halibut.Transport.Protocol.ResponseMessage QueueAndWait(Halibut.Transport.Protocol.RequestMessage request) { }
+    }
+    public class PollingClientCollection
+    {
+        public PollingClientCollection() { }
+        public void Add(Halibut.Transport.PollingClient pollingClient) { }
+        public void Dispose() { }
+    }
+    public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
+    {
+        public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
+        public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+    }
+}
+namespace Halibut.Transport
+{
+    public class ConnectionPool<TKey, TPooledResource>
+    {
+        public ConnectionPool() { }
+        public void Clear(TKey key, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public int GetTotalConnectionCount() { }
+        public void Return(TKey endPoint, TPooledResource resource) { }
+        public TPooledResource Take(TKey endPoint) { }
+    }
+    public class DiscoveryClient
+    {
+        public DiscoveryClient() { }
+        public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint serviceEndpoint) { }
+    }
+    public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
+    {
+        public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+    }
+    public interface IPooledResource : IDisposable
+    {
+        public bool HasExpired() { }
+        public void NotifyUsed() { }
+    }
+    public interface ISecureClient
+    {
+        public Halibut.ServiceEndPoint ServiceEndpoint { get; }
+        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
+    }
+    public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
+    {
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public void Start() { }
+    }
+    public class SecureClient : Halibut.Transport.ISecureClient
+    {
+        public static int RetryCountLimit;
+        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public Halibut.ServiceEndPoint ServiceEndpoint { get; }
+        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
+    }
+    public class SecureConnection : Halibut.Transport.IConnection, Halibut.Transport.IPooledResource, IDisposable
+    {
+        public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+        public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+        public void Dispose() { }
+        public bool HasExpired() { }
+        public void NotifyUsed() { }
+    }
+    public class SecureListener : IDisposable
+    {
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public void Dispose() { }
+        public int Start() { }
+    }
+    public class SecureWebSocketListener : IDisposable
+    {
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public void Dispose() { }
+        public void Start() { }
+    }
+    public static class TcpClientExtensions
+    {
+        public static void ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout) { }
+        public static void ConnectWithTimeout(TcpClient client, string host, int port, TimeSpan timeout) { }
+    }
+}
+namespace Halibut.Transport.Protocol
+{
+    public class ConnectionInitializationFailedException : Exception, ISerializable
+    {
+        public ConnectionInitializationFailedException(string message) { }
+        public ConnectionInitializationFailedException(string message, Exception innerException) { }
+        public ConnectionInitializationFailedException(Exception innerException) { }
+    }
+    public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
+    {
+        public HalibutContractResolver() { }
+        public Newtonsoft.Json.Serialization.JsonContract ResolveContract(Type type) { }
+    }
+    public interface IMessageExchangeStream
+    {
+        public bool ExpectNextOrEnd() { }
+        public Task<bool> ExpectNextOrEndAsync() { }
+        public void ExpectProceeed() { }
+        public void IdentifyAsClient() { }
+        public void IdentifyAsServer() { }
+        public void IdentifyAsSubscriber(string subscriptionId) { }
+        public Halibut.Transport.Protocol.RemoteIdentity ReadRemoteIdentity() { }
+        public T Receive<T>() { }
+        public void Send<T>(T message) { }
+        public void SendEnd() { }
+        public void SendNext() { }
+        public void SendProceed() { }
+        public Task SendProceedAsync() { }
+    }
+    public class InMemoryDataStreamReceiver : Halibut.IDataStreamReceiver
+    {
+        public InMemoryDataStreamReceiver(Action<Stream> writer) { }
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public class MessageExchangeProtocol
+    {
+        public MessageExchangeProtocol(Stream stream, Halibut.Diagnostics.ILog log) { }
+        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream) { }
+        public void EndCommunicationWithServer() { }
+        public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
+        public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
+        public Task ExchangeAsServerAsync(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
+        public void ExchangeAsSubscriber(Uri subscriptionId, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, int maxAttempts) { }
+        public void StopAcceptingClientRequests() { }
+    }
+    public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
+    {
+        public static Func<Newtonsoft.Json.JsonSerializer> Serializer;
+        public MessageExchangeStream(Stream stream, Halibut.Diagnostics.ILog log) { }
+        public bool ExpectNextOrEnd() { }
+        public Task<bool> ExpectNextOrEndAsync() { }
+        public void ExpectProceeed() { }
+        public void IdentifyAsClient() { }
+        public void IdentifyAsServer() { }
+        public void IdentifyAsSubscriber(string subscriptionId) { }
+        public Halibut.Transport.Protocol.RemoteIdentity ReadRemoteIdentity() { }
+        public T Receive<T>() { }
+        public void Send<T>(T message) { }
+        public void SendEnd() { }
+        public void SendNext() { }
+        public void SendProceed() { }
+        public Task SendProceedAsync() { }
+    }
+    public class ProtocolException : Exception, ISerializable
+    {
+        public ProtocolException(string message) { }
+    }
+    public class RemoteIdentity
+    {
+        public RemoteIdentity(Halibut.Transport.Protocol.RemoteIdentityType identityType, Uri subscriptionId) { }
+        public RemoteIdentity(Halibut.Transport.Protocol.RemoteIdentityType identityType) { }
+        public Halibut.Transport.Protocol.RemoteIdentityType IdentityType { get; }
+        public Uri SubscriptionId { get; }
+    }
+    public enum RemoteIdentityType
+    {
+        Client = 0,
+        Subscriber = 1,
+        Server = 2
+    }
+    public class RequestMessage
+    {
+        public RequestMessage() { }
+        public Guid ActivityId { get; set; }
+        public Halibut.ServiceEndPoint Destination { get; set; }
+        public string Id { get; set; }
+        public string MethodName { get; set; }
+        public Object[] Params { get; set; }
+        public string ServiceName { get; set; }
+        public string ToString() { }
+    }
+    public class ResponseMessage
+    {
+        public ResponseMessage() { }
+        public Halibut.Transport.Protocol.ServerError Error { get; set; }
+        public string Id { get; set; }
+        public Object Result { get; set; }
+        public static Halibut.Transport.Protocol.ResponseMessage FromError(Halibut.Transport.Protocol.RequestMessage request, string message) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromException(Halibut.Transport.Protocol.RequestMessage request, Exception ex) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromResult(Halibut.Transport.Protocol.RequestMessage request, Object result) { }
+    }
+    public class ServerError
+    {
+        public ServerError() { }
+        public string Details { get; set; }
+        public string Message { get; set; }
+    }
+    public class StreamCapture : IDisposable
+    {
+        public StreamCapture() { }
+        public static Halibut.Transport.Protocol.StreamCapture Current { get; }
+        public ICollection<Halibut.DataStream> DeserializedStreams { get; }
+        public ICollection<Halibut.DataStream> SerializedStreams { get; }
+        public void Dispose() { }
+        public static Halibut.Transport.Protocol.StreamCapture New() { }
+    }
+    public class TemporaryFileDataStreamReceiver : Halibut.IDataStreamReceiver
+    {
+        public TemporaryFileDataStreamReceiver(Action<Stream> writer) { }
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public class TemporaryFileStream : Halibut.IDataStreamReceiver
+    {
+        public TemporaryFileStream(string path, Halibut.Diagnostics.ILog log) { }
+        protected void Finalize() { }
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public class WebSocketStream : Stream, IDisposable
+    {
+        public WebSocketStream(WebSocket context) { }
+        public bool CanRead { get; }
+        public bool CanSeek { get; }
+        public bool CanWrite { get; }
+        public long Length { get; }
+        public long Position { get; set; }
+        protected void Dispose(bool disposing) { }
+        public void Flush() { }
+        public int Read(Byte[] buffer, int offset, int count) { }
+        public Task<string> ReadTextMessage() { }
+        public long Seek(long offset, SeekOrigin origin) { }
+        public void SetLength(long value) { }
+        public void Write(Byte[] buffer, int offset, int count) { }
+        public Task WriteTextMessage(string message) { }
+    }
+}
+namespace Halibut.Transport.Proxy
+{
+    public class HttpProxyClient : Halibut.Transport.Proxy.IProxyClient
+    {
+        public HttpProxyClient(Halibut.Diagnostics.ILog logger, string proxyHost, int proxyPort, string proxyUserName, string proxyPassword) { }
+        public string ProxyHost { get; set; }
+        public string ProxyName { get; }
+        public string ProxyPassword { get; set; }
+        public int ProxyPort { get; set; }
+        public string ProxyUserName { get; set; }
+        public TcpClient TcpClient { get; set; }
+        public TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout) { }
+        public Halibut.Transport.Proxy.IProxyClient WithTcpClientFactory(Func<TcpClient> tcpClientfactory) { }
+    }
+    public interface IProxyClient
+    {
+        public string ProxyHost { get; set; }
+        public string ProxyName { get; }
+        public int ProxyPort { get; set; }
+        public TcpClient TcpClient { get; }
+        public TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout) { }
+        public Halibut.Transport.Proxy.IProxyClient WithTcpClientFactory(Func<TcpClient> tcpClientfactory) { }
+    }
+    public class ProxyClientFactory
+    {
+        public ProxyClientFactory() { }
+        public Halibut.Transport.Proxy.IProxyClient CreateProxyClient(Halibut.Diagnostics.ILog logger, Halibut.Transport.Proxy.ProxyType type, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword) { }
+        public Halibut.Transport.Proxy.IProxyClient CreateProxyClient(Halibut.Diagnostics.ILog logger, Halibut.ProxyDetails proxyDetails) { }
+    }
+    public enum ProxyType
+    {
+        None = 0,
+        HTTP = 1,
+        SOCKS4 = 2,
+        SOCKS4A = 3,
+        SOCKS5 = 4
+    }
+}
+namespace Halibut.Transport.Proxy.Exceptions
+{
+    public class ProxyException : Exception, ISerializable
+    {
+        public ProxyException() { }
+        public ProxyException(string message) { }
+        public ProxyException(string message, Exception innerException) { }
+        protected ProxyException(SerializationInfo info, StreamingContext context) { }
+    }
+}

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -294,6 +294,15 @@ namespace Halibut.ServiceModel
 }
 namespace Halibut.Transport
 {
+    public class ConnectionManager : IDisposable
+    {
+        public ConnectionManager() { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public void ReleaseConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Transport.IConnection connection) { }
+    }
     public class ConnectionPool<TKey, TPooledResource>
     {
         public ConnectionPool() { }
@@ -311,6 +320,10 @@ namespace Halibut.Transport
     public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
     {
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+    }
+    public interface IConnectionFactory
+    {
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -332,7 +345,7 @@ namespace Halibut.Transport
     public class SecureClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
         public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
     }
@@ -356,7 +369,7 @@ namespace Halibut.Transport
     public class SecureWebSocketClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureWebSocketClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public SecureWebSocketClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
         public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
     }
@@ -373,6 +386,16 @@ namespace Halibut.Transport
     {
         public static void ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout) { }
         public static void ConnectWithTimeout(TcpClient client, string host, int port, TimeSpan timeout) { }
+    }
+    public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
+    {
+        public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+    }
+    public class WebSocketConnectionFactory : Halibut.Transport.IConnectionFactory
+    {
+        public WebSocketConnectionFactory(X509Certificate2 clientCertificate) { }
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -44,6 +44,7 @@ namespace Halibut
         public static bool OSSupportsWebSockets { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Uri uri) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public void Dispose() { }
@@ -70,6 +71,7 @@ namespace Halibut
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Uri uri) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public bool IsTrusted(string remoteThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -301,6 +301,7 @@ namespace Halibut.Transport
         public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
+        public IReadOnlyCollection<Halibut.Transport.IConnection> GetActiveConnections(Halibut.ServiceEndPoint serviceEndPoint) { }
         public void ReleaseConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Transport.IConnection connection) { }
     }
     public class ConnectionPool<TKey, TPooledResource>
@@ -319,11 +320,12 @@ namespace Halibut.Transport
     }
     public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
     {
+        event EventHandler OnDisposed
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
     }
     public interface IConnectionFactory
     {
-        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -351,6 +353,7 @@ namespace Halibut.Transport
     }
     public class SecureConnection : Halibut.Transport.IConnection, Halibut.Transport.IPooledResource, IDisposable
     {
+        event EventHandler OnDisposed
         public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
         public void Dispose() { }
@@ -390,12 +393,12 @@ namespace Halibut.Transport
     public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
     {
         public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
-        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public class WebSocketConnectionFactory : Halibut.Transport.IConnectionFactory
     {
         public WebSocketConnectionFactory(X509Certificate2 clientCertificate) { }
-        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs.orig
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs.orig
@@ -1,0 +1,573 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Halibut
+{
+    public class DataStream : IEquatable<Halibut.DataStream>
+    {
+        public DataStream() { }
+        public DataStream(long length, Action<Stream> writer) { }
+        public Guid Id { get; set; }
+        public long Length { get; set; }
+        public bool Equals(Halibut.DataStream other) { }
+        public bool Equals(Object obj) { }
+        public static Halibut.DataStream FromBytes(Byte[] data) { }
+        public static Halibut.DataStream FromStream(Stream source, Action<int> updateProgress) { }
+        public static Halibut.DataStream FromStream(Stream source) { }
+        public static Halibut.DataStream FromString(string text) { }
+        public static Halibut.DataStream FromString(string text, Encoding encoding) { }
+        public int GetHashCode() { }
+        public Halibut.IDataStreamReceiver Receiver() { }
+    }
+    public class HalibutClientException : Exception, ISerializable, _Exception
+    {
+        public HalibutClientException(string message) { }
+        public HalibutClientException(string message, Exception inner) { }
+        public HalibutClientException(string message, string serverException) { }
+    }
+    public class HalibutRuntime : Halibut.IHalibutRuntime, IDisposable
+    {
+        public static string DefaultFriendlyHtmlPageContent;
+        public HalibutRuntime(X509Certificate2 serverCertificate) { }
+        public HalibutRuntime(Halibut.ServiceModel.IServiceFactory serviceFactory, X509Certificate2 serverCertificate) { }
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
+        public static bool OSSupportsWebSockets { get; }
+        public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
+        public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
+        public Halibut.ServiceEndPoint Discover(Uri uri) { }
+        public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
+        public void Dispose() { }
+        public bool IsTrusted(string remoteThumbprint) { }
+        public int Listen() { }
+        public int Listen(int port) { }
+        public int Listen(IPEndPoint endpoint) { }
+        public void ListenWebSocket(string endpoint) { }
+        public void Poll(Uri subscription, Halibut.ServiceEndPoint endPoint) { }
+        public void RemoveTrust(string clientThumbprint) { }
+        public void Route(Halibut.ServiceEndPoint to, Halibut.ServiceEndPoint via) { }
+        public void SetFriendlyHtmlPageContent(string html) { }
+        public void SetFriendlyHtmlPageHeaders(IEnumerable<KeyValuePair<string, string>> headers) { }
+        public void Trust(string clientThumbprint) { }
+        public void TrustOnly(IReadOnlyList<string> thumbprints) { }
+    }
+    public interface IDataStreamReceiver
+    {
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public interface IHalibutRuntime : IDisposable
+    {
+        public Halibut.Diagnostics.ILogFactory Logs { get; }
+        public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
+        public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
+        public void Disconnect(Halibut.ServiceEndPoint endpoint) { }
+        public Halibut.ServiceEndPoint Discover(Uri uri) { }
+        public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
+        public bool IsTrusted(string remoteThumbprint) { }
+        public int Listen() { }
+        public int Listen(int port) { }
+        public int Listen(IPEndPoint endpoint) { }
+        public void ListenWebSocket(string endpoint) { }
+        public void Poll(Uri subscription, Halibut.ServiceEndPoint endPoint) { }
+        public void RemoveTrust(string clientThumbprint) { }
+        public void Route(Halibut.ServiceEndPoint to, Halibut.ServiceEndPoint via) { }
+        public void SetFriendlyHtmlPageContent(string html) { }
+        public void Trust(string clientThumbprint) { }
+        public void TrustOnly(IReadOnlyList<string> thumbprints) { }
+    }
+    public class ProxyDetails : IEquatable<Halibut.ProxyDetails>
+    {
+        public ProxyDetails(string host, int port, Halibut.Transport.Proxy.ProxyType type) { }
+        public ProxyDetails(string host, int port, Halibut.Transport.Proxy.ProxyType type, string userName, string password) { }
+        public string Host { get; }
+        public string Password { get; }
+        public int Port { get; }
+        public Halibut.Transport.Proxy.ProxyType Type { get; }
+        public string UserName { get; }
+        public bool Equals(Halibut.ProxyDetails other) { }
+        public bool Equals(Object obj) { }
+        public int GetHashCode() { }
+    }
+    public class ServiceEndPoint : IEquatable<Halibut.ServiceEndPoint>
+    {
+        public ServiceEndPoint(string baseUri, string remoteThumbprint) { }
+        public ServiceEndPoint(Uri baseUri, string remoteThumbprint) { }
+        public ServiceEndPoint(Uri baseUri, string remoteThumbprint, Halibut.ProxyDetails proxy) { }
+        public Uri BaseUri { get; }
+        public TimeSpan ConnectionErrorRetryTimeout { get; set; }
+        public bool IsWebSocketEndpoint { get; }
+        public TimeSpan PollingRequestMaximumMessageProcessingTimeout { get; set; }
+        public TimeSpan PollingRequestQueueTimeout { get; set; }
+        public Halibut.ProxyDetails Proxy { get; }
+        public string RemoteThumbprint { get; }
+        public int RetryCountLimit { get; set; }
+        public TimeSpan RetryListeningSleepInterval { get; set; }
+        public TimeSpan TcpClientConnectTimeout { get; set; }
+        public bool Equals(Halibut.ServiceEndPoint other) { }
+        public bool Equals(Object obj) { }
+        public int GetHashCode() { }
+        public static bool IsWebSocketAddress(Uri baseUri) { }
+        public string ToString() { }
+    }
+}
+namespace Halibut.Diagnostics
+{
+    public enum EventType
+    {
+        OpeningNewConnection = 0,
+        UsingExistingConnectionFromPool = 1,
+        Security = 2,
+        MessageExchange = 3,
+        Diagnostic = 4,
+        ClientDenied = 5,
+        Error = 6,
+        ListenerStarted = 7,
+        ListenerAcceptedClient = 8,
+        ListenerStopped = 9,
+        SecurityNegotiation = 10,
+        FileTransfer = 11
+    }
+    public static class ExceptionExtensions
+    {
+        public static bool IsSocketConnectionReset(Exception exception) { }
+        public static bool IsSocketConnectionTimeout(Exception exception) { }
+        public static bool IsSocketTimeout(Exception exception) { }
+        public static Exception UnpackFromContainers(Exception error) { }
+    }
+    public class HalibutLimits
+    {
+        public static TimeSpan ConnectionErrorRetryTimeout;
+        public static TimeSpan PollingQueueWaitTimeout;
+        public static TimeSpan PollingRequestMaximumMessageProcessingTimeout;
+        public static TimeSpan PollingRequestQueueTimeout;
+        public static int RetryCountLimit;
+        public static TimeSpan RetryListeningSleepInterval;
+        public static TimeSpan TcpClientConnectTimeout;
+        public static TimeSpan TcpClientHeartbeatReceiveTimeout;
+        public static TimeSpan TcpClientHeartbeatSendTimeout;
+        public static TimeSpan TcpClientPooledConnectionTimeout;
+        public static TimeSpan TcpClientReceiveTimeout;
+        public static TimeSpan TcpClientSendTimeout;
+        public HalibutLimits() { }
+        public static TimeSpan SafeTcpClientPooledConnectionTimeout { get; }
+    }
+    public interface ILog
+    {
+        public IList<Halibut.Diagnostics.LogEvent> GetLogs() { }
+        public void Write(Halibut.Diagnostics.EventType type, string message, Object[] args) { }
+        public void WriteException(Halibut.Diagnostics.EventType type, string message, Exception ex, Object[] args) { }
+    }
+    public interface ILogFactory
+    {
+        public Halibut.Diagnostics.ILog ForEndpoint(Uri endpoint) { }
+        public Halibut.Diagnostics.ILog ForPrefix(string endPoint) { }
+        public Uri[] GetEndpoints() { }
+        public String[] GetPrefixes() { }
+    }
+    public class LogEvent
+    {
+        public LogEvent(Halibut.Diagnostics.EventType type, string message, Exception error, Object[] formatArguments) { }
+        public Exception Error { get; }
+        public string FormattedMessage { get; }
+        public string Message { get; }
+        public DateTimeOffset Time { get; }
+        public Halibut.Diagnostics.EventType Type { get; }
+        public string ToString() { }
+    }
+    public class LogFactory : Halibut.Diagnostics.ILogFactory
+    {
+        public LogFactory() { }
+        public Halibut.Diagnostics.ILog ForEndpoint(Uri endpoint) { }
+        public Halibut.Diagnostics.ILog ForPrefix(string prefix) { }
+        public Uri[] GetEndpoints() { }
+        public String[] GetPrefixes() { }
+    }
+}
+namespace Halibut.Logging
+{
+    public interface ILogProvider
+    {
+        public Halibut.Logging.Logger GetLogger(string name) { }
+        public IDisposable OpenMappedContext(string key, string value) { }
+        public IDisposable OpenNestedContext(string message) { }
+    }
+    public sealed class Logger : MulticastDelegate, ICloneable, ISerializable
+    {
+        public Logger(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Halibut.Logging.LogLevel logLevel, Func<string> messageFunc, Exception exception, Object[] formatParameters, AsyncCallback callback, Object @object) { }
+        public bool EndInvoke(IAsyncResult result) { }
+        public bool Invoke(Halibut.Logging.LogLevel logLevel, Func<string> messageFunc, Exception exception, Object[] formatParameters) { }
+    }
+    public enum LogLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Info = 2,
+        Warn = 3,
+        Error = 4,
+        Fatal = 5
+    }
+    public static class LogProvider
+    {
+        public static string DisableLoggingEnvironmentVariable;
+        internal static Halibut.Logging.ILogProvider CurrentLogProvider {  }
+        public static bool IsDisabled { get; set; }
+        static Action<Halibut.Logging.ILogProvider> OnCurrentLogProviderSet {  }
+        public static void SetCurrentLogProvider(Halibut.Logging.ILogProvider logProvider) { }
+    }
+}
+namespace Halibut.Portability
+{
+    public static class TypeExtensions
+    {
+        public static Assembly Assembly(Type type) { }
+        public static bool IsValueType(Type type) { }
+    }
+}
+namespace Halibut.ServiceModel
+{
+    public class DelegateServiceFactory : Halibut.ServiceModel.IServiceFactory
+    {
+        public DelegateServiceFactory() { }
+        public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
+        public void Register<TContract>(Func<TContract> implementation) { }
+    }
+    public interface IPendingRequestQueue
+    {
+        public bool IsEmpty { get; }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
+        public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
+    }
+    public interface IPollingClient : IDisposable
+    {
+        public void Start() { }
+    }
+    public interface IServiceFactory
+    {
+        public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
+    }
+    public interface IServiceInvoker
+    {
+        public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+    }
+    public interface IServiceLease : IDisposable
+    {
+        public Object Service { get; }
+    }
+    public class NullServiceFactory : Halibut.ServiceModel.IServiceFactory
+    {
+        public NullServiceFactory() { }
+        public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
+    }
+    public class PendingRequestQueue : Halibut.ServiceModel.IPendingRequestQueue
+    {
+        public PendingRequestQueue(Halibut.Diagnostics.ILog log) { }
+        public bool IsEmpty { get; }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
+        public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
+        public Halibut.Transport.Protocol.ResponseMessage QueueAndWait(Halibut.Transport.Protocol.RequestMessage request) { }
+    }
+    public class PollingClientCollection
+    {
+        public PollingClientCollection() { }
+        public void Add(Halibut.Transport.PollingClient pollingClient) { }
+        public void Dispose() { }
+    }
+    public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
+    {
+        public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
+        public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+    }
+}
+namespace Halibut.Transport
+{
+    public class ConnectionPool<TKey, TPooledResource>
+    {
+        public ConnectionPool() { }
+        public void Clear(TKey key, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public int GetTotalConnectionCount() { }
+        public void Return(TKey endPoint, TPooledResource resource) { }
+        public TPooledResource Take(TKey endPoint) { }
+    }
+    public class DiscoveryClient
+    {
+        public DiscoveryClient() { }
+        public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint serviceEndpoint) { }
+    }
+    public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
+    {
+        public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+    }
+    public interface IPooledResource : IDisposable
+    {
+        public bool HasExpired() { }
+        public void NotifyUsed() { }
+    }
+    public interface ISecureClient
+    {
+        public Halibut.ServiceEndPoint ServiceEndpoint { get; }
+        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
+    }
+    public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
+    {
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public void Start() { }
+    }
+    public class SecureClient : Halibut.Transport.ISecureClient
+    {
+        public static int RetryCountLimit;
+        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public Halibut.ServiceEndPoint ServiceEndpoint { get; }
+        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
+    }
+    public class SecureConnection : Halibut.Transport.IConnection, Halibut.Transport.IPooledResource, IDisposable
+    {
+        public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+        public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+        public void Dispose() { }
+        public bool HasExpired() { }
+        public void NotifyUsed() { }
+    }
+    public class SecureListener : IDisposable
+    {
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public void Dispose() { }
+        public int Start() { }
+    }
+    public class SecureWebSocketClient : Halibut.Transport.ISecureClient
+    {
+        public static int RetryCountLimit;
+        public SecureWebSocketClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public Halibut.ServiceEndPoint ServiceEndpoint { get; }
+        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
+    }
+    public class SecureWebSocketListener : IDisposable
+    {
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public void Dispose() { }
+        public void Start() { }
+    }
+    public static class TcpClientExtensions
+    {
+        public static void ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout) { }
+        public static void ConnectWithTimeout(TcpClient client, string host, int port, TimeSpan timeout) { }
+    }
+}
+namespace Halibut.Transport.Protocol
+{
+    public class ConnectionInitializationFailedException : Exception, ISerializable, _Exception
+    {
+        public ConnectionInitializationFailedException(string message) { }
+        public ConnectionInitializationFailedException(string message, Exception innerException) { }
+        public ConnectionInitializationFailedException(Exception innerException) { }
+    }
+    public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
+    {
+        public HalibutContractResolver() { }
+        public Newtonsoft.Json.Serialization.JsonContract ResolveContract(Type type) { }
+    }
+    public interface IMessageExchangeStream
+    {
+        public bool ExpectNextOrEnd() { }
+        public Task<bool> ExpectNextOrEndAsync() { }
+        public void ExpectProceeed() { }
+        public void IdentifyAsClient() { }
+        public void IdentifyAsServer() { }
+        public void IdentifyAsSubscriber(string subscriptionId) { }
+        public Halibut.Transport.Protocol.RemoteIdentity ReadRemoteIdentity() { }
+        public T Receive<T>() { }
+        public void Send<T>(T message) { }
+        public void SendEnd() { }
+        public void SendNext() { }
+        public void SendProceed() { }
+        public Task SendProceedAsync() { }
+    }
+    public class InMemoryDataStreamReceiver : Halibut.IDataStreamReceiver
+    {
+        public InMemoryDataStreamReceiver(Action<Stream> writer) { }
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public class MessageExchangeProtocol
+    {
+        public MessageExchangeProtocol(Stream stream, Halibut.Diagnostics.ILog log) { }
+        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream) { }
+        public void EndCommunicationWithServer() { }
+        public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
+        public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
+        public Task ExchangeAsServerAsync(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
+        public void ExchangeAsSubscriber(Uri subscriptionId, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, int maxAttempts) { }
+        public void StopAcceptingClientRequests() { }
+    }
+    public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
+    {
+        public static Func<Newtonsoft.Json.JsonSerializer> Serializer;
+        public MessageExchangeStream(Stream stream, Halibut.Diagnostics.ILog log) { }
+        public bool ExpectNextOrEnd() { }
+        public Task<bool> ExpectNextOrEndAsync() { }
+        public void ExpectProceeed() { }
+        public void IdentifyAsClient() { }
+        public void IdentifyAsServer() { }
+        public void IdentifyAsSubscriber(string subscriptionId) { }
+        public Halibut.Transport.Protocol.RemoteIdentity ReadRemoteIdentity() { }
+        public T Receive<T>() { }
+        public void Send<T>(T message) { }
+        public void SendEnd() { }
+        public void SendNext() { }
+        public void SendProceed() { }
+        public Task SendProceedAsync() { }
+    }
+    public class ProtocolException : Exception, ISerializable, _Exception
+    {
+        public ProtocolException(string message) { }
+    }
+    public class RemoteIdentity
+    {
+        public RemoteIdentity(Halibut.Transport.Protocol.RemoteIdentityType identityType, Uri subscriptionId) { }
+        public RemoteIdentity(Halibut.Transport.Protocol.RemoteIdentityType identityType) { }
+        public Halibut.Transport.Protocol.RemoteIdentityType IdentityType { get; }
+        public Uri SubscriptionId { get; }
+    }
+    public enum RemoteIdentityType
+    {
+        Client = 0,
+        Subscriber = 1,
+        Server = 2
+    }
+    public class RequestMessage
+    {
+        public RequestMessage() { }
+        public Guid ActivityId { get; set; }
+        public Halibut.ServiceEndPoint Destination { get; set; }
+        public string Id { get; set; }
+        public string MethodName { get; set; }
+        public Object[] Params { get; set; }
+        public string ServiceName { get; set; }
+        public string ToString() { }
+    }
+    public class ResponseMessage
+    {
+        public ResponseMessage() { }
+        public Halibut.Transport.Protocol.ServerError Error { get; set; }
+        public string Id { get; set; }
+        public Object Result { get; set; }
+        public static Halibut.Transport.Protocol.ResponseMessage FromError(Halibut.Transport.Protocol.RequestMessage request, string message) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromException(Halibut.Transport.Protocol.RequestMessage request, Exception ex) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromResult(Halibut.Transport.Protocol.RequestMessage request, Object result) { }
+    }
+    public class ServerError
+    {
+        public ServerError() { }
+        public string Details { get; set; }
+        public string Message { get; set; }
+    }
+    public class StreamCapture : IDisposable
+    {
+        public StreamCapture() { }
+        public static Halibut.Transport.Protocol.StreamCapture Current { get; }
+        public ICollection<Halibut.DataStream> DeserializedStreams { get; }
+        public ICollection<Halibut.DataStream> SerializedStreams { get; }
+        public void Dispose() { }
+        public static Halibut.Transport.Protocol.StreamCapture New() { }
+    }
+    public class TemporaryFileDataStreamReceiver : Halibut.IDataStreamReceiver
+    {
+        public TemporaryFileDataStreamReceiver(Action<Stream> writer) { }
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public class TemporaryFileStream : Halibut.IDataStreamReceiver
+    {
+        public TemporaryFileStream(string path, Halibut.Diagnostics.ILog log) { }
+        protected void Finalize() { }
+        public void Read(Action<Stream> reader) { }
+        public void SaveTo(string filePath) { }
+    }
+    public class WebSocketStream : Stream, IDisposable
+    {
+        public WebSocketStream(WebSocket context) { }
+        public bool CanRead { get; }
+        public bool CanSeek { get; }
+        public bool CanWrite { get; }
+        public long Length { get; }
+        public long Position { get; set; }
+        protected void Dispose(bool disposing) { }
+        public void Flush() { }
+        public int Read(Byte[] buffer, int offset, int count) { }
+        public Task<string> ReadTextMessage() { }
+        public long Seek(long offset, SeekOrigin origin) { }
+        public void SetLength(long value) { }
+        public void Write(Byte[] buffer, int offset, int count) { }
+        public Task WriteTextMessage(string message) { }
+    }
+}
+namespace Halibut.Transport.Proxy
+{
+    public class HttpProxyClient : Halibut.Transport.Proxy.IProxyClient
+    {
+        public HttpProxyClient(Halibut.Diagnostics.ILog logger, string proxyHost, int proxyPort, string proxyUserName, string proxyPassword) { }
+        public string ProxyHost { get; set; }
+        public string ProxyName { get; }
+        public string ProxyPassword { get; set; }
+        public int ProxyPort { get; set; }
+        public string ProxyUserName { get; set; }
+        public TcpClient TcpClient { get; set; }
+        public TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout) { }
+        public Halibut.Transport.Proxy.IProxyClient WithTcpClientFactory(Func<TcpClient> tcpClientfactory) { }
+    }
+    public interface IProxyClient
+    {
+        public string ProxyHost { get; set; }
+        public string ProxyName { get; }
+        public int ProxyPort { get; set; }
+        public TcpClient TcpClient { get; }
+        public TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout) { }
+        public Halibut.Transport.Proxy.IProxyClient WithTcpClientFactory(Func<TcpClient> tcpClientfactory) { }
+    }
+    public class ProxyClientFactory
+    {
+        public ProxyClientFactory() { }
+        public Halibut.Transport.Proxy.IProxyClient CreateProxyClient(Halibut.Diagnostics.ILog logger, Halibut.Transport.Proxy.ProxyType type, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword) { }
+        public Halibut.Transport.Proxy.IProxyClient CreateProxyClient(Halibut.Diagnostics.ILog logger, Halibut.ProxyDetails proxyDetails) { }
+    }
+    public enum ProxyType
+    {
+        None = 0,
+        HTTP = 1,
+        SOCKS4 = 2,
+        SOCKS4A = 3,
+        SOCKS5 = 4
+    }
+}
+namespace Halibut.Transport.Proxy.Exceptions
+{
+    public class ProxyException : Exception, ISerializable, _Exception
+    {
+        public ProxyException() { }
+        public ProxyException(string message) { }
+        public ProxyException(string message, Exception innerException) { }
+        protected ProxyException(SerializationInfo info, StreamingContext context) { }
+    }
+}

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs.orig
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs.orig
@@ -294,6 +294,15 @@ namespace Halibut.ServiceModel
 }
 namespace Halibut.Transport
 {
+    public class ConnectionManager : IDisposable
+    {
+        public ConnectionManager() { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
+        public void Dispose() { }
+        public void ReleaseConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Transport.IConnection connection) { }
+    }
     public class ConnectionPool<TKey, TPooledResource>
     {
         public ConnectionPool() { }
@@ -311,6 +320,10 @@ namespace Halibut.Transport
     public interface IConnection : Halibut.Transport.IPooledResource, IDisposable
     {
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
+    }
+    public interface IConnectionFactory
+    {
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -332,7 +345,7 @@ namespace Halibut.Transport
     public class SecureClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
         public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
     }
@@ -356,7 +369,7 @@ namespace Halibut.Transport
     public class SecureWebSocketClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureWebSocketClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionPool<Halibut.ServiceEndPoint, Halibut.Transport.IConnection> pool) { }
+        public SecureWebSocketClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
         public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
     }
@@ -373,6 +386,16 @@ namespace Halibut.Transport
     {
         public static void ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout) { }
         public static void ConnectWithTimeout(TcpClient client, string host, int port, TimeSpan timeout) { }
+    }
+    public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
+    {
+        public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+    }
+    public class WebSocketConnectionFactory : Halibut.Transport.IConnectionFactory
+    {
+        public WebSocketConnectionFactory(X509Certificate2 clientCertificate) { }
+        public Halibut.Transport.SecureConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -174,7 +174,6 @@ namespace Halibut
                 trustedThumbprints.Remove(clientThumbprint);
         }
 
-
         public void TrustOnly(IReadOnlyList<string> thumbprints)
         {
             lock (trustedThumbprints)
@@ -204,6 +203,12 @@ namespace Halibut
         public void SetFriendlyHtmlPageHeaders(IEnumerable<KeyValuePair<string, string>> headers)
         {
             friendlyHtmlPageHeaders = headers?.ToDictionary(x => x.Key, x => x.Value) ?? new Dictionary<string, string>();
+        }
+
+        public void Disconnect(ServiceEndPoint endpoint)
+        {
+            var log = logs.ForEndpoint(endpoint.BaseUri);
+            pool.Clear(endpoint, log);
         }
 
         public void Dispose()

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -23,7 +23,7 @@ namespace Halibut
         readonly ConcurrentDictionary<Uri, ServiceEndPoint> routeTable = new ConcurrentDictionary<Uri, ServiceEndPoint>();
         readonly ServiceInvoker invoker;
         readonly LogFactory logs = new LogFactory();
-        readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new ConnectionPool<ServiceEndPoint, IConnection>();
+        readonly ConnectionManager connectionManager = new ConnectionManager();
         readonly PollingClientCollection pollingClients = new PollingClientCollection();
         string friendlyHtmlPageContent = DefaultFriendlyHtmlPageContent;
         Dictionary<string, string> friendlyHtmlPageHeaders = new Dictionary<string, string>();
@@ -38,10 +38,7 @@ namespace Halibut
             invoker = new ServiceInvoker(serviceFactory);
         }
 
-        public ILogFactory Logs
-        {
-            get { return logs; }
-        }
+        public ILogFactory Logs => logs;
 
         PendingRequestQueue GetQueue(Uri target)
         {
@@ -86,14 +83,14 @@ namespace Halibut
             if (endPoint.IsWebSocketEndpoint)
             {
 #if SUPPORTS_WEB_SOCKET_CLIENT
-                client = new SecureWebSocketClient(endPoint, serverCertificate, log, pool);
+                client = new SecureWebSocketClient(endPoint, serverCertificate, log, connectionManager);
 #else
                 throw new NotSupportedException("The netstandard build of this library cannot act as the client in a WebSocket polling setup");
 #endif
             }
             else
             {
-                client = new SecureClient(endPoint, serverCertificate, log, pool);
+                client = new SecureClient(endPoint, serverCertificate, log, connectionManager);
             }
             pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log));
         }
@@ -141,7 +138,7 @@ namespace Halibut
 
         ResponseMessage SendOutgoingHttpsRequest(RequestMessage request)
         {
-            var client = new SecureClient(request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), pool);
+            var client = new SecureClient(request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
 
             ResponseMessage response = null;
             client.ExecuteTransaction(protocol =>
@@ -208,13 +205,13 @@ namespace Halibut
         public void Disconnect(ServiceEndPoint endpoint)
         {
             var log = logs.ForEndpoint(endpoint.BaseUri);
-            pool.Clear(endpoint, log);
+            connectionManager.Disconnect(endpoint, log);
         }
 
         public void Dispose()
         {
             pollingClients.Dispose();
-            pool.Dispose();
+            connectionManager.Dispose();
             foreach (var listener in listeners)
             {
                 listener.Dispose();

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -24,5 +24,6 @@ namespace Halibut
 
         void Route(ServiceEndPoint to, ServiceEndPoint via);
         void SetFriendlyHtmlPageContent(string html);
+        void Disconnect(ServiceEndPoint endpoint);
     }
 }

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Halibut.Diagnostics;
 
 namespace Halibut.Transport
@@ -6,16 +8,54 @@ namespace Halibut.Transport
     public class ConnectionManager : IDisposable
     {
         readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new ConnectionPool<ServiceEndPoint, IConnection>();
+        readonly Dictionary<ServiceEndPoint, HashSet<IConnection>> activeConnections = new Dictionary<ServiceEndPoint, HashSet<IConnection>>();
 
         public IConnection AcquireConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
         {
+            lock (activeConnections)
+            {
+                var connection = GetFromPoolOrCreateConnection(connectionFactory, serviceEndpoint, log);
+                AddConnectionToActiveConnections(serviceEndpoint, connection);
+
+                return connection;
+            }
+        }
+
+        IConnection GetFromPoolOrCreateConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
+        {
             var connection = pool.Take(serviceEndpoint);
-            return connection ?? connectionFactory.EstablishNewConnection(serviceEndpoint, log);
+            if (connection == null)
+            {
+                connection = connectionFactory.EstablishNewConnection(serviceEndpoint, log);
+                connection.OnDisposed += OnConnectionDisposed;
+            }
+
+            return connection;
+        }
+
+        void AddConnectionToActiveConnections(ServiceEndPoint serviceEndpoint, IConnection connection)
+        {
+            if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
+            {
+                connections.Add(connection);
+            }
+            else
+            {
+                connections = new HashSet<IConnection> {connection};
+                activeConnections.Add(serviceEndpoint, connections);
+            }
         }
 
         public void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection)
         {
-            pool.Return(serviceEndpoint, connection);
+            lock (activeConnections)
+            {
+                pool.Return(serviceEndpoint, connection);
+                if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
+                {
+                    connections.Remove(connection);
+                }
+            }
         }
 
         public void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log)
@@ -23,14 +63,63 @@ namespace Halibut.Transport
             pool.Clear(serviceEndPoint, log);
         }
 
+        public IReadOnlyCollection<IConnection> GetActiveConnections(ServiceEndPoint serviceEndPoint)
+        {
+            lock (activeConnections)
+            {
+                if (activeConnections.TryGetValue(serviceEndPoint, out var value))
+                {
+                    return value.ToArray();
+                }
+            }
+
+            return Enumerable.Empty<IConnection>().ToArray();
+        }
+
         public void Disconnect(ServiceEndPoint serviceEndPoint, ILog log)
         {
             ClearPooledConnections(serviceEndPoint, log);
+            ClearActiveConnections(serviceEndPoint);
         }
 
         public void Dispose()
         {
             pool.Dispose();
+        }
+
+
+        void ClearActiveConnections(ServiceEndPoint serviceEndPoint)
+        {
+            lock (activeConnections)
+            {
+                if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
+                {
+                    foreach (var connection in activeConnectionsForEndpoint)
+                    {
+                        connection.Dispose();
+                    }
+                }
+            }
+        }
+
+        void OnConnectionDisposed(object sender, EventArgs e)
+        {
+            lock (activeConnections)
+            {
+                var connection = sender as IConnection;
+
+                var setsContainingConnection = activeConnections.Where(c => c.Value.Contains(connection)).ToList();
+                var setsToRemoveCompletely = setsContainingConnection.Where(c => c.Value.Count == 1).ToList();
+                foreach (var setContainingConnection in setsContainingConnection.Except(setsToRemoveCompletely))
+                {
+                    setContainingConnection.Value.Remove(connection);
+                }
+
+                foreach (var setToRemoveCompletely in setsToRemoveCompletely)
+                {
+                    activeConnections.Remove(setToRemoveCompletely.Key);
+                }
+            }
         }
     }
 }

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -14,21 +14,17 @@ namespace Halibut.Transport
         {
             lock (activeConnections)
             {
-                var connection = GetFromPoolOrCreateConnection(connectionFactory, serviceEndpoint, log);
+                var connection = pool.Take(serviceEndpoint) ?? CreateConnection(connectionFactory, serviceEndpoint, log);
                 AddConnectionToActiveConnections(serviceEndpoint, connection);
 
                 return connection;
             }
         }
 
-        IConnection GetFromPoolOrCreateConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
+        IConnection CreateConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
         {
-            var connection = pool.Take(serviceEndpoint);
-            if (connection == null)
-            {
-                connection = connectionFactory.EstablishNewConnection(serviceEndpoint, log);
-                connection.OnDisposed += OnConnectionDisposed;
-            }
+            var connection = connectionFactory.EstablishNewConnection(serviceEndpoint, log);
+            connection.OnDisposed += OnConnectionDisposed;
 
             return connection;
         }

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -1,0 +1,36 @@
+using System;
+using Halibut.Diagnostics;
+
+namespace Halibut.Transport
+{
+    public class ConnectionManager : IDisposable
+    {
+        readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new ConnectionPool<ServiceEndPoint, IConnection>();
+
+        public IConnection AcquireConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
+        {
+            var connection = pool.Take(serviceEndpoint);
+            return connection ?? connectionFactory.EstablishNewConnection(serviceEndpoint, log);
+        }
+
+        public void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection)
+        {
+            pool.Return(serviceEndpoint, connection);
+        }
+
+        public void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log)
+        {
+            pool.Clear(serviceEndPoint, log);
+        }
+
+        public void Disconnect(ServiceEndPoint serviceEndPoint, ILog log)
+        {
+            ClearPooledConnections(serviceEndPoint, log);
+        }
+
+        public void Dispose()
+        {
+            pool.Dispose();
+        }
+    }
+}

--- a/source/Halibut/Transport/ConnectionPool.cs
+++ b/source/Halibut/Transport/ConnectionPool.cs
@@ -65,6 +65,7 @@ namespace Halibut.Transport
                 }
 
                 connections.Clear();
+                pool.Remove(key);
             }
         }
 

--- a/source/Halibut/Transport/IConnection.cs
+++ b/source/Halibut/Transport/IConnection.cs
@@ -1,9 +1,11 @@
-﻿using Halibut.Transport.Protocol;
+﻿using System;
+using Halibut.Transport.Protocol;
 
 namespace Halibut.Transport
 {
     public interface IConnection : IPooledResource
     {
-        MessageExchangeProtocol Protocol { get; } 
+        MessageExchangeProtocol Protocol { get; }
+        event EventHandler OnDisposed;
     }
 }

--- a/source/Halibut/Transport/IConnectionFactory.cs
+++ b/source/Halibut/Transport/IConnectionFactory.cs
@@ -1,0 +1,9 @@
+using Halibut.Diagnostics;
+
+namespace Halibut.Transport
+{
+    public interface IConnectionFactory
+    {
+        SecureConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log);
+    }
+}

--- a/source/Halibut/Transport/IConnectionFactory.cs
+++ b/source/Halibut/Transport/IConnectionFactory.cs
@@ -4,6 +4,6 @@ namespace Halibut.Transport
 {
     public interface IConnectionFactory
     {
-        SecureConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log);
+        IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log);
     }
 }

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -22,7 +22,7 @@ namespace Halibut.Transport
             lastUsed = DateTimeOffset.UtcNow;
         }
 
-        public MessageExchangeProtocol Protocol { get { return protocol; } }
+        internal MessageExchangeProtocol Protocol { get { return protocol; } }
         public event EventHandler OnDisposed;
 
         public void NotifyUsed()

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -22,7 +22,7 @@ namespace Halibut.Transport
             lastUsed = DateTimeOffset.UtcNow;
         }
 
-        internal MessageExchangeProtocol Protocol { get { return protocol; } }
+        public MessageExchangeProtocol Protocol => protocol;
         public event EventHandler OnDisposed;
 
         public void NotifyUsed()

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -23,6 +23,7 @@ namespace Halibut.Transport
         }
 
         public MessageExchangeProtocol Protocol { get { return protocol; } }
+        public event EventHandler OnDisposed;
 
         public void NotifyUsed()
         {
@@ -36,6 +37,7 @@ namespace Halibut.Transport
 
         public void Dispose()
         {
+            OnDisposed?.Invoke(this, EventArgs.Empty);
             try
             {
                 protocol.StopAcceptingClientRequests();

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
+using Halibut.Transport.Proxy;
+
+namespace Halibut.Transport
+{
+    public class TcpConnectionFactory : IConnectionFactory
+    {
+        static readonly byte[] MxLine = Encoding.ASCII.GetBytes("MX" + Environment.NewLine + Environment.NewLine);
+
+        readonly X509Certificate2 clientCertificate;
+
+        public TcpConnectionFactory(X509Certificate2 clientCertificate)
+        {
+            this.clientCertificate = clientCertificate;
+        }
+
+        public SecureConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
+        {
+            log.Write(EventType.OpeningNewConnection, "Opening a new connection");
+
+            var certificateValidator = new ClientCertificateValidator(serviceEndpoint);
+            var client = CreateConnectedTcpClient(serviceEndpoint, log);
+            log.Write(EventType.Diagnostic, "Connection established");
+
+            var stream = client.GetStream();
+
+            log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
+            var ssl = new SslStream(stream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
+            ssl.AuthenticateAsClient(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(clientCertificate), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
+            ssl.Write(MxLine, 0, MxLine.Length);
+            ssl.Flush();
+
+            log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
+
+            var protocol = new MessageExchangeProtocol(ssl, log);
+            return new SecureConnection(client, ssl, protocol);
+        }
+
+        TcpClient CreateConnectedTcpClient(ServiceEndPoint endPoint, ILog log)
+        {
+            TcpClient client;
+            if (endPoint.Proxy == null)
+            {
+                client = CreateTcpClient();
+                client.ConnectWithTimeout(endPoint.BaseUri, endPoint.TcpClientConnectTimeout);
+            }
+            else
+            {
+                log.Write(EventType.Diagnostic, "Creating a proxy client");
+                client = new ProxyClientFactory()
+                    .CreateProxyClient(log, endPoint.Proxy)
+                    .WithTcpClientFactory(CreateTcpClient)
+                    .CreateConnection(endPoint.BaseUri.Host, endPoint.BaseUri.Port, endPoint.TcpClientConnectTimeout);
+            }
+            return client;
+        }
+
+        static TcpClient CreateTcpClient()
+        {
+            var client = new TcpClient(AddressFamily.InterNetworkV6)
+            {
+                SendTimeout = (int)HalibutLimits.TcpClientSendTimeout.TotalMilliseconds,
+                ReceiveTimeout = (int)HalibutLimits.TcpClientReceiveTimeout.TotalMilliseconds,
+                Client = { DualMode = true }
+            };
+            return client;
+        }
+
+        X509Certificate UserCertificateSelectionCallback(object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] acceptableIssuers)
+        {
+            return clientCertificate;
+        }
+    }
+}

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -21,7 +21,7 @@ namespace Halibut.Transport
             this.clientCertificate = clientCertificate;
         }
 
-        public SecureConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
+        public IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
         {
             log.Write(EventType.OpeningNewConnection, "Opening a new connection");
 
@@ -43,7 +43,7 @@ namespace Halibut.Transport
             return new SecureConnection(client, ssl, protocol);
         }
 
-        TcpClient CreateConnectedTcpClient(ServiceEndPoint endPoint, ILog log)
+        static TcpClient CreateConnectedTcpClient(ServiceEndPoint endPoint, ILog log)
         {
             TcpClient client;
             if (endPoint.Proxy == null)

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -1,0 +1,98 @@
+#if SUPPORTS_WEB_SOCKET_CLIENT
+using System;
+using System.Net;
+using System.Net.WebSockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
+using Halibut.Transport.Proxy;
+using Halibut.Transport.Proxy.Exceptions;
+
+namespace Halibut.Transport
+{
+    public class WebSocketConnectionFactory : IConnectionFactory
+    {
+        readonly X509Certificate2 clientCertificate;
+
+        public WebSocketConnectionFactory(X509Certificate2 clientCertificate)
+        {
+            this.clientCertificate = clientCertificate;
+        }
+
+        public SecureConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
+        {
+            log.Write(EventType.OpeningNewConnection, "Opening a new connection");
+
+            var client = CreateConnectedClient(serviceEndpoint);
+
+            log.Write(EventType.Diagnostic, "Connection established");
+
+            var stream = new WebSocketStream(client);
+
+            log.Write(EventType.Security, "Performing handshake");
+            stream.WriteTextMessage("MX");
+
+            log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}", serviceEndpoint.BaseUri, serviceEndpoint.RemoteThumbprint);
+
+            var protocol = new MessageExchangeProtocol(stream, log);
+            return new SecureConnection(client, stream, protocol);
+        }
+
+        
+        ClientWebSocket CreateConnectedClient(ServiceEndPoint serviceEndpoint)
+        {
+            if (!serviceEndpoint.IsWebSocketEndpoint)
+                throw new Exception("Only wss:// endpoints are supported");
+
+            var connectionId = Guid.NewGuid().ToString();
+
+            var client = new ClientWebSocket();
+            client.Options.ClientCertificates = new X509Certificate2Collection(new X509Certificate2Collection(clientCertificate));
+            client.Options.AddSubProtocol("Octopus");
+            client.Options.SetRequestHeader(ServerCertificateInterceptor.Header, connectionId);
+            if (serviceEndpoint.Proxy != null)
+                client.Options.Proxy = new WebSocketProxy(serviceEndpoint.Proxy);
+
+            try
+            {
+                ServerCertificateInterceptor.Expect(connectionId);
+                using (var cts = new CancellationTokenSource(serviceEndpoint.TcpClientConnectTimeout))
+                    client.ConnectAsync(serviceEndpoint.BaseUri, cts.Token)
+                        .ConfigureAwait(false).GetAwaiter().GetResult();
+                ServerCertificateInterceptor.Validate(connectionId, serviceEndpoint);
+            }
+            finally
+            {
+                ServerCertificateInterceptor.Remove(connectionId);
+            }
+            
+            return client;
+        }
+    }
+    
+    class WebSocketProxy : IWebProxy
+    {
+        readonly Uri uri;
+
+        public WebSocketProxy(ProxyDetails proxy)
+        {
+            if (proxy.Type != ProxyType.HTTP)
+                throw new ProxyException(string.Format("Unknown proxy type {0}.", proxy.Type.ToString()));
+
+            uri = new Uri($"http://{proxy.Host}:{proxy.Port}");
+
+            if (string.IsNullOrWhiteSpace(proxy.UserName) && string.IsNullOrEmpty(proxy.Password))
+                return;
+
+            Credentials = new NetworkCredential(proxy.UserName, proxy.Password);
+        }
+
+        public Uri GetProxy(Uri destination) => uri;
+
+        public bool IsBypassed(Uri host) => false;
+
+        public ICredentials Credentials { get; set; }
+    }
+}
+#endif

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -20,7 +20,7 @@ namespace Halibut.Transport
             this.clientCertificate = clientCertificate;
         }
 
-        public SecureConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
+        public IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
         {
             log.Write(EventType.OpeningNewConnection, "Opening a new connection");
 


### PR DESCRIPTION
This method will be used when a machine is deleted from Octopus to immediately close existing connections to that machine.

Do we need to worry about connections that are not in the pool?