### PR TITLE
More relaxed on the type of exception

### DIFF
--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -43,12 +43,12 @@ namespace Halibut.Transport
                 {
                     protocol.EndCommunicationWithServer();
                 }
-                catch (IOException ioe) when ((ioe.InnerException as SocketException) != null)
+                catch (Exception)
                 {
                     // The stream might have already disconnected, so don't worry about it.
                 }
                 stream.Dispose();
-                ((IDisposable)client).Dispose();
+                client.Dispose();
             }
             catch (SocketException)
             {


### PR DESCRIPTION
In netcore we actually get a different type of exception, and given we are cleaning up, I think it is ok to be more relaxed on the type of exception since we want to clean-up regardless.

The exception we get here in netcore is:
```
The WriteAsync method cannot be called when another write operation is pending.
 System.NotSupportedException
 at System.Net.Security.SslStreamInternal.WriteAsyncInternal[TWriteAdapter](TWriteAdapter writeAdapter, ReadOnlyMemory`1 buffer)
 at System.Net.Security.SslStreamInternal.Write(Byte[] buffer, Int32 offset, Int32 count)
 at System.Net.Security.SslStream.Write(Byte[] buffer, Int32 offset, Int32 count)
 at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
 at Halibut.Transport.Protocol.MessageExchangeStream.SendEnd()
 at Halibut.Transport.SecureConnection.Dispose()
 at Halibut.Transport.ConnectionManager.DisposableNotifierConnection.Dispose()
 at Halibut.Transport.SecureClient.ExecuteTransaction(Action`1 protocolHandler)
```

This exception happens when the Server side of Halibut closes the connection, and the Client side handles this.

I have tried to reproduce this issue in a test, but I could not, I would be happy to pair to see if we can cover it with a test.
I tested this fix manually, running Octopus on netcore + Tentacle also on netcore, both running on WindowsOS.
