### PR TITLE
Properly dispose SecureClient to not throw exception when shutting down

### DIFF
--- a/source/Halibut/Transport/ISecureClient.cs
+++ b/source/Halibut/Transport/ISecureClient.cs
@@ -3,7 +3,7 @@ using Halibut.Transport.Protocol;
 
 namespace Halibut.Transport
 {
-    public interface ISecureClient
+    public interface ISecureClient : IDisposable
     {
         ServiceEndPoint ServiceEndpoint { get; }
         void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler);

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -60,6 +60,7 @@ namespace Halibut.Transport
         public void Dispose()
         {
             working = false;
+            secureClient.Dispose();
         }
     }
 }

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -20,6 +20,8 @@ namespace Halibut.Transport
         readonly ConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
 
+        bool isDisposing;
+
         public SecureClient(ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
         {
             this.ServiceEndpoint = serviceEndpoint;
@@ -60,7 +62,8 @@ namespace Halibut.Transport
                     catch
                     {
                         connection?.Dispose();
-                        throw;
+                        if (!isDisposing)
+                            throw;
                     }
 
                     // Only return the connection to the pool if all went well
@@ -151,6 +154,11 @@ namespace Halibut.Transport
             }
 
             throw new HalibutClientException(error.ToString(), lastError);
+        }
+
+        public void Dispose()
+        {
+            isDisposing = true;
         }
     }
 }

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -25,6 +25,8 @@ namespace Halibut.Transport
         readonly ILog log;
         readonly ConnectionManager connectionManager;
 
+        bool isDisposing;
+
         public SecureWebSocketClient(ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
         {
             this.serviceEndpoint = serviceEndpoint;
@@ -69,7 +71,8 @@ namespace Halibut.Transport
                     catch
                     {
                         connection?.Dispose();
-                        throw;
+                        if (!isDisposing)
+                            throw;
                     }
 
                     // Only return the connection to the pool if all went well
@@ -142,6 +145,11 @@ namespace Halibut.Transport
             }
 
             throw new HalibutClientException(error.ToString(), lastError);
+        }
+
+        public void Dispose()
+        {
+            isDisposing = true;
         }
     }
 }


### PR DESCRIPTION
When shutting down a polling client, it was rethrowing an IOException exception, we now check to see if we are disposing before rethrowing the exception.