### PR TITLE
Check if we are disposing/shutting down before throwing exception

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -321,6 +321,7 @@ namespace Halibut.Transport
     public class ConnectionManager : IDisposable
     {
         public ConnectionManager() { }
+        public bool IsDisposed { get; }
         public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
         public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -315,6 +315,7 @@ namespace Halibut.Transport
     public class ConnectionManager : IDisposable
     {
         public ConnectionManager() { }
+        public bool IsDisposed { get; }
         public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
         public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -11,6 +11,8 @@ namespace Halibut.Transport
         readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new ConnectionPool<ServiceEndPoint, IConnection>();
         readonly Dictionary<ServiceEndPoint, HashSet<IConnection>> activeConnections = new Dictionary<ServiceEndPoint, HashSet<IConnection>>();
 
+        public bool IsDisposed { get; private set; }
+
         public IConnection AcquireConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
         {
             lock (activeConnections)
@@ -93,6 +95,8 @@ namespace Halibut.Transport
                     SafelyDisposeConnection(connection, null);
                 }
             }
+
+            IsDisposed = true;
         }
 
 

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -60,6 +60,8 @@ namespace Halibut.Transport
                     catch
                     {
                         connection?.Dispose();
+                        if (connectionManager.IsDisposed)
+                            return;
                         throw;
                     }
 


### PR DESCRIPTION
Fixes an issue where an IOException gets thrown when shutting down polling tentacles