### PR TITLE
Added a phased random retry to if the polling target is not available…

### DIFF
--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -33,17 +33,27 @@ namespace Halibut.Diagnostics
 
         void WriteInternal(LogEvent logEvent)
         {
-            var logLevel = logEvent.Type == EventType.Diagnostic ||
-                           logEvent.Type == EventType.SecurityNegotiation ||
-                           logEvent.Type == EventType.MessageExchange
-                ? LogLevel.Trace 
-                : LogLevel.Info;
+            var logLevel = GetLogLevel(logEvent);
             SendToTrace(logEvent, logLevel);
 
             events.Enqueue(logEvent);
 
-            LogEvent ignore;
-            while (events.Count > 100 && events.TryDequeue(out ignore)) { }
+            while (events.Count > 100 && events.TryDequeue(out _)) { }
+        }
+
+        static LogLevel GetLogLevel(LogEvent logEvent)
+        {
+            switch (logEvent.Type)
+            {
+                case EventType.Error:
+                    return LogLevel.Error;
+                case EventType.Diagnostic:
+                case EventType.SecurityNegotiation:
+                case EventType.MessageExchange:
+                    return LogLevel.Trace;
+                default:
+                    return LogLevel.Info;
+            }
         }
 
         void SendToTrace(LogEvent logEvent, LogLevel level)

--- a/source/Halibut/Util/PhasedBackoffRetryTracker.cs
+++ b/source/Halibut/Util/PhasedBackoffRetryTracker.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace Halibut.Util
 {
-    public class PhasedBackoffRetryTracker
+    class PhasedBackoffRetryTracker
     {
         readonly Stopwatch stopwatch = new Stopwatch();
         readonly Random random = new Random();

--- a/source/Halibut/Util/PhasedBackoffRetryTracker.cs
+++ b/source/Halibut/Util/PhasedBackoffRetryTracker.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+
+namespace Halibut.Util
+{
+    public class PhasedBackoffRetryTracker
+    {
+        readonly Stopwatch stopwatch = new Stopwatch();
+        readonly Random random = new Random();
+
+        public void Try()
+        {
+            stopwatch.Start();
+        }
+
+        public void Success()
+        {
+            stopwatch.Reset();
+        }
+
+        public TimeSpan GetSleepPeriod()
+        {
+            var elapsed = stopwatch.Elapsed;
+            
+            // Using a random interval prevents all the servers connecting back at the same time when the client comes back online
+            if(elapsed < TimeSpan.FromMinutes(5))
+                return TimeSpan.FromMilliseconds(random.Next(5_000, 10_000));
+            
+            if(elapsed < TimeSpan.FromHours(1))
+                return TimeSpan.FromMilliseconds(random.Next(15_000, 30_000));
+            
+            return TimeSpan.FromMilliseconds(random.Next(60_000, 120_000));
+        }
+    }
+}


### PR DESCRIPTION
… or refuses the connection. Also cleared up the log messages.

To Test:
- Uncomment just lines 32 and 33 of SampleClient.Program (Comment out the thumbprint Trust and the websocket listening part)
- Comment in just line 39 (//Begin Polling Setup) in the Sample Server