### PR TITLE
Disposed of WebSocket connections when the client's certificate is not recognised.

### DIFF
--- a/source/Halibut.SampleClient/Program.cs
+++ b/source/Halibut.SampleClient/Program.cs
@@ -44,10 +44,16 @@ namespace Halibut.SampleClient
 
                 while (true)
                 {
-                    var result = calculator.Add(12, 18);
-
-                    Console.WriteLine("12 + 18 = " + result);
-                    Console.ReadKey();
+                    try
+                    {
+                        var result = calculator.Add(12, 18);
+                        Console.WriteLine("12 + 18 = " + result);
+                        Console.ReadKey();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Write(ex.Message);
+                    }
                 }
             }
         }

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -57,7 +57,7 @@ namespace Halibut.Tests
                 Params = new object[] { "Fred" }
             };
 
-            var secureClient = new SecureClient(endpoint, Certificates.Octopus, log, connectionManager);
+            var secureClient = new SecureListeningClient(endpoint, Certificates.Octopus, log, connectionManager);
             ResponseMessage response = null;
             secureClient.ExecuteTransaction((mep) => response = mep.ExchangeAsClient(request));
 

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -149,7 +149,7 @@ namespace Halibut
 
         ResponseMessage SendOutgoingHttpsRequest(RequestMessage request)
         {
-            var client = new SecureClient(request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
+            var client = new SecureListeningClient(request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
 
             ResponseMessage response = null;
             client.ExecuteTransaction(protocol =>

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
 using Halibut.Transport.Proxy;
+using Halibut.Util;
 
 namespace Halibut.Transport
 {
@@ -76,13 +77,13 @@ namespace Halibut.Transport
                 }
                 catch (SocketException cex) when (cex.SocketErrorCode == SocketError.ConnectionRefused)
                 {
-                    log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} refused the connection, this may mean that the expected listening service is not running.");
+                    log.Write(EventType.Error, $"The remote host at {ServiceEndpoint.Format()} refused the connection, this may mean that the expected listening service is not running.");
                     lastError = cex;
                     retryAllowed = false;
                 }
                 catch (SocketException sex)
                 {
-                    log.WriteException(EventType.Error, $"Socket communication error with connection to  {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", sex);
+                    log.WriteException(EventType.Error, $"Socket communication error with connection to  {ServiceEndpoint.Format()}", sex);
                     lastError = sex;
                     // When the host is not found an immediate retry isn't going to help
                     if (sex.SocketErrorCode == SocketError.HostNotFound)
@@ -92,7 +93,7 @@ namespace Halibut.Transport
                 }
                 catch (ConnectionInitializationFailedException cex)
                 {
-                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", cex);
+                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {ServiceEndpoint.Format()}", cex);
                     lastError = cex;
                     retryAllowed = true;
 
@@ -107,14 +108,14 @@ namespace Halibut.Transport
                 }
                 catch (IOException iox) when (iox.IsSocketConnectionReset())
                 {
-                    log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} reset the connection, this may mean that the expected listening service does not trust the thumbprint {clientCertificate.Thumbprint} or was shut down.");
+                    log.Write(EventType.Error, $"The remote host at {ServiceEndpoint.Format()} reset the connection, this may mean that the expected listening service does not trust the thumbprint {clientCertificate.Thumbprint} or was shut down.");
                     lastError = iox;
                     Thread.Sleep(retryInterval);
                 }
                 catch (IOException iox) when (iox.IsSocketConnectionTimeout())
                 {
                     // Received on a polling client when the network connection is lost.
-                    log.Write(EventType.Error, $"The connection to the host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} timed out, there may be problems with the network, connection will be retried.");
+                    log.Write(EventType.Error, $"The connection to the host at {ServiceEndpoint.Format()} timed out, there may be problems with the network, connection will be retried.");
                     lastError = iox;
                     Thread.Sleep(retryInterval);
                 }

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -70,7 +70,6 @@ namespace Halibut.Transport
                 }
                 catch (AuthenticationException aex)
                 {
-                    log.WriteException(EventType.Error, $"Authentication failed while setting up connection to {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", aex);
                     lastError = aex;
                     retryAllowed = false;
                     break;

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -80,7 +80,6 @@ namespace Halibut.Transport
                     log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} refused the connection, this may mean that the expected listening service is not running.");
                     lastError = cex;
                     retryAllowed = false;
-                    Thread.Sleep(retryInterval);
                 }
                 catch (SocketException sex)
                 {

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
 using Halibut.Transport.Proxy;
+using Halibut.Util;
 
 namespace Halibut.Transport
 {
@@ -69,20 +70,20 @@ namespace Halibut.Transport
                 }
                 catch (AuthenticationException aex)
                 {
-                    log.WriteException(EventType.Error, $"Authentication failed while setting up connection to {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", aex);
+                    log.WriteException(EventType.Error, $"Authentication failed while setting up connection to {ServiceEndpoint.Format()}", aex);
                     lastError = aex;
                     retryAllowed = false;
                     break;
                 }
                 catch (SocketException cex) when (cex.SocketErrorCode == SocketError.ConnectionRefused)
                 {
-                    log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} refused the connection, this may mean that the expected listening service is not running.");
+                    log.Write(EventType.Error, $"The remote host at {ServiceEndpoint.Format()} refused the connection, this may mean that the expected listening service is not running.");
                     lastError = cex;
                     Thread.Sleep(retryInterval);
                 }
                 catch (SocketException sex)
                 {
-                    log.WriteException(EventType.Error, $"Socket communication error with connection to  {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", sex);
+                    log.WriteException(EventType.Error, $"Socket communication error with connection to  {ServiceEndpoint.Format()}", sex);
                     lastError = sex;
                     // When the host is not found an immediate retry isn't going to help
                     if (sex.SocketErrorCode == SocketError.HostNotFound)
@@ -92,7 +93,7 @@ namespace Halibut.Transport
                 }
                 catch (ConnectionInitializationFailedException cex)
                 {
-                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", cex);
+                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {ServiceEndpoint.Format()}", cex);
                     lastError = cex;
                     retryAllowed = true;
 
@@ -107,14 +108,14 @@ namespace Halibut.Transport
                 }
                 catch (IOException iox) when (iox.IsSocketConnectionReset())
                 {
-                    log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} reset the connection, this may mean that the expected listening service does not trust the thumbprint {clientCertificate.Thumbprint} or was shut down.");
+                    log.Write(EventType.Error, $"The remote host at {ServiceEndpoint.Format()} reset the connection, this may mean that the expected listening service does not trust the thumbprint {clientCertificate.Thumbprint} or was shut down.");
                     lastError = iox;
                     Thread.Sleep(retryInterval);
                 }
                 catch (IOException iox) when (iox.IsSocketConnectionTimeout())
                 {
                     // Received on a polling client when the network connection is lost.
-                    log.Write(EventType.Error, $"The connection to the host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} timed out, there may be problems with the network, connection will be retried.");
+                    log.Write(EventType.Error, $"The connection to the host at {ServiceEndpoint.Format()} timed out, there may be problems with the network, connection will be retried.");
                     lastError = iox;
                     Thread.Sleep(retryInterval);
                 }

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
+using Halibut.Transport.Proxy;
+
+namespace Halibut.Transport
+{
+    class SecureListeningClient : ISecureClient
+    {
+        readonly ILog log;
+        readonly ConnectionManager connectionManager;
+        readonly X509Certificate2 clientCertificate;
+
+        public SecureListeningClient(ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        {
+            this.ServiceEndpoint = serviceEndpoint;
+            this.clientCertificate = clientCertificate;
+            this.log = log;
+            this.connectionManager = connectionManager;
+        }
+
+        public ServiceEndPoint ServiceEndpoint { get; }
+
+        public void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler)
+        {
+            var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
+
+            Exception lastError = null;
+
+            // retryAllowed is also used to indicate if the error occurred before or after the connection was made
+            var retryAllowed = true;
+            var watch = Stopwatch.StartNew();
+            for (var i = 0; i < ServiceEndpoint.RetryCountLimit && retryAllowed && watch.Elapsed < ServiceEndpoint.ConnectionErrorRetryTimeout; i++)
+            {
+                if (i > 0) log.Write(EventType.Error, "Retry attempt {0}", i);
+
+                try
+                {
+                    lastError = null;
+
+                    IConnection connection = null;
+                    try
+                    {
+                        connection = connectionManager.AcquireConnection(new TcpConnectionFactory(clientCertificate), ServiceEndpoint, log);
+
+                        // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
+                        retryAllowed = false;
+
+                        protocolHandler(connection.Protocol);
+                    }
+                    catch
+                    {
+                        connection?.Dispose();
+                        if (connectionManager.IsDisposed)
+                            return;
+                        throw;
+                    }
+
+                    // Only return the connection to the pool if all went well
+                    connectionManager.ReleaseConnection(ServiceEndpoint, connection);
+                }
+                catch (AuthenticationException aex)
+                {
+                    log.WriteException(EventType.Error, $"Authentication failed while setting up connection to {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", aex);
+                    lastError = aex;
+                    retryAllowed = false;
+                    break;
+                }
+                catch (SocketException cex) when (cex.SocketErrorCode == SocketError.ConnectionRefused)
+                {
+                    log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} refused the connection, this may mean that the expected listening service is not running.");
+                    lastError = cex;
+                    Thread.Sleep(retryInterval);
+                }
+                catch (SocketException sex)
+                {
+                    log.WriteException(EventType.Error, $"Socket communication error with connection to  {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", sex);
+                    lastError = sex;
+                    // When the host is not found an immediate retry isn't going to help
+                    if (sex.SocketErrorCode == SocketError.HostNotFound)
+                    {
+                        break;
+                    }
+                }
+                catch (ConnectionInitializationFailedException cex)
+                {
+                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())}", cex);
+                    lastError = cex;
+                    retryAllowed = true;
+
+                    // If this is the second failure, clear the pooled connections as a precaution
+                    // against all connections in the pool being bad
+                    if (i == 1)
+                    {
+                        connectionManager.ClearPooledConnections(ServiceEndpoint, log);
+                    }
+
+                    Thread.Sleep(retryInterval);
+                }
+                catch (IOException iox) when (iox.IsSocketConnectionReset())
+                {
+                    log.Write(EventType.Error, $"The remote host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} reset the connection, this may mean that the expected listening service does not trust the thumbprint {clientCertificate.Thumbprint} or was shut down.");
+                    lastError = iox;
+                    Thread.Sleep(retryInterval);
+                }
+                catch (IOException iox) when (iox.IsSocketConnectionTimeout())
+                {
+                    // Received on a polling client when the network connection is lost.
+                    log.Write(EventType.Error, $"The connection to the host at {(ServiceEndpoint == null ? "(Null EndPoint)" : ServiceEndpoint.BaseUri.ToString())} timed out, there may be problems with the network, connection will be retried.");
+                    lastError = iox;
+                    Thread.Sleep(retryInterval);
+                }
+                catch (Exception ex)
+                {
+                    log.WriteException(EventType.Error, "Unexpected exception executing transaction.", ex);
+                    lastError = ex;
+                    Thread.Sleep(retryInterval);
+                }
+            }
+
+            HandleError(lastError, retryAllowed);
+        }
+
+        void HandleError(Exception lastError, bool retryAllowed)
+        {
+            if (lastError == null)
+                return;
+
+            lastError = lastError.UnpackFromContainers();
+
+            var error = new StringBuilder();
+            error.Append("An error occurred when sending a request to '").Append(ServiceEndpoint.BaseUri).Append("', ");
+            error.Append(retryAllowed ? "before the request could begin: " : "after the request began: ");
+            error.Append(lastError.Message);
+
+            var inner = lastError as SocketException;
+            if (inner != null)
+            {
+                if ((inner.SocketErrorCode == SocketError.ConnectionAborted || inner.SocketErrorCode == SocketError.ConnectionReset) && retryAllowed)
+                {
+                    error.Append("The server aborted the connection before it was fully established. This usually means that the server rejected the certificate that we provided. We provided a certificate with a thumbprint of '");
+                    error.Append(clientCertificate.Thumbprint + "'.");
+                }
+            }
+
+            throw new HalibutClientException(error.ToString(), lastError);
+        }
+    }
+}

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -77,7 +77,6 @@ namespace Halibut.Transport
                 }
                 catch (AuthenticationException aex)
                 {
-                    log.WriteException(EventType.Error, $"Authentication failed while setting up connection to {(serviceEndpoint == null ? "(Null EndPoint)" : serviceEndpoint.BaseUri.ToString())}", aex);
                     lastError = aex;
                     retryAllowed = false;
                 }

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -3,6 +3,7 @@
 // This means we cannot validate the remote is presenting the correct certificate
 // See https://github.com/dotnet/corefx/issues/12038
 
+using Halibut.Util;
 #if SUPPORTS_WEB_SOCKET_CLIENT
 using System;
 using System.Diagnostics;
@@ -97,12 +98,12 @@ namespace Halibut.Transport
                     }
                     else
                     {
-                        log.Write(EventType.Error, $"Socket communication error with connection to  {(serviceEndpoint == null ? "(Null EndPoint)" : serviceEndpoint.BaseUri.ToString())}");
+                        log.Write(EventType.Error, $"Socket communication error with connection to  {serviceEndpoint.Format()}");
                     }
                 }
                 catch (ConnectionInitializationFailedException cex)
                 {
-                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {(serviceEndpoint == null ? "(Null EndPoint)" : serviceEndpoint.BaseUri.ToString())}", cex);
+                    log.WriteException(EventType.Error, $"Connection initialization failed while connecting to  {serviceEndpoint.Format()}", cex);
                     lastError = cex;
                     retryAllowed = true;
 

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -138,7 +138,7 @@ namespace Halibut.Transport
             {
                 var webSocketContext = await listenerContext.AcceptWebSocketAsync("Octopus");
                 webSocketStream = new WebSocketStream(webSocketContext.WebSocket);
-                
+
                 var req = await webSocketStream.ReadTextMessage(); // Initial message
                 if (string.IsNullOrEmpty(req))
                 {
@@ -160,6 +160,11 @@ namespace Halibut.Transport
                     // Mark the stream as delegated once everything has succeeded
                     keepConnection = true;
                 }
+            }
+            catch (TaskCanceledException)
+            {
+                if(!cts.Token.IsCancellationRequested)
+                    log.Write(EventType.Error, "A timeout occurred while receiving data");
             }
             catch (Exception ex)
             {

--- a/source/Halibut/Util/ServiceEndPointExtensions.cs
+++ b/source/Halibut/Util/ServiceEndPointExtensions.cs
@@ -1,0 +1,8 @@
+namespace Halibut.Util
+{
+    static class ServiceEndPointExtensions
+    {
+        public static string Format(this ServiceEndPoint serviceEndpoint)
+            => serviceEndpoint?.BaseUri.ToString() ?? "(Null EndPoint)";
+    }
+}


### PR DESCRIPTION
This was keeping connections open by the server and causing the client to run out of memory.

Added a timeout to the receive on the client so that it kills those open connections (for connections by previous version of Halibut).
Correctly closed the connections at both ends. I'm guessing it changed between versions of the lib and now requires CloseAsync and CloseOutputAsync calls.
Cleaned up the message output
Fixes https://github.com/OctopusDeploy/Issues/issues/4227