### PR TITLE
Avoid multiple enumeration in `ConnectionManager`

### DIFF
--- a/source/Halibut.Tests/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/ConnectionManagerFixture.cs
@@ -25,6 +25,20 @@ namespace Halibut.Tests
         }
 
         [Test]
+        public void DisposedConnectionsAreRemovedFromActive_WhenMultipleConnectionsAreActive()
+        {
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            var connectionManager = new ConnectionManager();
+
+            //do it twice because this bug only triggers on multiple enumeration, having 1 in the collection doesn't trigger the bug
+            connectionManager.AcquireConnection(connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            connectionManager.AcquireConnection(connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+
+            connectionManager.Disconnect(serviceEndpoint, null);
+            connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
+        }
+       
+        [Test]
         public void ReleasedConnectionsAreNotActive()
         {
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -121,7 +121,7 @@ namespace Halibut.Transport
             {
                 if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
                 {
-                    foreach (var connection in activeConnectionsForEndpoint)
+                    foreach (var connection in activeConnectionsForEndpoint.ToArray())
                     {
                         SafelyDisposeConnection(connection, log);
                     }


### PR DESCRIPTION
This PR Addresses disconnection issues where multiple active connections are managed by the `ConnectionManager` class, this cropped up during E2E tests in OctopusServer - see [internal build server link](https://build.octopushq.com/viewLog.html?buildId=956217&tab=buildResultsDiv&buildTypeId=OctopusDeploy_OctopusServer_TestOrchestration_TestE2eWindows201664bitSql2016cs&logTab=)