### PR TITLE
Always close TcpClient at the end of a conversation

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 #tool "nuget:?package=gitlink&version=3.1.0"
+#tool "nuget:?package=JetBrains.DotMemoryUnit&version=3.0.20171219.105559"
 #addin "Cake.FileHelpers&version=3.2.0"
 
 //////////////////////////////////////////////////////////////////////
@@ -82,8 +83,19 @@ Task("Test")
 {
     DotNetCoreTest("./source/Halibut.Tests/Halibut.Tests.csproj", new DotNetCoreTestSettings
     {
-        Configuration = configuration,
-        NoBuild = true
+        ArgumentCustomization = args => {
+            args.Clear();
+            args.Append("\"C:/Program Files/dotnet/dotnet.exe\"");
+            args.Append("--propagate-exit-code");
+            args.Append("--instance-name=" + Guid.NewGuid());
+            args.Append("--");
+            args.Append("test");
+            args.Append("./source/Halibut.Tests/Halibut.Tests.csproj");
+            args.Append("--configuration=" + configuration);
+            args.Append("--no-build");
+            return args;
+        },
+        ToolPath = "./tools/JetBrains.dotMemoryUnit.3.0.20171219.105559/lib/tools/dotMemoryUnit.exe"
     });
 });
 

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.0.20171219.105559" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Assent" Version="1.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
@@ -47,6 +48,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT</DefineConstants>
+  </PropertyGroup>
   
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -39,7 +39,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
+    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">

--- a/source/Halibut.Tests/MemoryFixture.cs
+++ b/source/Halibut.Tests/MemoryFixture.cs
@@ -71,7 +71,7 @@ namespace Halibut.Tests
                 {
                     var tcpClientCount = memory.GetObjects(x => x.Type.Is<TcpClient>()).ObjectsCount;
                     Console.WriteLine($"Found {tcpClientCount} instances of TcpClient still in memory.");
-                    Assert.That(tcpClientCount, Is.EqualTo(expectedTcpClientCount), "Unexpected number of TcpClient objects in memory");
+                    Assert.That(tcpClientCount, Is.LessThanOrEqualTo(expectedTcpClientCount), "Unexpected number of TcpClient objects in memory");
                 });
             }
         }

--- a/source/Halibut.Tests/MemoryFixture.cs
+++ b/source/Halibut.Tests/MemoryFixture.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using JetBrains.dotMemoryUnit;
+using JetBrains.dotMemoryUnit.Kernel;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public interface ICalculatorService
+    {
+        long Add(long a, long b);
+    }
+
+    public class CalculatorService : ICalculatorService
+    {
+        public long Add(long a, long b)
+        {
+            //Console.WriteLine($"Got a request to add {a} + {b}");
+            return a + b;
+        }
+    }
+    
+    [TestFixture]
+    public class MemoryFixture
+    {
+        const int Clients = 5;
+        const int RequestsPerClient = 5;
+
+        [Test]
+        [DotMemoryUnit(SavingStrategy = SavingStrategy.OnCheckFail, Directory = @"c:\temp\dotmemoryunit", WorkspaceNumberLimit = 5, DiskSpaceLimit = 104857600)]
+        public void TcpClientsAreDisposedCorrectly()
+        {
+            if (!dotMemoryApi.IsEnabled)
+                Assert.Inconclusive("This test is meant to be run under dotMemory Unit. In your IDE, right click on the test icon and choose 'Run under dotMemory Unit'.");
+
+            using (RunServer(Certificates.Octopus, out var port))
+            {
+                for (var i = 0; i < Clients; i++)
+                    RunListeningClient(Certificates.TentacleListening, port, Certificates.OctopusPublicThumbprint);
+                for (var i = 0; i < Clients; i++)
+                    RunPollingClient(Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint);
+#if SUPPORTS_WEB_SOCKET_CLIENT
+                for (var i = 0; i < Clients; i++)
+                    RunWebSocketPollingClient(Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint, Certificates.OctopusPublicThumbprint);
+#endif
+
+                //https://dotnettools-support.jetbrains.com/hc/en-us/community/posts/360000088690-How-reproduce-DotMemory-s-Force-GC-button-s-behaviour-on-code-with-c-?page=1#community_comment_360000072750
+                for (var i = 0; i < 4; i++)
+                {
+                    GC.Collect(2, GCCollectionMode.Forced, true);
+                    GC.WaitForPendingFinalizers();
+                }
+
+                //server listen doesn't keep a port
+                //server polling doesn't keep a port
+                //server websocket polling _keeps_ a port
+                //client listening _keeps_ a port
+                //client polling doesn't keep a port
+                //client websocket polling doesn't keep a port
+
+                const int expectedTcpClientCount = 2;
+                dotMemory.Check(memory => { Assert.That(memory.GetObjects(x => x.Type.Is<TcpClient>()).ObjectsCount, Is.LessThanOrEqualTo(expectedTcpClientCount)); });
+            }
+        }
+
+        static HalibutRuntime RunServer(X509Certificate2 serverCertificate, out int port)
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<ICalculatorService>(() => new CalculatorService());
+
+            var server = new HalibutRuntime(services, serverCertificate);
+            
+            //set up listening  
+            server.Trust(Certificates.TentacleListeningPublicThumbprint);
+            port = server.Listen();
+            
+            //setup polling
+            var serviceEndPoint = new ServiceEndPoint(new Uri("https://localhost:8433"), Certificates.TentaclePollingPublicThumbprint);
+            server.Poll(new Uri("poll://SQ-TENTAPOLL"), serviceEndPoint);
+            
+            //setup polling websocket
+            AddSslCertToLocalStoreAndRegisterFor("0.0.0.0:8434");
+            var endPoint = new ServiceEndPoint(new Uri("wss://localhost:8434/Halibut"), Certificates.SslThumbprint);
+            server.Poll(new Uri("poll://SQ-WEBSOCKETPOLL"), endPoint);
+            
+            return server;
+        }
+
+        static void RunListeningClient(X509Certificate2 clientCertificate, int port, string remoteThumbprint, bool expectSuccess = true)
+        {
+            using (var runtime = new HalibutRuntime(clientCertificate))
+            {
+                var calculator = runtime.CreateClient<ICalculatorService>($"https://localhost:{port}/", remoteThumbprint);
+                MakeRequest(calculator, "listening", expectSuccess);
+            }
+        }
+        
+        static void RunPollingClient(X509Certificate2 clientCertificate, string remoteThumbprint, bool expectSuccess = true)
+        {
+            using (var runtime = new HalibutRuntime(clientCertificate))
+            {
+                runtime.Listen(new IPEndPoint(IPAddress.IPv6Any, 8433));
+                runtime.Trust(Certificates.OctopusPublicThumbprint);
+                var endpoint = new ServiceEndPoint("poll://SQ-TENTAPOLL", remoteThumbprint);
+                
+                var calculator = runtime.CreateClient<ICalculatorService>(endpoint);
+    
+                MakeRequest(calculator, "polling", expectSuccess);
+            }
+        }
+        
+        static void RunWebSocketPollingClient(X509Certificate2 clientCertificate, string remoteThumbprint, string trustedCertificate, bool expectSuccess = true)
+        {
+            using (var runtime = new HalibutRuntime(clientCertificate))
+            {
+                runtime.ListenWebSocket("https://+:8434/Halibut");
+                runtime.Trust(trustedCertificate);
+                var endpoint = new ServiceEndPoint("poll://SQ-WEBSOCKETPOLL", remoteThumbprint);
+                var calculator = runtime.CreateClient<ICalculatorService>(endpoint);
+    
+                MakeRequest(calculator, "websocket polling", expectSuccess);
+            }
+        }
+
+        static void MakeRequest(ICalculatorService calculator, string requestType, bool expectSuccess)
+        {
+            for (var i = 0; i < RequestsPerClient; i++)
+            {
+                try
+                {
+                    var result = calculator.Add(12, 18);
+                    Assert.That(result, Is.EqualTo(30));
+                    if (!expectSuccess)
+                        Assert.Fail(DateTime.Now.ToString("s") + ": Wasn't expecting this test to pass");
+                }
+                catch (Exception)
+                {
+                    if (expectSuccess)
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+
+        static void AddSslCertToLocalStoreAndRegisterFor(string address)
+        {
+            var certificate = Certificates.Ssl;
+            var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            store.Open(OpenFlags.ReadWrite);
+            store.Add(certificate);
+            store.Close();
+
+            var proc = new Process
+            {
+                StartInfo = new ProcessStartInfo("netsh", $"http add sslcert ipport={address} certhash={certificate.Thumbprint} appid={{2e282bfb-fce9-40fc-a594-2136043e1c8f}}")
+                {
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false
+                }
+            };
+            proc.Start();
+            proc.WaitForExit();
+            var output = proc.StandardOutput.ReadToEnd();
+
+            if (proc.ExitCode != 0 && !output.Contains("Cannot create a file when that file already exists"))
+            {
+                Console.WriteLine(output);
+                Console.WriteLine(proc.StandardError.ReadToEnd());
+                throw new Exception("Could not bind cert to port");
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/TcpClientManagerFixture.cs
+++ b/source/Halibut.Tests/TcpClientManagerFixture.cs
@@ -42,5 +42,18 @@ namespace Halibut.Tests
 
             manager.GetActiveClients(thumbprint).Should().BeEmpty();
         }
+        
+        [Test]
+        public void ShouldRemoveClient()
+        {
+            const string thumbprint = "123";
+            var manager = new TcpClientManager();
+            var client = new TcpClient();
+
+            manager.AddActiveClient(thumbprint, client);
+            manager.RemoveClient(client);
+
+            manager.GetActiveClients(thumbprint).Should().BeEmpty();
+        }
     }
 }

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -184,7 +184,6 @@ namespace Halibut.Transport
         {
             var clientName = client.Client.RemoteEndPoint;
             var stream = client.GetStream();
-
             using (var ssl = new SslStream(stream, true, AcceptAnySslCertificate))
             {
                 try
@@ -255,7 +254,7 @@ namespace Halibut.Transport
                     // Closing an already closed stream or client is safe, better not to leak
                     stream.Close();
                     client.Close();
-                    tcpClientManager.RemoveDisconnectedClient(client);
+                    tcpClientManager.RemoveClient(client);
                 }
             }
         }

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -251,10 +251,10 @@ namespace Halibut.Transport
                 }
                 finally
                 {
+                    tcpClientManager.RemoveClient(client);
                     // Closing an already closed stream or client is safe, better not to leak
                     stream.Close();
                     client.Close();
-                    tcpClientManager.RemoveClient(client);
                 }
             }
         }

--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -53,5 +53,24 @@ namespace Halibut.Transport
 
             return NoClients;
         }
+
+        public void RemoveDisconnectedClient(TcpClient client)
+        {
+            lock (activeClients)
+            {
+                foreach(var activeClient in activeClients)
+                {
+                    if (activeClient.Value.Contains(client))
+                        activeClient.Value.Remove(client);
+                }
+
+                var inactiveThumbprints = activeClients
+                    .Where(x => x.Value.Count == 0)
+                    .Select(x => x.Key)
+                    .ToArray();
+                foreach (var inactiveThumbprint in inactiveThumbprints)
+                    activeClients.Remove(inactiveThumbprint);
+            }
+        }
     }
 }

--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -58,18 +58,18 @@ namespace Halibut.Transport
         {
             lock (activeClients)
             {
-                foreach(var activeClient in activeClients)
+                foreach(var thumbprintClientsPair in activeClients)
                 {
-                    if (activeClient.Value.Contains(client))
-                        activeClient.Value.Remove(client);
+                    if (thumbprintClientsPair.Value.Contains(client))
+                        thumbprintClientsPair.Value.Remove(client);
                 }
 
-                var inactiveThumbprints = activeClients
+                var thumbprintsWithNoClients = activeClients
                     .Where(x => x.Value.Count == 0)
                     .Select(x => x.Key)
                     .ToArray();
-                foreach (var inactiveThumbprint in inactiveThumbprints)
-                    activeClients.Remove(inactiveThumbprint);
+                foreach (var thumbprint in thumbprintsWithNoClients)
+                    activeClients.Remove(thumbprint);
             }
         }
     }

--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -54,7 +54,7 @@ namespace Halibut.Transport
             return NoClients;
         }
 
-        public void RemoveDisconnectedClient(TcpClient client)
+        public void RemoveClient(TcpClient client)
         {
             lock (activeClients)
             {


### PR DESCRIPTION
Previously, a finished conversation would leave the TCPClient around, but GC would clean it up. Now we were tracking Clients so that we could disconnect them, this was keeping a reference to them, causing leaked connections

Fixes https://github.com/OctopusDeploy/Halibut/issues/92

Note: @michaelnoonan - this removes a comment of yours ("we no longer own the stream lifetime") that we think was wrong. Can you :eyes: this closely.