### PR TITLE
Bump newtonsoft.json to fix TentacleManager version mismatch

### DIFF
--- a/source/Halibut.SampleClient/Halibut.SampleClient.csproj
+++ b/source/Halibut.SampleClient/Halibut.SampleClient.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>

--- a/source/Halibut.SampleServer/Halibut.SampleServer.csproj
+++ b/source/Halibut.SampleServer/Halibut.SampleServer.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
We were facing issues in Tentacle Manager due to a newtonsoft.json mismatch:

![image](https://user-images.githubusercontent.com/373389/64085980-04655f00-cd79-11e9-9b70-84bc92c48885.png)

This was caused by:
* Tentacle Manager referencing 11.0.2.
* Tentacle referencing OctopusShared which referenced Halibut which referenced Newtonsoft.Json 10.0.3
* the msi creation copying the Tentacle Manger bin folder, and then the Tentacle bin folder
-> resulting in older version being shipped