### PR TITLE
Handle "unable to connect" exception nicer

### DIFF
--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -104,7 +104,7 @@ namespace Halibut.Tests
                 };
                 var echo = octopus.CreateClient<IEchoService>(endpoint);
                 var ex = Assert.Throws<HalibutClientException>(() => echo.Crash());
-                ex.Message.Should().Contain("when sending a request to 'https://google.com:88/', before the request");
+                ex.Message.Should().Be("An error occurred when sending a request to 'https://google.com:88/', before the request could begin: The client was unable to establish the initial connection within 00:00:02.");
             }
         }
 

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -81,6 +81,12 @@ namespace Halibut.Transport
                     lastError = cex;
                     Thread.Sleep(retryInterval);
                 }
+                catch (HalibutClientException hce)
+                {
+                    lastError = hce;
+                    log.Write(EventType.Error, $"{hce.Message?.TrimEnd('.')}. Retrying in {retryInterval.TotalSeconds:n1} seconds.");
+                    Thread.Sleep(retryInterval);
+                }
                 catch (SocketException sex)
                 {
                     log.WriteException(EventType.Error, $"Socket communication error with connection to  {ServiceEndpoint.Format()}", sex);

--- a/source/Halibut/Transport/TcpClientExtensions.cs
+++ b/source/Halibut/Transport/TcpClientExtensions.cs
@@ -40,7 +40,7 @@ namespace Halibut.Transport
                 {
                 }
 
-                throw new HalibutClientException("The client was unable to establish the initial connection within " + timeout);
+                throw new HalibutClientException($"The client was unable to establish the initial connection within {timeout}.");
             }
         }
     }


### PR DESCRIPTION
Dont log the stack trace on an exception that can happen in a relatively normal situation.

Fixes https://github.com/OctopusDeploy/Halibut/issues/101

### Before
```
https://example.com:10933/      128  Unexpected exception executing transaction.
Halibut.HalibutClientException: The client was unable to establish the initial connection within 00:01:00
   at Halibut.Transport.TcpClientExtensions.ConnectWithTimeout(TcpClient client, String host, Int32 port, TimeSpan timeout)
   at Halibut.Transport.TcpClientExtensions.ConnectWithTimeout(TcpClient client, Uri remoteUri, TimeSpan timeout)
   at Halibut.Transport.TcpConnectionFactory.CreateConnectedTcpClient(ServiceEndPoint endPoint, ILog log)
   at Halibut.Transport.TcpConnectionFactory.EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
   at Halibut.Transport.ConnectionManager.<>c__DisplayClass8_0.<CreateNewConnection>b__0()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at System.Lazy`1.get_Value()
   at Halibut.Transport.ConnectionManager.<>c__DisplayClass8_0.<CreateNewConnection>b__1()
   at Halibut.Transport.ConnectionManager.AcquireConnection(IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log)
   at Halibut.Transport.SecureListeningClient.ExecuteTransaction(Action`1 protocolHandler)
```


### After

```
https://example.com:10933/      128  Opening a new connection
https://example.com:10933/      128  The client was unable to establish the initial connection within 00:01:00. Retrying in 1.0 seconds.
https://example.com:10933/      128  Retry attempt 1
https://example.com:10933/      128  Opening a new connection
https://example.com:10933/      128  The client was unable to establish the initial connection within 00:01:00. Retrying in 1.0 seconds.
https://example.com:10933/      128  Retry attempt 2
https://example.com:10933/      128  Opening a new connection
```