### PR TITLE
Lower severity of client receive timeout

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -214,7 +214,7 @@ namespace Halibut.Transport.Protocol
                 // We get socket timeout on the server when the network connection to a polling client drops
                 // (in Octopus this is the server for a Polling Tentacle)
                 // In normal operation a client will poll more often than the timeout so we shouldn't see this.
-                log.Write(EventType.Error, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
+                log.Write(EventType.Diagnostic, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
                 return false;
             }
             stream.SendProceed();
@@ -252,7 +252,7 @@ namespace Halibut.Transport.Protocol
                 // We get socket timeout on the server when the network connection to a polling client drops
                 // (in Octopus this is the server for a Polling Tentacle)
                 // In normal operation a client will poll more often than the timeout so we shouldn't see this.
-                log.Write(EventType.Error, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
+                log.Write(EventType.Diagnostic, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
                 return false;
             }
             await stream.SendProceedAsync();


### PR DESCRIPTION
Just a suggestion, we have this happen somewhat often in production and as they are logged as Error this increased a lot of false warning flags from logging systems that keep us up to date on all Errors in the system. 

Maybe another event type could be handy (Warning), as the event is self-recovering and not that significant, but as that doesn't exist I followed the example of line 155 and marked it as diagnostic: https://github.com/OctopusDeploy/Halibut/blob/d70d8076023c7890f4ea72bf9e206fc4a7e93bb3/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs#L155
