### PR TITLE
Improve some logging messages

### DIFF
--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -41,7 +41,8 @@ namespace Halibut.Transport
             var watch = Stopwatch.StartNew();
             for (var i = 0; i < ServiceEndpoint.RetryCountLimit && retryAllowed && watch.Elapsed < ServiceEndpoint.ConnectionErrorRetryTimeout; i++)
             {
-                if (i > 0) log.Write(EventType.Error, "Retry attempt {0}", i);
+                if (i > 0)
+                    log.Write(EventType.OpeningNewConnection, $"Retrying connection to {ServiceEndpoint.Format()} - attempt #{i}.");
 
                 try
                 {

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -50,7 +50,7 @@ namespace Halibut.Transport
                 if (i > 0)
                 {
                     Thread.Sleep(retryInterval);
-                    log.Write(EventType.Error, "Retry attempt {0}", i);
+                    log.Write(EventType.OpeningNewConnection, $"Retrying connection to {serviceEndpoint.Format()} - attempt #{i}.");
                 }
 
                 try

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -23,11 +23,11 @@ namespace Halibut.Transport
 
         public IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
         {
-            log.Write(EventType.OpeningNewConnection, "Opening a new connection");
+            log.Write(EventType.OpeningNewConnection, $"Opening a new connection to {serviceEndpoint.BaseUri}");
 
             var certificateValidator = new ClientCertificateValidator(serviceEndpoint);
             var client = CreateConnectedTcpClient(serviceEndpoint, log);
-            log.Write(EventType.Diagnostic, "Connection established");
+            log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
 
             var stream = client.GetStream();
 


### PR DESCRIPTION
Some logging messages weren't so clear. This improves them so we can correlate logs better

![image](https://user-images.githubusercontent.com/373389/70681564-e1d7d000-1cef-11ea-9085-d56f0834d9e3.png)


_tagging @droyad as an fyi_