### PR TITLE
Ensure we dont leave unobserved exceptions

### DIFF
--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -104,7 +104,7 @@ namespace Halibut.Tests
                 };
                 var echo = octopus.CreateClient<IEchoService>(endpoint);
                 var ex = Assert.Throws<HalibutClientException>(() => echo.Crash());
-                ex.Message.Should().Be("An error occurred when sending a request to 'https://google.com:88/', before the request could begin: The client was unable to establish the initial connection within 00:00:02.");
+                ex.Message.Should().Be("An error occurred when sending a request to 'https://google.com:88/', before the request could begin: The client was unable to establish the initial connection within the timeout 00:00:02.");
             }
         }
 

--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -35,7 +35,9 @@ namespace Halibut.Tests.Util.AsyncEx
             });
             Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(100), CancellationToken.None);
             act.ShouldThrow<TimeoutException>();
-            triggered.Should().Be(false, "the task should have been aborted");
+            triggered.Should().Be(false, "we should have stopped waiting on the task when timeout happened");
+            await Task.Delay(200);
+            triggered.Should().Be(true, "task should have continued executing in the background");
         }
         
         [Test]
@@ -57,7 +59,9 @@ namespace Halibut.Tests.Util.AsyncEx
             });
             Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(150), cancellationTokenSource.Token);
             act.ShouldThrow<TaskCanceledException>();
-            triggered.Should().Be(false, "the task should have been aborted");
+            triggered.Should().Be(false, "we should have stopped waiting on the task when cancellation happened");
+            await Task.Delay(200);
+            triggered.Should().Be(true, "task should have continued executing in the background (not entirely ideal, but this task is designed to handle non-cancelable tasks)");
         }
         
         [Test]

--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Util.AsyncEx;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Util.AsyncEx
+{
+    [TestFixture]
+    public class TaskExtensionsFixture
+    {
+        [Test]
+        public async Task When_TaskCompletesWithinTimeout_TaskCompletesSuccessfully()
+        {
+            var triggered = false;
+            var task = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                triggered = true;
+            });
+            await task.TimeoutAfter(TimeSpan.FromMilliseconds(300), CancellationToken.None);
+            triggered.Should().Be(true, "the task should have triggered");
+        }
+        
+        [Test]
+        public async Task When_TaskDoesNotCompleteWithinTimeout_ThrowsTimeoutException()
+        {
+            var triggered = false;
+            var task = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                triggered = true;
+            });
+            Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(100), CancellationToken.None);
+            act.ShouldThrow<TimeoutException>();
+            triggered.Should().Be(false, "the task should have been aborted");
+        }
+        
+        [Test]
+        public async Task When_TaskGetsCancelled_ThrowsTaskCanceledException()
+        {
+            var triggered = false;
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                cancellationTokenSource.Cancel();
+            });
+            
+            var task = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                triggered = true;
+            });
+            Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(150), cancellationTokenSource.Token);
+            act.ShouldThrow<TaskCanceledException>();
+            triggered.Should().Be(false, "the task should have been aborted");
+        }
+        
+        [Test]
+        public async Task When_TaskThrowsExceptionAfterTimeout_ExceptionsAreObserved()
+        {
+            await VerifyNoUnobservedExceptions<TimeoutException>(Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                throw new ApplicationException("this task threw an exception after timeout");
+            }).TimeoutAfter(TimeSpan.FromMilliseconds(100), CancellationToken.None));
+        }
+        
+        [Test]
+        public async Task When_TaskGetsCanceledButStillThrowsExceptionAfterCancellation_ExceptionsAreObserved()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                cancellationTokenSource.Cancel();
+            });
+            await VerifyNoUnobservedExceptions<TaskCanceledException>(Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                throw new ApplicationException("this task threw an exception after timeout");
+            }).TimeoutAfter(TimeSpan.FromMilliseconds(150), cancellationTokenSource.Token));
+        }
+
+        static async Task VerifyNoUnobservedExceptions<T>(Task task)
+            where T : Exception
+        {
+            //inspired by https://stackoverflow.com/a/21269145/779192
+            var mre = new ManualResetEvent(initialState: false);
+            void Subscription(object s, UnobservedTaskExceptionEventArgs args) => mre.Set();
+            TaskScheduler.UnobservedTaskException += Subscription;
+            try
+            {
+                Func<Task> act = async () => await task;
+                act.ShouldThrow<T>();
+
+                //delay long enough to ensure the task throws its exception
+                await Task.Delay(200);
+
+                //unobserved task exceptions are thrown from the finalizer
+                task = null; // Allow the task to be GC'ed
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                if (mre.WaitOne(2000))
+                    Assert.Fail("We should not have had an unobserved task exception");
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= Subscription;
+            }
+        }
+    }
+}

--- a/source/Halibut/Util/AsyncEx/TaskExtensions.cs
+++ b/source/Halibut/Util/AsyncEx/TaskExtensions.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Util.AsyncEx
+{
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        /// Waits for a) the task to complete, b) the timeout to pass or c) the cancellationToken to be triggered.
+        /// Wraps it all up so that we dont get UnobservedTaskExceptions 
+        /// </summary>
+        /// <param name="task">The task to wait on</param>
+        /// <param name="timeout">The amount of time to wait until we give up</param>
+        /// <param name="cancellationToken">Supports task cancellation</param>
+        /// <returns>The task if successful, otherwise a TimeoutException or OperationCanceledException</returns>
+        /// <exception cref="TimeoutException">If the timeout gets reached before the task completes</exception>
+        /// <exception cref="OperationCanceledException">The task was cancelled via the cancellation token</exception>
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            var timeOutTask = Task.Delay(timeout);
+            var cancellationTask = cancellationToken.AsTask();
+            var timeoutCancellation = new CancellationTokenSource();
+            var wrappedTask = AwaitAndSwallowExceptionsWhenCancelled(task, timeoutCancellation.Token);
+            var completedTask = await Task.WhenAny(wrappedTask, timeOutTask, cancellationTask);
+            if (completedTask == timeOutTask)
+            {
+                timeoutCancellation.Cancel();
+                if (wrappedTask.IsCompleted)
+                {
+                    await wrappedTask;
+                }
+                throw new TimeoutException();
+            }
+
+            if (completedTask == cancellationTask)
+            {
+                timeoutCancellation.Cancel();
+                throw new OperationCanceledException();
+            }
+            await wrappedTask;
+        }
+        
+        /// <summary>
+        /// Allows us to await the task, but swallow the exception if the timeout has passed
+        /// This prevents us from getting UnobservedTaskException
+        /// </summary>
+        /// <param name="task"></param>
+        /// <param name="timeoutCancellation"></param>
+        /// <returns></returns>
+        static async Task AwaitAndSwallowExceptionsWhenCancelled(Task task, CancellationToken timeoutCancellation)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception)
+            {
+                if (!timeoutCancellation.IsCancellationRequested)
+                {
+                    throw;
+                }
+            }
+        }
+        
+        static Task AsTask(this CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            cancellationToken.Register(() => tcs.TrySetCanceled(), useSynchronizationContext: false);
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
Unobserved exceptions were happening when:
a) a connection was being attempted to a host that wasn't there
b) the timeout was being hit,
c) after the timeout was hit, the connection attempt fails with an exception

We now ignore any exceptions raised after the timeout is hit

How to reproduce:

1. turn off a Tentacle
1. run a health check on the same Tentacle (that will not respond)
1. put a breakpoint in the code somewhere (say in `FilterEnvironmentsByProjectAndChannelRule`)
1. trigger an action that will hit the breakpoint (ie, viewing the Environments page)
-> the ide will break at the break point
1. wait at the break point for a while (say 3min) (ie, as if you were trying to debug whats going on)
1. hit F5 to run the code again
-> the TaskScheduler.UnobservedTaskException in OctopusProgram will be hit with:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Net.Sockets.TcpClient.EndConnect(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
```