### PR TITLE
Check for null and throw explicit exceptions to troubleshoot intermittent null ref

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -246,10 +246,20 @@ namespace Halibut.Transport.Protocol
 
         T ReadBsonMessage<T>()
         {
+            //TODO: Remove these debugging checks once we're done investigating https://trello.com/c/0gHf4v7m/2974-null-ref-exceptions-in-halibut
+            if (stream == null)
+                throw new Exception("stream is null");
+            if (serializer == null)
+                throw new Exception("serializer is null");
+            
             using (var zip = new DeflateStream(stream, CompressionMode.Decompress, true))
             using (var bson = new BsonDataReader(zip) { CloseInput = false })
             {
-                return (T)serializer.Deserialize<MessageEnvelope>(bson).Message;
+                var messageEnvelope = serializer.Deserialize<MessageEnvelope>(bson);
+                if (messageEnvelope == null)
+                    throw new Exception("messageEnvelope is null");
+                
+                return (T)messageEnvelope.Message;
             }
         }
 


### PR DESCRIPTION
Just adding some debug exception throwing to help us narrow down the cause of the null ref.

https://trello.com/c/0gHf4v7m/2974-null-ref-exceptions-in-halibut

Stacktrace:
```
Halibut.HalibutClientException: An error occurred when sending a request to 'https://40.68.76.169:10933/', after the request began: Object reference not set to an instance of an object. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Halibut.Transport.Protocol.MessageExchangeStream.ReadBsonMessage[T]()
   at Halibut.Transport.Protocol.MessageExchangeStream.Receive[T]()
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ExchangeAsClient(RequestMessage request)
   at Halibut.HalibutRuntime.<>c__DisplayClass34_0.<SendOutgoingHttpsRequest>b__0(MessageExchangeProtocol protocol)
   at Halibut.Transport.SecureListeningClient.ExecuteTransaction(Action`1 protocolHandler)
   --- End of inner exception stack trace ---
   at Halibut.Transport.SecureListeningClient.HandleError(Exception lastError, Boolean retryAllowed)
   at Halibut.Transport.SecureListeningClient.ExecuteTransaction(Action`1 protocolHandler)
   at Halibut.HalibutRuntime.SendOutgoingHttpsRequest(RequestMessage request)
   at Halibut.HalibutRuntime.SendOutgoingRequest(RequestMessage request)
   at Halibut.ServiceModel.HalibutProxy.DispatchRequest(RequestMessage requestMessage)
   at Halibut.ServiceModel.HalibutProxy.Invoke(MethodInfo targetMethod, Object[] args)
```