### PR TITLE
Partially revert debugging null checks added in #111

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -246,12 +246,6 @@ namespace Halibut.Transport.Protocol
 
         T ReadBsonMessage<T>()
         {
-            //TODO: Remove these debugging checks once we're done investigating https://trello.com/c/0gHf4v7m/2974-null-ref-exceptions-in-halibut
-            if (stream == null)
-                throw new Exception("stream is null");
-            if (serializer == null)
-                throw new Exception("serializer is null");
-            
             using (var zip = new DeflateStream(stream, CompressionMode.Decompress, true))
             using (var bson = new BsonDataReader(zip) { CloseInput = false })
             {


### PR DESCRIPTION
Remove some of the null checks from "Check for null and throw explicit exceptions to troubleshoot intermittent null ref (#111)", don't need them anymore.

The null-check for the MessageEnvelope is worth keeping
