### PR TITLE
Listen only on IPv4 when IPv6 is disabled

### DIFF
--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -64,7 +65,11 @@ namespace Halibut
 
         public int Listen(int port)
         {
-            return Listen(new IPEndPoint(IPAddress.IPv6Any, port));
+            var ipAddress = Socket.OSSupportsIPv6
+                ? IPAddress.IPv6Any
+                : IPAddress.Any;
+
+            return Listen(new IPEndPoint(ipAddress, port));
         }
 
         public int Listen(IPEndPoint endpoint)


### PR DESCRIPTION
Relates to https://github.com/OctopusDeploy/Halibut/issues/99

A customer is attempting to setup Octopus Server in a Linux container without IPv6. This should let them by only attempting to listen on IPv4 if IPv6 is not available.

Open to suggestions how to write a test for this.