### PR TITLE
Fix polling disconnects

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "3.1.402",
+        "rollForward": "latestFeature"
+    }
+}

--- a/source/Halibut.SamplePolling/App.config
+++ b/source/Halibut.SamplePolling/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="Halibut.LogControlMessages" value="false"/>
+  </appSettings>
+</configuration>

--- a/source/Halibut.SamplePolling/App.config
+++ b/source/Halibut.SamplePolling/App.config
@@ -2,5 +2,6 @@
 <configuration>
   <appSettings>
     <add key="Halibut.LogControlMessages" value="false"/>
+    <add key="Halibut.LogBsonPayloadBytes" value="false"/>
   </appSettings>
 </configuration>

--- a/source/Halibut.SamplePolling/App.config
+++ b/source/Halibut.SamplePolling/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Halibut.LogControlMessages" value="false"/>
-    <add key="Halibut.LogBsonPayloadBytes" value="false"/>
+    <add key="Halibut.LogControlMessages" value="true"/>
+    <add key="Halibut.LogBsonPayloadBytes" value="true"/>
   </appSettings>
 </configuration>

--- a/source/Halibut.Tests/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/ConnectionManagerFixture.cs
@@ -19,7 +19,7 @@ namespace Halibut.Tests
         public void SetUp()
         {
             var stream = Substitute.For<IMessageExchangeStream>();
-            connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, new MessageExchangeProtocol(stream));
+            connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, new MessageExchangeProtocol(stream, Substitute.For<ILog>()));
             connectionFactory = Substitute.For<IConnectionFactory>();
             connectionFactory.EstablishNewConnection(Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>()).Returns(connection);
         }

--- a/source/Halibut.Tests/MessageExchangeStreamFixture.cs
+++ b/source/Halibut.Tests/MessageExchangeStreamFixture.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class MessageExchangeStreamFixture
+    {
+        readonly ILog nullLog = Substitute.For<ILog>();
+        
+        [Test]
+        public void AStringCanBeRoundTripped()
+        {
+            WithLinkedStreams((a, b) =>
+            {
+                a.Send("This is the message");
+                b.Receive<string>().Should().Be("This is the message");
+            });
+        }
+
+        [Test]
+        public void ALongCanBeRoundTripped()
+        {
+            WithLinkedStreams((a, b) =>
+            {
+                a.Send(4L);
+                b.Receive<long>().Should().Be(4);
+            });
+        }
+
+        [Test]
+        public void AnObjectCanBeRoundTripped()
+        {
+            WithLinkedStreams((a, b) =>
+            {
+                a.Send(new Person{ Name = "Octobob", Age = 30 });
+                var actual = b.Receive<Person>();
+
+                actual.Name.Should().Be("Octobob");
+                actual.Age.Should().Be(30);
+            });
+        }
+
+        [Test]
+        public void AnExceptionIsThrownIfEndIsReceivedUnexpectedly()
+        {
+            WithLinkedStreams((a, b) =>
+            {
+                a.SendEnd();
+                b.Invoking(x => x.Receive<string>())
+                    .ShouldThrow<HalibutClientException>()
+                    .WithMessage("Connection ended by remote. This can occur if the remote shut down while a request was in process.");
+            });
+        }
+
+        [Test]
+        public void AnExceptionIsThrownIfAControlMessageIsReceivedUnexpectedly()
+        {
+            WithLinkedStreams((a, b) =>
+            {
+                a.SendNext();
+                b.Invoking(x => x.Receive<string>())
+                    .ShouldThrow<HalibutClientException>()
+                    .WithMessage("Data format error: expected deflated bson message, but got control message 'NEXT'");
+            });
+        }
+
+        /// <summary>
+        /// Creates two streams, where writing to one end writes the bytes into the buffer
+        /// of the other stream. Simulates a pair of connected network streams.
+        /// </summary>
+        void WithLinkedStreams(Action<MessageExchangeStream, MessageExchangeStream> action)
+        {
+            var underlyingStream1 = new LinkedStream();
+            var underlyingStream2 = new LinkedStream();
+
+            underlyingStream1.Other = underlyingStream2;
+            underlyingStream2.Other = underlyingStream1;
+
+            using (underlyingStream1)
+            using (underlyingStream2)
+            {
+                var mxStream1 = new MessageExchangeStream(underlyingStream1, nullLog);
+                var mxStream2 = new MessageExchangeStream(underlyingStream2, nullLog);
+                action(mxStream1, mxStream2);
+            }
+        }
+
+        class Person
+        {
+            public string Name { get; set; }
+            
+            public int Age { get; set; }
+        }
+        
+        class LinkedStream : Stream
+        {
+            public LinkedStream Other = null;
+
+            readonly MemoryStream inner = new MemoryStream();
+            
+            public override void Flush()
+            {
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return inner.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                inner.SetLength(value);
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                return inner.Read(buffer, offset, count);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                var pos = Other.inner.Position;
+                Other.inner.Write(buffer, offset, count);
+                Other.inner.Position = pos;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => true;
+            public override bool CanWrite => true;
+            public override long Length => inner.Length;
+
+            public override long Position
+            {
+                get => inner.Position;
+                set => inner.Position = value;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                inner?.Dispose();
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests
         {
             stream = new DumpStream();
             stream.SetRemoteIdentity(new RemoteIdentity(RemoteIdentityType.Server));
-            protocol = new MessageExchangeProtocol(stream);
+            protocol = new MessageExchangeProtocol(stream, Substitute.For<ILog>());
         }
 
         [Test]

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -475,6 +475,7 @@ namespace Halibut.Transport.Protocol
     {
         public MessageExchangeProtocol(Stream stream, Halibut.Diagnostics.ILog log) { }
         public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream) { }
+        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream, Halibut.Diagnostics.ILog log) { }
         public void EndCommunicationWithServer() { }
         public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
         public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -482,6 +482,7 @@ namespace Halibut.Transport.Protocol
     {
         public MessageExchangeProtocol(Stream stream, Halibut.Diagnostics.ILog log) { }
         public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream) { }
+        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream, Halibut.Diagnostics.ILog log) { }
         public void EndCommunicationWithServer() { }
         public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
         public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -45,7 +45,7 @@ namespace Halibut.Tests
             for (int i = 0; i < HalibutLimits.RetryCountLimit; i++)
             {
                 var connection = Substitute.For<IConnection>();
-                connection.Protocol.Returns(new MessageExchangeProtocol(stream));
+                connection.Protocol.Returns(new MessageExchangeProtocol(stream, Substitute.For<ILog>()));
                 connectionManager.ReleaseConnection(endpoint, connection);
             }
 

--- a/source/Halibut.Tests/Util/CaptureReadStreamFixture.cs
+++ b/source/Halibut.Tests/Util/CaptureReadStreamFixture.cs
@@ -1,0 +1,73 @@
+﻿using System.IO;
+using System.Text;
+using FluentAssertions;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Util
+{
+    public class CaptureReadStreamFixture
+    {
+        static readonly string LoremIpsum = 
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod " +
+            "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, " +
+            "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo " +
+            "consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse " +
+            "cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non " +
+            "proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+        static readonly byte[] LoremIpsumAsBytes = Encoding.ASCII.GetBytes(LoremIpsum);
+
+        [Test]
+        public void CapturesTheFirstBytes()
+        {
+            using (var inner = new MemoryStream(LoremIpsumAsBytes))
+            using (var capture = new CaptureReadStream(inner, 11))
+            using (var outer = new StreamReader(capture))
+            {
+                outer.ReadToEnd();
+
+                capture.GetBytes().Length.Should().Be(11);
+                Encoding.ASCII.GetString(capture.GetBytes()).Should().Be("Lorem ipsum");
+            }
+        }
+
+        [Test]
+        public void OnlyCapturesUpToTheSpecifiedCapacity()
+        {
+            using (var inner = new MemoryStream(LoremIpsumAsBytes))
+            using (var capture = new CaptureReadStream(inner, 32))
+            using (var outer = new StreamReader(capture))
+            {
+                outer.ReadToEnd();
+                capture.GetBytes().Length.Should().Be(32);
+            }
+        }
+
+        [Test]
+        public void DoesntPreventReadingMoreBytesThanTheBufferCanHold()
+        {
+            using (var inner = new MemoryStream(LoremIpsumAsBytes))
+            using (var capture = new CaptureReadStream(inner, 32))
+            using (var outer = new StreamReader(capture))
+            {
+                outer.ReadToEnd().Should().Be(LoremIpsum);
+            }
+        }
+
+        [Test]
+        public void CanHandleInputStreamThatAreShorterThanTheBuffer()
+        {
+            var shortLoremIpsum = LoremIpsum.Substring(0, 16);
+            var shortLoremIpsumAsBytes = Encoding.ASCII.GetBytes(shortLoremIpsum);
+            
+            using (var inner = new MemoryStream(shortLoremIpsumAsBytes))
+            using (var capture = new CaptureReadStream(inner, 32))
+            using (var outer = new StreamReader(capture))
+            {
+                outer.ReadToEnd().Should().Be(shortLoremIpsum);
+                capture.GetBytes().Should().Equal(shortLoremIpsumAsBytes);
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/CaptureWriteStreamFixture.cs
+++ b/source/Halibut.Tests/Util/CaptureWriteStreamFixture.cs
@@ -1,0 +1,78 @@
+﻿using System.IO;
+using System.Text;
+using FluentAssertions;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Util
+{
+    public class CaptureWriteStreamFixture
+    {
+        static readonly string LoremIpsum = 
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod " +
+            "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, " +
+            "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo " +
+            "consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse " +
+            "cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non " +
+            "proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+        static readonly byte[] LoremIpsumAsBytes = Encoding.ASCII.GetBytes(LoremIpsum);
+
+        [Test]
+        public void CapturesTheFirstBytes()
+        {
+            using (var inner = new MemoryStream())
+            using (var capture = new CaptureWriteStream(inner, 11))
+            using (var outer = new StreamWriter(capture))
+            {
+                outer.Write(LoremIpsum);
+                outer.Flush();
+
+                capture.GetBytes().Length.Should().Be(11);
+                Encoding.ASCII.GetString(capture.GetBytes()).Should().Be("Lorem ipsum");
+            }
+        }
+
+        [Test]
+        public void OnlyCapturesUpToTheSpecifiedCapacity()
+        {
+            using (var inner = new MemoryStream())
+            using (var capture = new CaptureWriteStream(inner, 32))
+            using (var outer = new StreamWriter(capture))
+            {
+                outer.Write(LoremIpsum);
+                outer.Flush();
+                capture.GetBytes().Length.Should().Be(32);
+            }
+        }
+
+        [Test]
+        public void DoesntPreventWritingMoreBytesThanTheBufferCanHold()
+        {
+            using (var inner = new MemoryStream())
+            using (var capture = new CaptureWriteStream(inner, 32))
+            using (var outer = new StreamWriter(capture))
+            {
+                outer.Write(LoremIpsum);
+                outer.Flush();
+                inner.Length.Should().Be(LoremIpsumAsBytes.Length);
+            }
+        }
+
+        [Test]
+        public void CanHandleStreamsThatAreShorterThanTheBuffer()
+        {
+            var shortLoremIpsum = LoremIpsum.Substring(0, 16);
+            var shortLoremIpsumAsBytes = Encoding.ASCII.GetBytes(shortLoremIpsum);
+            
+            using (var inner = new MemoryStream())
+            using (var capture = new CaptureWriteStream(inner, 32))
+            using (var outer = new StreamWriter(capture))
+            {
+                outer.Write(shortLoremIpsum);
+                outer.Flush();
+                capture.GetBytes().Should().Equal(shortLoremIpsumAsBytes);
+            }
+        }
+    }
+}

--- a/source/Halibut/Diagnostics/HalibutLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutLimits.cs
@@ -32,6 +32,11 @@ namespace Halibut.Diagnostics
         public static bool LogControlMessages = false;
         
         /// <summary>
+        /// If set to true, Halibut will log the bytes of BSON paylods that are sent and received.
+        /// </summary>
+        public static bool LogBsonPayloadBytes = false;
+        
+        /// <summary>
         /// The default amount of time the client will wait for the server to collect a message from the
         /// polling request queue before raising a TimeoutException. Can be overridden via the ServiceEndPoint.
         /// </summary>

--- a/source/Halibut/Diagnostics/HalibutLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutLimits.cs
@@ -14,11 +14,23 @@ namespace Halibut.Diagnostics
             {
                 var value = settings.Get("Halibut." + field.Name);
                 if (string.IsNullOrWhiteSpace(value)) continue;
-                var time = TimeSpan.Parse(value);
-                field.SetValue(null, time);
+
+                if (field.FieldType == typeof(TimeSpan))
+                {
+                    field.SetValue(null, TimeSpan.Parse(value));
+                }
+                else if (field.FieldType == typeof(bool))
+                {
+                    field.SetValue(null, Convert.ToBoolean(value));
+                }
             }
         }
 
+        /// <summary>
+        /// If set to true, Halibut will log the control messages that are sent and received.
+        /// </summary>
+        public static bool LogControlMessages = false;
+        
         /// <summary>
         /// The default amount of time the client will wait for the server to collect a message from the
         /// polling request queue before raising a TimeoutException. Can be overridden via the ServiceEndPoint.

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -23,9 +23,16 @@ namespace Halibut.Transport.Protocol
             this.log = log;
         }
 
+        [Obsolete("Please use the overload where you pass an ILog")]
         public MessageExchangeProtocol(IMessageExchangeStream stream)
         {
             this.stream = stream;
+        }
+
+        public MessageExchangeProtocol(IMessageExchangeStream stream, ILog log)
+        {
+            this.stream = stream;
+            this.log = log;
         }
 
         public ResponseMessage ExchangeAsClient(RequestMessage request)

--- a/source/Halibut/Util/CaptureReadStream.cs
+++ b/source/Halibut/Util/CaptureReadStream.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Halibut.Util
+{
+    class CaptureReadStream : Stream
+    {
+        readonly Stream inner;
+        readonly int maxBytesToCapture;
+        readonly List<byte> bytes;
+
+        public CaptureReadStream(Stream inner, int maxBytesToCapture)
+        {
+            this.inner = inner;
+            this.maxBytesToCapture = maxBytesToCapture;
+            bytes = new List<byte>(maxBytesToCapture);
+        }
+
+        public byte[] GetBytes() => bytes.ToArray();
+
+        public override void Flush()
+        {
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var bytesRead = inner.Read(buffer, offset, count);
+            var spaceRemainingInBuffer = maxBytesToCapture - bytes.Count;
+            var numBytesToCopyToCapture = Math.Min(bytesRead, spaceRemainingInBuffer);
+
+            if (numBytesToCopyToCapture > 0)
+            {
+                bytes.AddRange(buffer.Skip(offset).Take(numBytesToCopyToCapture));
+            }
+
+            return bytesRead;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException($"{nameof(CaptureReadStream)} does not support seeking.");
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException($"{nameof(CaptureReadStream)} is intended for read-only streams.");
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException($"{nameof(CaptureReadStream)} is intended for read-only streams.");
+        }
+
+        public override bool CanRead => inner.CanRead;
+
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => throw new NotSupportedException($"{nameof(CaptureReadStream)} is intended for read-only streams.");
+        }
+    }
+}

--- a/source/Halibut/Util/CaptureWriteStream.cs
+++ b/source/Halibut/Util/CaptureWriteStream.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Halibut.Util
+{
+    class CaptureWriteStream : Stream
+    {
+        readonly Stream inner;
+        readonly int maxBytesToCapture;
+        readonly List<byte> bytes;
+
+        public CaptureWriteStream(Stream inner, int maxBytesToCapture)
+        {
+            this.inner = inner;
+            this.maxBytesToCapture = maxBytesToCapture;
+            bytes = new List<byte>(maxBytesToCapture);
+        }
+
+        public byte[] GetBytes() => bytes.ToArray();
+
+        public override void Flush()
+        {
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException($"{nameof(CaptureWriteStream)} is intended for write-only streams.");
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException($"{nameof(CaptureReadStream)} does not support seeking.");
+        }
+
+        public override void SetLength(long value)
+        {
+            inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            inner.Write(buffer, offset, count);
+            
+            var spaceRemainingInBuffer = maxBytesToCapture - bytes.Count;
+            var numBytesToCopyToCapture = Math.Min(count, spaceRemainingInBuffer);
+
+            if (numBytesToCopyToCapture > 0)
+            {
+                bytes.AddRange(buffer.Skip(offset).Take(numBytesToCopyToCapture));
+            }
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => throw new NotSupportedException($"{nameof(CaptureReadStream)} is intended for write-only streams.");
+        }
+    }
+}


### PR DESCRIPTION
When polling clients (tentacles) disconnect, the server can end up getting an error that implies a comms error:

```
The step failed: Activity Run a Script on EC2AMAZ-25701AL-Polling failed with error 'The archive entry was compressed using an unsupported compression method. Server exception: System.IO.InvalidDataException: The archive entry was compressed using an unsupported compression method.
  at System.IO.Compression.Inflater.Inflate(FlushCode flushCode)
  at System.IO.Compression.Inflater.ReadInflateOutput(Byte* bufPtr, Int32 length, FlushCode flushCode, Int32& bytesRead)
  at System.IO.Compression.Inflater.ReadOutput(Byte* bufPtr, Int32 length, Int32& bytesRead)
  at System.IO.Compression.Inflater.InflateVerified(Byte* bufPtr, Int32 length)
  at System.IO.Compression.DeflateStream.ReadCore(Span`1 buffer)
  at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
  at System.IO.BinaryReader.InternalRead(Int32 numBytes)
  at System.IO.BinaryReader.ReadInt32()
  at Newtonsoft.Json.Bson.BsonDataReader.ReadNormal()
  at Newtonsoft.Json.Bson.BsonDataReader.Read()
  at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
  at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
  at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
  at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
  at Halibut.Transport.Protocol.MessageExchangeStream.ReadBsonMessage[T]()
  at Halibut.Transport.Protocol.MessageExchangeStream.Receive[T]()
  at Halibut.Transport.Protocol.MessageExchangeProtocol.ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest)'.
```
This has been tracked to:
* a clean shutdown of the server
* which sends an `END` control message
* which in common use cases, the `MessageExchangeProtocol` isn't expecting, as it's actually expecting a expected deflated bson message

This is a WIP PR that throws a nicer error when this happens.

In Octopus server, due to timing, this can manifest as:
* a failed task with a message `Connection ended by remote`
* a task that has an apparent pause in the middle (if the tentacle comes back on line within the timeout (usually 2 minutes))
* a task that fails with a polling timeout (if the tentacle doesn't come back online)

Still outstanding:
 - [ ] tests for this scenario
 - [ ] improve the `BufferedReadStream` so that it doesn't buffer the whole message, just the first 10? 100? characters.
 - [ ] perf and memory tests
 - [ ] disable the logging of bytes & json by default, but allow it to be enabled for diagnostics