### PR TITLE
Securing the Protocol

### DIFF
--- a/source/Halibut.Tests/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/DiscoveryClientFixture.cs
@@ -1,6 +1,5 @@
 using System;
 using FluentAssertions;
-using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using Halibut.Transport;
@@ -8,7 +7,7 @@ using NUnit.Framework;
 
 namespace Halibut.Tests
 {
-    public class DiscoveryClientFixture : IDisposable
+    public class DiscoveryClientFixture
     {
         ServiceEndPoint endpoint;
         HalibutRuntime tentacle;
@@ -27,11 +26,11 @@ namespace Halibut.Tests
             };
         }
 
-        public void Dispose()
+        [TearDown]
+        public void TearDown()
         {
             tentacle.Dispose();
         }
-
 
         [Test]
         public void DiscoverMethodReturnsEndpointDetails()

--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests
         {
             stream = new DumpStream();
             stream.SetRemoteIdentity(new RemoteIdentity(RemoteIdentityType.Server));
-            protocol = new MessageExchangeProtocol(stream);
+            protocol = new MessageExchangeProtocol(stream, Substitute.For<ILog>());
         }
 
         [Test]
@@ -344,7 +344,7 @@ namespace Halibut.Tests
                 numberOfReads = reads;
             }
 
-            public List<object> Sent { get; set; }
+            public List<object> Sent { get; }
 
             public void IdentifyAsClient()
             {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -669,3 +669,11 @@ namespace Halibut.Transport.Proxy.Exceptions
         protected ProxyException(SerializationInfo info, StreamingContext context) { }
     }
 }
+namespace Halibut.Util
+{
+    public static class TypeExtensionMethods
+    {
+        public static bool AllowedOnHalibutInterface(Type type) { }
+        public static IEnumerable<MethodInfo> GetHalibutServiceMethods(Type serviceType) { }
+    }
+}

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -260,6 +260,7 @@ namespace Halibut.ServiceModel
     public class DelegateServiceFactory : Halibut.ServiceModel.IServiceFactory
     {
         public DelegateServiceFactory() { }
+        public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
         public void Register<TContract>(Func<TContract> implementation) { }
     }
@@ -283,6 +284,7 @@ namespace Halibut.ServiceModel
     }
     public interface IServiceFactory
     {
+        public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
     }
     public interface IServiceInvoker
@@ -304,6 +306,7 @@ namespace Halibut.ServiceModel
     public class NullServiceFactory : Halibut.ServiceModel.IServiceFactory
     {
         public NullServiceFactory() { }
+        public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
     }
     public class PendingRequestQueue : Halibut.ServiceModel.IPendingRequestQueue
@@ -322,6 +325,10 @@ namespace Halibut.ServiceModel
         public void Add(Halibut.Transport.PollingClient pollingClient) { }
         public void Dispose() { }
     }
+    public static class ServiceFactoryExtensionMethods
+    {
+        public static Halibut.Transport.Protocol.ExchangeProtocolBuilder ExchangeProtocolBuilder(Halibut.ServiceModel.IServiceFactory factory) { }
+    }
     public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
     {
         public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
@@ -334,8 +341,8 @@ namespace Halibut.Transport
     {
         public ConnectionManager() { }
         public bool IsDisposed { get; }
-        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
         public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
@@ -363,8 +370,8 @@ namespace Halibut.Transport
     }
     public interface IConnectionFactory
     {
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -374,8 +381,8 @@ namespace Halibut.Transport
     public interface ISecureClient
     {
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, System.Threading.CancellationToken cancellationToken) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
     {
@@ -388,14 +395,14 @@ namespace Halibut.Transport
     public class SecureClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
+        public SecureClient(Halibut.Transport.Protocol.ExchangeProtocolBuilder protocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, System.Threading.CancellationToken cancellationToken) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SecureConnection : Halibut.Transport.IConnection, Halibut.Transport.IPooledResource, IDisposable
     {
-        public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+        public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Diagnostics.ILog log) { }
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
         public void Dispose() { }
         public bool HasExpired() { }
@@ -403,22 +410,18 @@ namespace Halibut.Transport
     }
     public class SecureListener : IDisposable
     {
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
         public void Disconnect(string thumbprint) { }
         public void Dispose() { }
         public int Start() { }
     }
     public class SecureWebSocketListener : IDisposable
     {
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
         public void Dispose() { }
         public void Start() { }
     }
@@ -432,8 +435,8 @@ namespace Halibut.Transport
     public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
     {
         public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
     }
 }
 namespace Halibut.Transport.Protocol
@@ -443,6 +446,27 @@ namespace Halibut.Transport.Protocol
         public ConnectionInitializationFailedException(string message) { }
         public ConnectionInitializationFailedException(string message, Exception innerException) { }
         public ConnectionInitializationFailedException(Exception innerException) { }
+    }
+    public sealed class ExchangeAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExchangeAction(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol, AsyncCallback callback, Object @object) { }
+        public void EndInvoke(IAsyncResult result) { }
+        public void Invoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+    }
+    public sealed class ExchangeActionAsync : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExchangeActionAsync(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol, AsyncCallback callback, Object @object) { }
+        public Task EndInvoke(IAsyncResult result) { }
+        public Task Invoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+    }
+    public sealed class ExchangeProtocolBuilder : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExchangeProtocolBuilder(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Stream stream, Halibut.Diagnostics.ILog log, AsyncCallback callback, Object @object) { }
+        public Halibut.Transport.Protocol.MessageExchangeProtocol EndInvoke(IAsyncResult result) { }
+        public Halibut.Transport.Protocol.MessageExchangeProtocol Invoke(Stream stream, Halibut.Diagnostics.ILog log) { }
     }
     public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
     {
@@ -473,8 +497,7 @@ namespace Halibut.Transport.Protocol
     }
     public class MessageExchangeProtocol
     {
-        public MessageExchangeProtocol(Stream stream, Halibut.Diagnostics.ILog log) { }
-        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream) { }
+        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream, Halibut.Diagnostics.ILog log) { }
         public void EndCommunicationWithServer() { }
         public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
         public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
@@ -484,8 +507,8 @@ namespace Halibut.Transport.Protocol
     }
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
     {
-        public static Func<Newtonsoft.Json.JsonSerializer> Serializer;
-        public MessageExchangeStream(Stream stream, Halibut.Diagnostics.ILog log) { }
+        public static Func<IEnumerable<Type>, Newtonsoft.Json.JsonSerializer> Serializer;
+        public MessageExchangeStream(Stream stream, IEnumerable<Type> registeredServiceTypes, Halibut.Diagnostics.ILog log) { }
         public bool ExpectNextOrEnd() { }
         public Task<bool> ExpectNextOrEndAsync() { }
         public void ExpectProceeed() { }
@@ -503,6 +526,12 @@ namespace Halibut.Transport.Protocol
     public class ProtocolException : Exception, ISerializable
     {
         public ProtocolException(string message) { }
+    }
+    public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.ISerializationBinder
+    {
+        public RegisteredSerializationBinder(IEnumerable<Type> registeredServiceTypes) { }
+        public void BindToName(Type serializedType, String& assemblyName, String& typeName) { }
+        public Type BindToType(string assemblyName, string typeName) { }
     }
     public class RemoteIdentity
     {
@@ -565,6 +594,12 @@ namespace Halibut.Transport.Protocol
         protected void Finalize() { }
         public void Read(Action<Stream> reader) { }
         public void SaveTo(string filePath) { }
+    }
+    public class TypeNotAllowedException : Exception, ISerializable
+    {
+        public TypeNotAllowedException(Type type, string path) { }
+        public Type DisallowedType { get; }
+        public string Path { get; }
     }
     public class WebSocketStream : Stream, IDisposable
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -676,3 +676,11 @@ namespace Halibut.Transport.Proxy.Exceptions
         protected ProxyException(SerializationInfo info, StreamingContext context) { }
     }
 }
+namespace Halibut.Util
+{
+    public static class TypeExtensionMethods
+    {
+        public static bool AllowedOnHalibutInterface(Type type) { }
+        public static IEnumerable<MethodInfo> GetHalibutServiceMethods(Type serviceType) { }
+    }
+}

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -260,6 +260,7 @@ namespace Halibut.ServiceModel
     public class DelegateServiceFactory : Halibut.ServiceModel.IServiceFactory
     {
         public DelegateServiceFactory() { }
+        public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
         public void Register<TContract>(Func<TContract> implementation) { }
     }
@@ -276,6 +277,7 @@ namespace Halibut.ServiceModel
     }
     public interface IServiceFactory
     {
+        public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
     }
     public interface IServiceInvoker
@@ -297,6 +299,7 @@ namespace Halibut.ServiceModel
     public class NullServiceFactory : Halibut.ServiceModel.IServiceFactory
     {
         public NullServiceFactory() { }
+        public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
     }
     public class PendingRequestQueue : Halibut.ServiceModel.IPendingRequestQueue
@@ -315,6 +318,10 @@ namespace Halibut.ServiceModel
         public void Add(Halibut.Transport.PollingClient pollingClient) { }
         public void Dispose() { }
     }
+    public static class ServiceFactoryExtensionMethods
+    {
+        public static Halibut.Transport.Protocol.ExchangeProtocolBuilder ExchangeProtocolBuilder(Halibut.ServiceModel.IServiceFactory factory) { }
+    }
     public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
     {
         public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
@@ -327,8 +334,8 @@ namespace Halibut.Transport
     {
         public ConnectionManager() { }
         public bool IsDisposed { get; }
-        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection AcquireConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.IConnectionFactory connectionFactory, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
         public void ClearPooledConnections(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Disconnect(Halibut.ServiceEndPoint serviceEndPoint, Halibut.Diagnostics.ILog log) { }
         public void Dispose() { }
@@ -356,8 +363,8 @@ namespace Halibut.Transport
     }
     public interface IConnectionFactory
     {
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
     }
     public interface IPooledResource : IDisposable
     {
@@ -367,8 +374,8 @@ namespace Halibut.Transport
     public interface ISecureClient
     {
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, System.Threading.CancellationToken cancellationToken) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler, System.Threading.CancellationToken cancellationToken) { }
     }
     public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
     {
@@ -381,14 +388,14 @@ namespace Halibut.Transport
     public class SecureClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
+        public SecureClient(Halibut.Transport.Protocol.ExchangeProtocolBuilder protocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, System.Threading.CancellationToken cancellationToken) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SecureConnection : Halibut.Transport.IConnection, Halibut.Transport.IPooledResource, IDisposable
     {
-        public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+        public SecureConnection(IDisposable client, Stream stream, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Diagnostics.ILog log) { }
         public Halibut.Transport.Protocol.MessageExchangeProtocol Protocol { get; }
         public void Dispose() { }
         public bool HasExpired() { }
@@ -396,11 +403,9 @@ namespace Halibut.Transport
     }
     public class SecureListener : IDisposable
     {
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
         public void Disconnect(string thumbprint) { }
         public void Dispose() { }
         public int Start() { }
@@ -408,18 +413,16 @@ namespace Halibut.Transport
     public class SecureWebSocketClient : Halibut.Transport.ISecureClient
     {
         public static int RetryCountLimit;
-        public SecureWebSocketClient(Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
+        public SecureWebSocketClient(Halibut.Transport.Protocol.ExchangeProtocolBuilder protocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, Halibut.Diagnostics.ILog log, Halibut.Transport.ConnectionManager connectionManager) { }
         public Halibut.ServiceEndPoint ServiceEndpoint { get; }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler) { }
-        public void ExecuteTransaction(Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, System.Threading.CancellationToken cancellationToken) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler) { }
+        public void ExecuteTransaction(Halibut.Transport.Protocol.ExchangeAction protocolHandler, System.Threading.CancellationToken cancellationToken) { }
     }
     public class SecureWebSocketListener : IDisposable
     {
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<Halibut.Transport.Protocol.MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<Halibut.Transport.Protocol.MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders) { }
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.Transport.Protocol.ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, Halibut.Diagnostics.ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, Halibut.UnauthorizedClientConnectResponse> unauthorizedClientConnect) { }
         public void Dispose() { }
         public void Start() { }
     }
@@ -433,14 +436,14 @@ namespace Halibut.Transport
     public class TcpConnectionFactory : Halibut.Transport.IConnectionFactory
     {
         public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
     }
     public class WebSocketConnectionFactory : Halibut.Transport.IConnectionFactory
     {
         public WebSocketConnectionFactory(X509Certificate2 clientCertificate) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
-        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
+        public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
     }
 }
 namespace Halibut.Transport.Protocol
@@ -450,6 +453,27 @@ namespace Halibut.Transport.Protocol
         public ConnectionInitializationFailedException(string message) { }
         public ConnectionInitializationFailedException(string message, Exception innerException) { }
         public ConnectionInitializationFailedException(Exception innerException) { }
+    }
+    public sealed class ExchangeAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExchangeAction(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol, AsyncCallback callback, Object @object) { }
+        public void EndInvoke(IAsyncResult result) { }
+        public void Invoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+    }
+    public sealed class ExchangeActionAsync : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExchangeActionAsync(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol, AsyncCallback callback, Object @object) { }
+        public Task EndInvoke(IAsyncResult result) { }
+        public Task Invoke(Halibut.Transport.Protocol.MessageExchangeProtocol protocol) { }
+    }
+    public sealed class ExchangeProtocolBuilder : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExchangeProtocolBuilder(Object @object, IntPtr method) { }
+        public IAsyncResult BeginInvoke(Stream stream, Halibut.Diagnostics.ILog log, AsyncCallback callback, Object @object) { }
+        public Halibut.Transport.Protocol.MessageExchangeProtocol EndInvoke(IAsyncResult result) { }
+        public Halibut.Transport.Protocol.MessageExchangeProtocol Invoke(Stream stream, Halibut.Diagnostics.ILog log) { }
     }
     public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
     {
@@ -480,8 +504,7 @@ namespace Halibut.Transport.Protocol
     }
     public class MessageExchangeProtocol
     {
-        public MessageExchangeProtocol(Stream stream, Halibut.Diagnostics.ILog log) { }
-        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream) { }
+        public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream, Halibut.Diagnostics.ILog log) { }
         public void EndCommunicationWithServer() { }
         public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
         public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
@@ -491,8 +514,8 @@ namespace Halibut.Transport.Protocol
     }
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
     {
-        public static Func<Newtonsoft.Json.JsonSerializer> Serializer;
-        public MessageExchangeStream(Stream stream, Halibut.Diagnostics.ILog log) { }
+        public static Func<IEnumerable<Type>, Newtonsoft.Json.JsonSerializer> Serializer;
+        public MessageExchangeStream(Stream stream, IEnumerable<Type> registeredServiceTypes, Halibut.Diagnostics.ILog log) { }
         public bool ExpectNextOrEnd() { }
         public Task<bool> ExpectNextOrEndAsync() { }
         public void ExpectProceeed() { }
@@ -510,6 +533,12 @@ namespace Halibut.Transport.Protocol
     public class ProtocolException : Exception, ISerializable, _Exception
     {
         public ProtocolException(string message) { }
+    }
+    public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.ISerializationBinder
+    {
+        public RegisteredSerializationBinder(IEnumerable<Type> registeredServiceTypes) { }
+        public void BindToName(Type serializedType, String& assemblyName, String& typeName) { }
+        public Type BindToType(string assemblyName, string typeName) { }
     }
     public class RemoteIdentity
     {
@@ -572,6 +601,12 @@ namespace Halibut.Transport.Protocol
         protected void Finalize() { }
         public void Read(Action<Stream> reader) { }
         public void SaveTo(string filePath) { }
+    }
+    public class TypeNotAllowedException : Exception, ISerializable, _Exception
+    {
+        public TypeNotAllowedException(Type type, string path) { }
+        public Type DisallowedType { get; }
+        public string Path { get; }
     }
     public class WebSocketStream : Stream, IDisposable
     {

--- a/source/Halibut.Tests/RegisteredSerializationBinderFixture.cs
+++ b/source/Halibut.Tests/RegisteredSerializationBinderFixture.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Transport.Protocol;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class RegisteredSerializationBinderFixture
+    {
+        public class ExampleProperties
+        {
+            public string Field;
+            
+            public string PropertyGet { get; set; }
+            
+            public string PropertyGetSet { get; set; }
+        }
+
+        public class ExampleWithObject
+        {
+            public string PropertyGetSet { get; set; }
+            
+            public object ObjectProperty  { get; set; }
+        }
+
+        public interface IHaveBase
+        {
+            float BaseMethod();
+        }
+        
+        public interface IExampleService : IHaveBase
+        {
+            bool SimpleMethod(int port);
+
+            string TupleMethod(Tuple<string, int> good);
+
+            ExampleProperties ReturnComplex();
+
+            void TakeComplex(ExampleProperties props);
+        }
+
+        public interface IAsyncService
+        { 
+            Task<string> GetAsync();
+        }
+
+        public interface IObjectResultSerice
+        {
+            object GetMeSomething();
+        }
+        
+        public interface IObjectPropertyService
+        {
+            void DoSomething(object data);
+        }
+
+        public interface IObjectExampleService
+        {
+            string DoThis(ExampleWithObject example);
+        }
+        
+        [Test]
+        public void BindMethods_WithValidClass_FindsAllMethodTypes()
+        {
+            var binder = new RegisteredSerializationBinder(new[] { typeof(IExampleService) });
+            binder.BindToName(typeof(ExampleProperties), out var assemblyName, out var typeName);
+            var t = binder.BindToType(assemblyName, typeName);
+            t.Should().Be(typeof(ExampleProperties));
+        }
+
+        [TestCase(typeof(IAsyncService))]
+        [TestCase(typeof(IObjectResultSerice))]
+        [TestCase(typeof(IObjectPropertyService))]
+        [TestCase(typeof(IObjectExampleService))]
+        public void Constructor_WithInvalidTypes_WillThrow(params Type[] types)
+        {
+            Assert.Throws<TypeNotAllowedException>(() => { _ = new RegisteredSerializationBinder(types); });
+        }
+    }
+}

--- a/source/Halibut.Tests/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/SecureListenerFixture.cs
@@ -37,7 +37,7 @@ namespace Halibut.Tests
         
         [Test]
         [WindowsTest]
-        public void SecureListenerDoesNotCreateHundredsOfIOEventsPerSecondOnWindows()
+        public void SecureListenerDoesNotCreateHundredsOfIoEventsPerSecondOnWindows()
         {
             const int secondsToSample = 5;
 
@@ -46,7 +46,8 @@ namespace Halibut.Tests
                 var client = new SecureListener(
                     new IPEndPoint(new IPAddress(new byte[]{ 127, 0, 0, 1 }), 1093), 
                     Certificates.TentacleListening,
-                    p => { },
+                    null,
+                    null,
                     thumbprint => true,
                     new LogFactory(), 
                     () => ""

--- a/source/Halibut/ServiceModel/DelegateServiceFactory.cs
+++ b/source/Halibut/ServiceModel/DelegateServiceFactory.cs
@@ -1,15 +1,19 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Halibut.ServiceModel
 {
     public class DelegateServiceFactory : IServiceFactory
     {
         readonly Dictionary<string, Func<object>> services = new Dictionary<string, Func<object>>(StringComparer.OrdinalIgnoreCase);
+        readonly HashSet<Type> serviceTypes = new HashSet<Type>();
 
         public void Register<TContract>(Func<TContract> implementation)
         {
-            services.Add(typeof(TContract).Name, () => implementation());
+            var serviceType = typeof(TContract);
+            services.Add(serviceType.Name, () => implementation());
+            serviceTypes.Add(serviceType);
         }
 
         public IServiceLease CreateService(string serviceName)
@@ -34,6 +38,8 @@ namespace Halibut.ServiceModel
             var service = serviceBuilder();
             return new Lease(service);
         }
+        
+        public IReadOnlyList<Type> RegisteredServiceTypes => serviceTypes.ToList();
 
         #region Nested type: Lease
 

--- a/source/Halibut/ServiceModel/IServiceFactory.cs
+++ b/source/Halibut/ServiceModel/IServiceFactory.cs
@@ -1,9 +1,21 @@
 using System;
+using System.Collections.Generic;
+using Halibut.Transport.Protocol;
 
 namespace Halibut.ServiceModel
 {
     public interface IServiceFactory
     {
         IServiceLease CreateService(string serviceName);
+
+        IReadOnlyList<Type> RegisteredServiceTypes { get; }
+    }
+
+    public static class ServiceFactoryExtensionMethods
+    {
+        public static ExchangeProtocolBuilder ExchangeProtocolBuilder(this IServiceFactory factory)
+        {
+            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, factory.RegisteredServiceTypes, log), log);
+        }
     }
 }

--- a/source/Halibut/ServiceModel/NullServiceFactory.cs
+++ b/source/Halibut/ServiceModel/NullServiceFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Halibut.ServiceModel
 {
@@ -8,5 +9,7 @@ namespace Halibut.ServiceModel
         {
             throw new InvalidOperationException("An attempt was made to call the service '" + serviceName + "' on this machine, but this server has been configured to be a client only.");
         }
+
+        public IReadOnlyList<Type> RegisteredServiceTypes => new List<Type>();
     }
 }

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Net.Security;
-using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using Halibut.Diagnostics;
-using Halibut.Transport.Proxy;
 
 namespace Halibut.Transport
 {

--- a/source/Halibut/Transport/IConnectionFactory.cs
+++ b/source/Halibut/Transport/IConnectionFactory.cs
@@ -1,11 +1,12 @@
 using System.Threading;
 using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
 
 namespace Halibut.Transport
 {
     public interface IConnectionFactory
     {
-        IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log);
-        IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
+        IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log);
+        IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/ISecureClient.cs
+++ b/source/Halibut/Transport/ISecureClient.cs
@@ -7,7 +7,7 @@ namespace Halibut.Transport
     public interface ISecureClient
     {
         ServiceEndPoint ServiceEndpoint { get; }
-        void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler);
-        void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler, CancellationToken cancellationToken);
+        void ExecuteTransaction(ExchangeAction protocolHandler);
+        void ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -1,12 +1,17 @@
 using System;
 using System.IO;
-using System.Net.Sockets;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 
 namespace Halibut.Transport.Protocol
 {
+    public delegate MessageExchangeProtocol ExchangeProtocolBuilder(Stream stream, ILog log);
+
+    public delegate void ExchangeAction(MessageExchangeProtocol protocol);
+
+    public delegate Task ExchangeActionAsync(MessageExchangeProtocol protocol);
+    
     /// <summary>
     /// Implements the core message exchange protocol for both the client and server.
     /// </summary>
@@ -17,15 +22,10 @@ namespace Halibut.Transport.Protocol
         bool identified;
         volatile bool acceptClientRequests = true;
 
-        public MessageExchangeProtocol(Stream stream, ILog log)
-        {
-            this.stream = new MessageExchangeStream(stream, log);
-            this.log = log;
-        }
-
-        public MessageExchangeProtocol(IMessageExchangeStream stream)
+        public MessageExchangeProtocol(IMessageExchangeStream stream, ILog log)
         {
             this.stream = stream;
+            this.log = log;
         }
 
         public ResponseMessage ExchangeAsClient(RequestMessage request)

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -29,18 +29,18 @@ namespace Halibut.Transport.Protocol
         readonly JsonSerializer serializer;
         readonly Version currentVersion = new Version(1, 0);
 
-        public MessageExchangeStream(Stream stream, ILog log)
+        public MessageExchangeStream(Stream stream, IEnumerable<Type> registeredServiceTypes, ILog log)
         {
             this.stream = stream;
             this.log = log;
             streamWriter = new StreamWriter(stream, new UTF8Encoding(false)) { NewLine = "\r\n" };
             streamReader = new StreamReader(stream, new UTF8Encoding(false));
-            serializer = Serializer();
+            serializer = Serializer(registeredServiceTypes);
             SetNormalTimeouts();
         }
 
-        static int streamCount = 0;
-        public static Func<JsonSerializer> Serializer = CreateDefault;
+        static int streamCount;
+        public static Func<IEnumerable<Type>, JsonSerializer> Serializer = CreateDefault;
 
         public void IdentifyAsClient()
         {
@@ -214,7 +214,9 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        static JsonSerializer CreateDefault()
+        
+
+        static JsonSerializer CreateDefault(IEnumerable<Type> registeredServiceTypes)
         {
             var serializer = JsonSerializer.Create();
             serializer.Formatting = Formatting.None;
@@ -222,6 +224,7 @@ namespace Halibut.Transport.Protocol
             serializer.TypeNameHandling = TypeNameHandling.Auto;
             serializer.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
             serializer.DateFormatHandling = DateFormatHandling.IsoDateFormat;
+            serializer.SerializationBinder = new RegisteredSerializationBinder(registeredServiceTypes);
             return serializer;
         }
 
@@ -252,11 +255,11 @@ namespace Halibut.Transport.Protocol
             using (var zip = new DeflateStream(stream, CompressionMode.Decompress, true))
             using (var bson = new BsonDataReader(zip) { CloseInput = false })
             {
-                var messageEnvelope = serializer.Deserialize<MessageEnvelope>(bson);
+                var messageEnvelope = serializer.Deserialize<MessageEnvelope<T>>(bson);
                 if (messageEnvelope == null)
                     throw new Exception("messageEnvelope is null");
                 
-                return (T)messageEnvelope.Message;
+                return messageEnvelope.Message;
             }
         }
 
@@ -314,7 +317,7 @@ namespace Halibut.Transport.Protocol
             using (var zip = new DeflateStream(stream, CompressionMode.Compress, true))
             using (var bson = new BsonDataWriter(zip) { CloseOutput = false })
             {
-                serializer.Serialize(bson, new MessageEnvelope { Message = messages });
+                serializer.Serialize(bson, new MessageEnvelope<T> { Message = messages });
             }
         }
 
@@ -335,9 +338,9 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        class MessageEnvelope
+        class MessageEnvelope<T>
         {
-            public object Message { get; set; }
+            public T Message { get; set; }
         }
 
         void SetNormalTimeouts()

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -214,8 +214,6 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        
-
         static JsonSerializer CreateDefault(IEnumerable<Type> registeredServiceTypes)
         {
             var serializer = JsonSerializer.Create();
@@ -338,6 +336,8 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        // By making this a generic type, each message specifies the exact type it sends/expects
+        // And it is impossible to deserialize the wrong type - any mismatched type will refuse to deserialize
         class MessageEnvelope<T>
         {
             public T Message { get; set; }

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Serialization;
+
+namespace Halibut.Transport.Protocol
+{
+    public class TypeNotAllowedException : Exception
+    {
+        public TypeNotAllowedException(Type type, string path)
+        : base($"The type {type.Name} is not allowed on the Halibut message protocol.  Found at {path}")
+        {
+            DisallowedType = type;
+            Path = path;
+        }
+        
+        public Type DisallowedType { get; }
+        
+        public string Path { get; }
+    }
+    
+    
+    public class RegisteredSerializationBinder : ISerializationBinder
+    {
+        HashSet<Type> allowedTypes = new HashSet<Type>();
+        ISerializationBinder baseBinder = new DefaultSerializationBinder();
+        
+        public RegisteredSerializationBinder(IEnumerable<Type> registeredServiceTypes)
+        {
+            foreach (var serviceType in registeredServiceTypes)
+            {
+                var methods = serviceType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+                foreach (var method in methods.Where(x => !(x.IsSpecialName || x.DeclaringType == typeof(object))))
+                {
+                    AllowType(method.ReturnType, $"{serviceType.Name}.{method.Name}:{method.ReturnType.Name}");
+                    
+                    foreach (var param in method.GetParameters())
+                    {
+                        AllowType(param.ParameterType,$"{serviceType.Name}.{method.Name}(){param.Name}:{param.ParameterType.Name}");
+                    }
+                }
+            }
+        }
+        
+        void AllowType(Type type, string path)
+        {
+            if (type == typeof(object) || type == typeof(Task) || type == typeof(Task<>))
+            {
+                throw new TypeNotAllowedException(type, path);
+            }
+
+            if (!allowedTypes.Add(type))
+            {
+                // Seen this before, no need to go further
+                return;
+            }
+
+            if (type.IsEnum || type.IsPrimitive)
+            {
+                return;
+            }
+            
+            foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                AllowType(p.PropertyType, $"{path}.{p.Name}");
+            }
+        }
+
+        public Type BindToType(string assemblyName, string typeName)
+        {
+            var type = baseBinder.BindToType(assemblyName, typeName);
+            return allowedTypes.Contains(type) ? type : null;
+        }
+
+        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            baseBinder.BindToName(serializedType, out assemblyName, out typeName);
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -1,27 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
+using Halibut.Util;
 using Newtonsoft.Json.Serialization;
 
 namespace Halibut.Transport.Protocol
 {
-    public class TypeNotAllowedException : Exception
-    {
-        public TypeNotAllowedException(Type type, string path)
-        : base($"The type {type.Name} is not allowed on the Halibut message protocol.  Found at {path}")
-        {
-            DisallowedType = type;
-            Path = path;
-        }
-        
-        public Type DisallowedType { get; }
-        
-        public string Path { get; }
-    }
-    
-    
     public class RegisteredSerializationBinder : ISerializationBinder
     {
         HashSet<Type> allowedTypes = new HashSet<Type>();
@@ -31,22 +15,21 @@ namespace Halibut.Transport.Protocol
         {
             foreach (var serviceType in registeredServiceTypes)
             {
-                var methods = serviceType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
-                foreach (var method in methods.Where(x => !(x.IsSpecialName || x.DeclaringType == typeof(object))))
+                foreach (var method in serviceType.GetHalibutServiceMethods())
                 {
-                    AllowType(method.ReturnType, $"{serviceType.Name}.{method.Name}:{method.ReturnType.Name}");
+                    RegisterType(method.ReturnType, $"{serviceType.Name}.{method.Name}:{method.ReturnType.Name}");
                     
                     foreach (var param in method.GetParameters())
                     {
-                        AllowType(param.ParameterType,$"{serviceType.Name}.{method.Name}(){param.Name}:{param.ParameterType.Name}");
+                        RegisterType(param.ParameterType,$"{serviceType.Name}.{method.Name}(){param.Name}:{param.ParameterType.Name}");
                     }
                 }
             }
         }
         
-        void AllowType(Type type, string path)
+        void RegisterType(Type type, string path)
         {
-            if (type == typeof(object) || type == typeof(Task) || type == typeof(Task<>))
+            if (!type.AllowedOnHalibutInterface())
             {
                 throw new TypeNotAllowedException(type, path);
             }
@@ -64,7 +47,7 @@ namespace Halibut.Transport.Protocol
             
             foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
-                AllowType(p.PropertyType, $"{path}.{p.Name}");
+                RegisterType(p.PropertyType, $"{path}.{p.Name}");
             }
         }
 

--- a/source/Halibut/Transport/Protocol/TypeNotAllowedException.cs
+++ b/source/Halibut/Transport/Protocol/TypeNotAllowedException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Halibut.Transport.Protocol
+{
+    public class TypeNotAllowedException : Exception
+    {
+        public TypeNotAllowedException(Type type, string path)
+            : base($"The type {type.Name} is not allowed on the Halibut message protocol.  Found at {path}")
+        {
+            DisallowedType = type;
+            Path = path;
+        }
+        
+        public Type DisallowedType { get; }
+        
+        public string Path { get; }
+    }
+}

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -18,9 +18,11 @@ namespace Halibut.Transport
         readonly ILog log;
         readonly ConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
+        readonly ExchangeProtocolBuilder protocolBuilder;
 
-        public SecureClient(ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
         {
+            this.protocolBuilder = protocolBuilder;
             this.ServiceEndpoint = serviceEndpoint;
             this.clientCertificate = clientCertificate;
             this.log = log;
@@ -29,12 +31,12 @@ namespace Halibut.Transport
 
         public ServiceEndPoint ServiceEndpoint { get; }
 
-        public void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler)
+        public void ExecuteTransaction(ExchangeAction protocolHandler)
         {
             ExecuteTransaction(protocolHandler, CancellationToken.None);
         }
 
-        public void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler, CancellationToken cancellationToken)
+        public void ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken)
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 
@@ -58,7 +60,7 @@ namespace Halibut.Transport
                     IConnection connection = null;
                     try
                     {
-                        connection = connectionManager.AcquireConnection(new TcpConnectionFactory(clientCertificate), ServiceEndpoint, log, cancellationToken);
+                        connection = connectionManager.AcquireConnection(protocolBuilder, new TcpConnectionFactory(clientCertificate), ServiceEndpoint, log, cancellationToken);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Net.Security;
 using System.Net.Sockets;
 using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
@@ -14,11 +13,11 @@ namespace Halibut.Transport
         readonly MessageExchangeProtocol protocol;
         DateTimeOffset lastUsed;
 
-        public SecureConnection(IDisposable client, Stream stream, MessageExchangeProtocol protocol)
+        public SecureConnection(IDisposable client, Stream stream, ExchangeProtocolBuilder exchangeProtocolBuilder, ILog log)
         {
             this.client = client;
             this.stream = stream;
-            this.protocol = protocol;
+            protocol = exchangeProtocolBuilder(stream, log);
             lastUsed = DateTimeOffset.UtcNow;
         }
 

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -25,9 +25,11 @@ namespace Halibut.Transport
         readonly X509Certificate2 clientCertificate;
         readonly ILog log;
         readonly ConnectionManager connectionManager;
+        readonly ExchangeProtocolBuilder protocolBuilder;
 
-        public SecureWebSocketClient(ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureWebSocketClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
         {
+            this.protocolBuilder = protocolBuilder;
             this.serviceEndpoint = serviceEndpoint;
             this.clientCertificate = clientCertificate;
             this.log = log;
@@ -36,12 +38,12 @@ namespace Halibut.Transport
 
         public ServiceEndPoint ServiceEndpoint => serviceEndpoint;
 
-        public void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler)
+        public void ExecuteTransaction(ExchangeAction protocolHandler)
         {
             ExecuteTransaction(protocolHandler, CancellationToken.None);
         }
 
-        public void ExecuteTransaction(Action<MessageExchangeProtocol> protocolHandler, CancellationToken cancellationToken)
+        public void ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken)
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 
@@ -65,7 +67,7 @@ namespace Halibut.Transport
                     IConnection connection = null;
                     try
                     {
-                        connection = connectionManager.AcquireConnection(new WebSocketConnectionFactory(clientCertificate), serviceEndpoint, log, cancellationToken);
+                        connection = connectionManager.AcquireConnection(protocolBuilder, new WebSocketConnectionFactory(clientCertificate), serviceEndpoint, log, cancellationToken);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -14,45 +14,35 @@ namespace Halibut.Transport
     public class SecureWebSocketListener : IDisposable
     {
         readonly string endPoint;
-        readonly Func<MessageExchangeProtocol, Task> protocolHandler;
+        readonly ExchangeProtocolBuilder exchangeProtocolBuilder;
         readonly Predicate<string> verifyClientThumbprint;
         readonly Func<string, string, UnauthorizedClientConnectResponse> unauthorizedClientConnect;
         readonly ILogFactory logFactory;
         readonly Func<string> getFriendlyHtmlPageContent;
         readonly Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders;
         readonly CancellationTokenSource cts = new CancellationTokenSource();
+        readonly ExchangeActionAsync exchangeAction;
         ILog log;
         HttpListener listener;
 
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent)
-            : this(endPoint, serverCertificate, h => Task.Run(() => protocolHandler(h)), verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, () => new Dictionary<string, string>())
-
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent)
+            : this(endPoint, serverCertificate, exchangeProtocolBuilder, exchangeAction, verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, () => new Dictionary<string, string>())
         {
         }
 
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Action<MessageExchangeProtocol> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders)
-            : this(endPoint, serverCertificate, h => Task.Run(() => protocolHandler(h)), verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, getFriendlyHtmlPageHeaders)
-
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders)
+            : this(endPoint, serverCertificate, exchangeProtocolBuilder, exchangeAction, verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, getFriendlyHtmlPageHeaders, (clientName, thumbprint) => UnauthorizedClientConnectResponse.BlockConnection)
         {
         }
 
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent)
-            : this(endPoint, serverCertificate, h => Task.Run(() => protocolHandler(h)), verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, () => new Dictionary<string, string>())
-        {
-        }
-
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders)
-            : this(endPoint, serverCertificate, protocolHandler, verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, getFriendlyHtmlPageHeaders, (clientName, thumbprint) => UnauthorizedClientConnectResponse.BlockConnection)
-        {
-        }
-
-        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, Func<MessageExchangeProtocol, Task> protocolHandler, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, UnauthorizedClientConnectResponse> unauthorizedClientConnect)
+        public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, UnauthorizedClientConnectResponse> unauthorizedClientConnect)
         {
             if (!endPoint.EndsWith("/"))
                 endPoint += "/";
 
             this.endPoint = endPoint;
-            this.protocolHandler = protocolHandler;
+            this.exchangeProtocolBuilder = exchangeProtocolBuilder;
+            this.exchangeAction = exchangeAction;
             this.verifyClientThumbprint = verifyClientThumbprint;
             this.unauthorizedClientConnect = unauthorizedClientConnect;
             this.logFactory = logFactory;
@@ -228,7 +218,7 @@ namespace Halibut.Transport
         {
             log.Write(EventType.Diagnostic, "Begin message exchange");
 
-            return protocolHandler(new MessageExchangeProtocol(stream, log));
+            return exchangeAction(exchangeProtocolBuilder(stream, log));
         }
 
         // ReSharper disable once UnusedParameter.Local

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -22,12 +22,12 @@ namespace Halibut.Transport
             this.clientCertificate = clientCertificate;
         }
 
-        public IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log)
+        public IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log)
         {
-            return EstablishNewConnection(serviceEndpoint, log, CancellationToken.None);
+            return EstablishNewConnection(exchangeProtocolBuilder, serviceEndpoint, log, CancellationToken.None);
         }
 
-        public IConnection EstablishNewConnection(ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        public IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
             log.Write(EventType.OpeningNewConnection, $"Opening a new connection to {serviceEndpoint.BaseUri}");
 
@@ -45,8 +45,7 @@ namespace Halibut.Transport
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
 
-            var protocol = new MessageExchangeProtocol(ssl, log);
-            return new SecureConnection(client, ssl, protocol);
+            return new SecureConnection(client, ssl, exchangeProtocolBuilder, log);
         }
 
         internal static TcpClient CreateConnectedTcpClient(ServiceEndPoint endPoint, ILog log, CancellationToken cancellationToken)

--- a/source/Halibut/Util/TypeExtensionMethods.cs
+++ b/source/Halibut/Util/TypeExtensionMethods.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Halibut.Util
+{
+
+    public static class TypeExtensionMethods
+    {
+        public static IEnumerable<MethodInfo> GetHalibutServiceMethods(this Type serviceType)
+        {
+            var methods = serviceType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+            foreach (var method in methods.Where(x => !(x.IsSpecialName || x.DeclaringType == typeof(object))))
+            {
+                yield return method;
+            }
+        }
+
+        public static bool AllowedOnHalibutInterface(this Type type)
+        {
+            return type != typeof(object) && type != typeof(Task) && type != typeof(Task<>);
+        }
+    }
+}


### PR DESCRIPTION
It has been possible to pass random objects across the Json protocol, rather than the specific classes specified as part of the interface.  This change ensures that only properties listed on the service interface can be sent over the protocol (both client and server must agree on the types used) 