### PR TITLE
Enhance Halibut tests, fix client and protocol

### DIFF
--- a/source/Halibut.OctopusSample/OctopusForm.cs
+++ b/source/Halibut.OctopusSample/OctopusForm.cs
@@ -1,11 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Windows.Forms;
 using Halibut.ServiceModel;
 

--- a/source/Halibut.OctopusSample/TentacleForm.cs
+++ b/source/Halibut.OctopusSample/TentacleForm.cs
@@ -8,13 +8,12 @@ namespace Halibut.OctopusSample
     public partial class TentacleForm : Form
     {
         readonly HalibutRuntime tentacleHalibutRuntime;
-        readonly Logger log;
 
         public TentacleForm()
         {
             InitializeComponent();
 
-            log = new Logger(textBox1);
+            var log = new Logger(textBox1);
 
             var tentacleServices = new DelegateServiceFactory();
             tentacleServices.Register<IHealthCheckService>(() => new HealthCheck(log));

--- a/source/Halibut.SamplePolling/Program.cs
+++ b/source/Halibut.SamplePolling/Program.cs
@@ -13,7 +13,7 @@ namespace Halibut.SamplePolling
         static readonly X509Certificate2 ServerCertificate = new X509Certificate2("HalibutServer.pfx");
         const string PollUrl = "poll://SQ-TENTAPOLL";
 
-        static void Main(string[] args)
+        static void Main()
         {
             Log.Logger = new LoggerConfiguration()
                 .WriteTo.ColoredConsole()
@@ -22,7 +22,7 @@ namespace Halibut.SamplePolling
             var services = new DelegateServiceFactory();
             services.Register<ICalculatorService>(() => new CalculatorService());
 
-            using (var client = new HalibutRuntime(services, ClientCertificate))
+            using (var client = new HalibutRuntime(new NullServiceFactory(), ClientCertificate))
             using (var server = new HalibutRuntime(services, ServerCertificate))
             {
                 var octopusPort = client.Listen();

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -38,7 +38,7 @@ namespace Halibut.Tests
         public void FailWhenServerThrowsAnException()
         {
             var services = GetStubDelegateServiceFactory();
-            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
             using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
             {
                 var tentaclePort = tentacleListening.Listen();
@@ -54,7 +54,7 @@ namespace Halibut.Tests
         public void FailWhenServerThrowsAnExceptionOnPolling()
         {
             var services = GetStubDelegateServiceFactory();
-            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
             using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
             {
                 var octopusPort = octopus.Listen();
@@ -112,7 +112,7 @@ namespace Halibut.Tests
         public void FailWhenListeningClientPresentsWrongCertificate()
         {
             var services = GetStubDelegateServiceFactory();
-            using (var octopus = new HalibutRuntime(services, Certificates.TentaclePolling))
+            using (var octopus = new HalibutRuntime(Certificates.TentaclePolling))
             using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
             {
                 var tentaclePort = tentacleListening.Listen();
@@ -128,7 +128,7 @@ namespace Halibut.Tests
         public void FailWhenListeningServerPresentsWrongCertificate()
         {
             var services = GetStubDelegateServiceFactory();
-            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
             using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
             {
                 var tentaclePort = tentacleListening.Listen();
@@ -136,7 +136,7 @@ namespace Halibut.Tests
 
                 var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentaclePollingPublicThumbprint);
 
-                var ex = Assert.Throws<HalibutClientException>(() => echo.SayHello("World"));
+                Assert.Throws<HalibutClientException>(() => echo.SayHello("World"));
             }
         }
     }

--- a/source/Halibut.Tests/MemoryFixture.cs
+++ b/source/Halibut.Tests/MemoryFixture.cs
@@ -3,8 +3,6 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
-using FluentAssertions;
-using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using JetBrains.dotMemoryUnit;
 using JetBrains.dotMemoryUnit.Kernel;
@@ -148,6 +146,7 @@ namespace Halibut.Tests
             }
         }
 
+        // ReSharper disable once UnusedParameter.Local
         static void MakeRequest(ICalculatorService calculator, string requestType, bool expectSuccess)
         {
             for (var i = 0; i < RequestsPerClient; i++)

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -325,10 +325,6 @@ namespace Halibut.ServiceModel
         public void Add(Halibut.Transport.PollingClient pollingClient) { }
         public void Dispose() { }
     }
-    public static class ServiceFactoryExtensionMethods
-    {
-        public static Halibut.Transport.Protocol.ExchangeProtocolBuilder ExchangeProtocolBuilder(Halibut.ServiceModel.IServiceFactory factory) { }
-    }
     public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
     {
         public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -318,10 +318,6 @@ namespace Halibut.ServiceModel
         public void Add(Halibut.Transport.PollingClient pollingClient) { }
         public void Dispose() { }
     }
-    public static class ServiceFactoryExtensionMethods
-    {
-        public static Halibut.Transport.Protocol.ExchangeProtocolBuilder ExchangeProtocolBuilder(Halibut.ServiceModel.IServiceFactory factory) { }
-    }
     public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
     {
         public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }

--- a/source/Halibut.Tests/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/SecureListenerFixture.cs
@@ -87,6 +87,7 @@ namespace Halibut.Tests
                 Thread.Sleep(sleepTime);
                 yield return counter.NextValue();
             }
+            // ReSharper disable once IteratorNeverReturns : Take is limit
         }
     }
 }

--- a/source/Halibut.Tests/TestServices/ISupportedServices.cs
+++ b/source/Halibut.Tests/TestServices/ISupportedServices.cs
@@ -2,6 +2,14 @@
 
 namespace Halibut.Tests.TestServices
 {
+
+    public class MapLocation
+    {
+        public int Latitude { get; set; }
+        
+        public int Longitude { get; set; }
+    }
+    
     public interface ISupportedServices
     {
         void MethodReturningVoid(long a, long b);
@@ -25,5 +33,7 @@ namespace Halibut.Tests.TestServices
 
         string Ambiguous(string a, string b);
         string Ambiguous(string a, Tuple<string, string> b);
+
+        MapLocation GetLocation(MapLocation loc);
     }
 }

--- a/source/Halibut.Tests/TestServices/SupportedServices.cs
+++ b/source/Halibut.Tests/TestServices/SupportedServices.cs
@@ -95,6 +95,7 @@ namespace Halibut.Tests.TestServices
 
         public MapLocation GetLocation(MapLocation loc)
         {
+            // Swap the latitude and longitude for the round trip verification... never know where you will end up! 
             return new MapLocation { Latitude = loc.Longitude, Longitude = loc.Latitude };
         }
     }

--- a/source/Halibut.Tests/TestServices/SupportedServices.cs
+++ b/source/Halibut.Tests/TestServices/SupportedServices.cs
@@ -92,5 +92,10 @@ namespace Halibut.Tests.TestServices
         {
             return "Hello tuple";
         }
+
+        public MapLocation GetLocation(MapLocation loc)
+        {
+            return new MapLocation { Latitude = loc.Longitude, Longitude = loc.Latitude };
+        }
     }
 }

--- a/source/Halibut/ServiceModel/IServiceFactory.cs
+++ b/source/Halibut/ServiceModel/IServiceFactory.cs
@@ -10,12 +10,4 @@ namespace Halibut.ServiceModel
 
         IReadOnlyList<Type> RegisteredServiceTypes { get; }
     }
-
-    public static class ServiceFactoryExtensionMethods
-    {
-        public static ExchangeProtocolBuilder ExchangeProtocolBuilder(this IServiceFactory factory)
-        {
-            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, factory.RegisteredServiceTypes, log), log);
-        }
-    }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -315,7 +315,10 @@ namespace Halibut.Transport.Protocol
             using (var zip = new DeflateStream(stream, CompressionMode.Compress, true))
             using (var bson = new BsonDataWriter(zip) { CloseOutput = false })
             {
-                serializer.Serialize(bson, new MessageEnvelope<T> { Message = messages });
+                // for the moment this MUST be object so that the $type property is included
+                // If it is not, then an old receiver (eg, old tentacle) will not be able to understand messages from a new sender (server)
+                // Once ALL sources and targets are deserializing to MessageEnvelope<T>, (ReadBsonMessage) then this can be changed to T
+                serializer.Serialize(bson, new MessageEnvelope<object> { Message = messages });
             }
         }
 


### PR DESCRIPTION
When using a polling Client, the message is parsed before being passed to the client.  As such, all types on created clients need to be available for deserialization.  Previously only registered service types were being included.  This worked because the tests used the same IServiceFactory for both client and server, so both knew the types and the tests passed.  There was also no test passing a non-standard object as a property or response, so the type binder was not being verified properly.

Also I found that mixing a new message source (eg Server) which was not including the $type property in the JSON, could not be deserialized by the old message receiver, which, missing the type (eg "$type":"Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared"), would deserialize it as JObject.  So for now all messages sent need to include the $type property like they used to, while the new reciever can specify the type to the deserializer if the $type is present without incident.