### PR TITLE
Extracted Serializer to better manage message contract types

### DIFF
--- a/source/Halibut.Tests/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/ConnectionManagerFixture.cs
@@ -78,7 +78,7 @@ namespace Halibut.Tests
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog log)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new Type[] { }, log), log);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializer(), log), log);
         }
     }
 }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -485,6 +485,11 @@ namespace Halibut.Transport.Protocol
         public void SendProceed() { }
         public Task SendProceedAsync() { }
     }
+    public interface IMessageSerializer
+    {
+        public T ReadMessage<T>(Stream stream) { }
+        public void WriteMessage<T>(Stream stream, T message) { }
+    }
     public class InMemoryDataStreamReceiver : Halibut.IDataStreamReceiver
     {
         public InMemoryDataStreamReceiver(Action<Stream> writer) { }
@@ -503,8 +508,7 @@ namespace Halibut.Transport.Protocol
     }
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
     {
-        public static Func<IEnumerable<Type>, Newtonsoft.Json.JsonSerializer> Serializer;
-        public MessageExchangeStream(Stream stream, IEnumerable<Type> registeredServiceTypes, Halibut.Diagnostics.ILog log) { }
+        public MessageExchangeStream(Stream stream, Halibut.Transport.Protocol.IMessageSerializer serializer, Halibut.Diagnostics.ILog log) { }
         public bool ExpectNextOrEnd() { }
         public Task<bool> ExpectNextOrEndAsync() { }
         public void ExpectProceeed() { }
@@ -519,15 +523,23 @@ namespace Halibut.Transport.Protocol
         public void SendProceed() { }
         public Task SendProceedAsync() { }
     }
+    public class MessageSerializer : Halibut.Transport.Protocol.IMessageSerializer
+    {
+        public MessageSerializer() { }
+        public void AddToMessageContract(Type[] types) { }
+        public T ReadMessage<T>(Stream stream) { }
+        public void WriteMessage<T>(Stream stream, T message) { }
+    }
     public class ProtocolException : Exception, ISerializable
     {
         public ProtocolException(string message) { }
     }
     public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.ISerializationBinder
     {
-        public RegisteredSerializationBinder(IEnumerable<Type> registeredServiceTypes) { }
+        public RegisteredSerializationBinder() { }
         public void BindToName(Type serializedType, String& assemblyName, String& typeName) { }
         public Type BindToType(string assemblyName, string typeName) { }
+        public void Register(Type[] registeredServiceTypes) { }
     }
     public class RemoteIdentity
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -492,6 +492,11 @@ namespace Halibut.Transport.Protocol
         public void SendProceed() { }
         public Task SendProceedAsync() { }
     }
+    public interface IMessageSerializer
+    {
+        public T ReadMessage<T>(Stream stream) { }
+        public void WriteMessage<T>(Stream stream, T message) { }
+    }
     public class InMemoryDataStreamReceiver : Halibut.IDataStreamReceiver
     {
         public InMemoryDataStreamReceiver(Action<Stream> writer) { }
@@ -510,8 +515,7 @@ namespace Halibut.Transport.Protocol
     }
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
     {
-        public static Func<IEnumerable<Type>, Newtonsoft.Json.JsonSerializer> Serializer;
-        public MessageExchangeStream(Stream stream, IEnumerable<Type> registeredServiceTypes, Halibut.Diagnostics.ILog log) { }
+        public MessageExchangeStream(Stream stream, Halibut.Transport.Protocol.IMessageSerializer serializer, Halibut.Diagnostics.ILog log) { }
         public bool ExpectNextOrEnd() { }
         public Task<bool> ExpectNextOrEndAsync() { }
         public void ExpectProceeed() { }
@@ -526,15 +530,23 @@ namespace Halibut.Transport.Protocol
         public void SendProceed() { }
         public Task SendProceedAsync() { }
     }
+    public class MessageSerializer : Halibut.Transport.Protocol.IMessageSerializer
+    {
+        public MessageSerializer() { }
+        public void AddToMessageContract(Type[] types) { }
+        public T ReadMessage<T>(Stream stream) { }
+        public void WriteMessage<T>(Stream stream, T message) { }
+    }
     public class ProtocolException : Exception, ISerializable, _Exception
     {
         public ProtocolException(string message) { }
     }
     public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.ISerializationBinder
     {
-        public RegisteredSerializationBinder(IEnumerable<Type> registeredServiceTypes) { }
+        public RegisteredSerializationBinder() { }
         public void BindToName(Type serializedType, String& assemblyName, String& typeName) { }
         public Type BindToType(string assemblyName, string typeName) { }
+        public void Register(Type[] registeredServiceTypes) { }
     }
     public class RemoteIdentity
     {

--- a/source/Halibut.Tests/RegisteredSerializationBinderFixture.cs
+++ b/source/Halibut.Tests/RegisteredSerializationBinderFixture.cs
@@ -12,7 +12,8 @@ namespace Halibut.Tests
         [Test]
         public void BindMethods_WithValidClass_FindsAllMethodTypes()
         {
-            var binder = new RegisteredSerializationBinder(new[] { typeof(IExampleService) });
+            var binder = new RegisteredSerializationBinder();
+            binder.Register(typeof(IExampleService));
             binder.BindToName(typeof(ExampleProperties), out var assemblyName, out var typeName);
             var t = binder.BindToType(assemblyName, typeName);
             t.Should().Be(typeof(ExampleProperties));
@@ -67,9 +68,10 @@ namespace Halibut.Tests
         [TestCase(typeof(IObjectResultService))]
         [TestCase(typeof(IObjectPropertyService))]
         [TestCase(typeof(IObjectExampleService))]
-        public void Constructor_WithInvalidTypes_WillThrow(params Type[] types)
+        public void Register_WithInvalidTypes_WillThrow(params Type[] types)
         {
-            Assert.Throws<TypeNotAllowedException>(() => { _ = new RegisteredSerializationBinder(types); });
+            var binder = new RegisteredSerializationBinder();
+            Assert.Throws<TypeNotAllowedException>(() => { binder.Register(types); });
         }
         
         public interface IAsyncService
@@ -95,7 +97,8 @@ namespace Halibut.Tests
         [Test]
         public void Circular_Types_CanBeResolved()
         {
-            var binder = new RegisteredSerializationBinder(new[] { typeof(IMCircular) });
+            var binder = new RegisteredSerializationBinder();
+            binder.Register(typeof(IMCircular));
             binder.BindToName(typeof(CircularPart1), out var assemblyName1, out var typeName1);
             var t1 = binder.BindToType(assemblyName1, typeName1);
             t1.Should().Be(typeof(CircularPart1));

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -42,7 +42,7 @@ namespace Halibut.Tests
         {
             var connectionManager = new ConnectionManager();
             var stream = Substitute.For<IMessageExchangeStream>();
-            stream.When(x => x.IdentifyAsClient()).Do(x => { throw new ConnectionInitializationFailedException(""); });
+            stream.When(x => x.IdentifyAsClient()).Do(x => throw new ConnectionInitializationFailedException(""));
             for (int i = 0; i < HalibutLimits.RetryCountLimit; i++)
             {
                 var connection = Substitute.For<IConnection>();
@@ -70,7 +70,7 @@ namespace Halibut.Tests
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog logger)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new Type[] { }, logger), logger);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializer(), logger), logger);
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/IMessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/IMessageSerializer.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace Halibut.Transport.Protocol
+{
+    public interface IMessageSerializer
+    {
+        void WriteMessage<T>(Stream stream, T message);
+
+        T ReadMessage<T>(Stream stream);
+    }
+}

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Bson;
+
+namespace Halibut.Transport.Protocol
+{
+    public class MessageSerializer : IMessageSerializer
+    {
+        readonly JsonSerializer serializer;
+
+        readonly RegisteredSerializationBinder binder = new RegisteredSerializationBinder();
+
+        readonly HashSet<Type> messageContractTypes = new HashSet<Type>();
+        
+        public MessageSerializer()
+        {
+            serializer = CreateDefaultSerializer();
+        }
+            
+        JsonSerializer CreateDefaultSerializer()
+        {
+            var jsonSerializer = JsonSerializer.Create();
+            jsonSerializer.Formatting = Formatting.None;
+            jsonSerializer.ContractResolver = new HalibutContractResolver();
+            jsonSerializer.TypeNameHandling = TypeNameHandling.Auto;
+            jsonSerializer.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
+            jsonSerializer.DateFormatHandling = DateFormatHandling.IsoDateFormat;
+            jsonSerializer.SerializationBinder = binder;
+            return jsonSerializer;
+        }
+
+        public void AddToMessageContract(params Type[] types)
+        {
+            lock (messageContractTypes)
+            {
+                var newTypes = types.Where(t => messageContractTypes.Add(t)).ToArray();
+                binder.Register(newTypes);
+            }
+        }
+        
+        public void WriteMessage<T>(Stream stream, T message)
+        {
+            using (var zip = new DeflateStream(stream, CompressionMode.Compress, true))
+            using (var bson = new BsonDataWriter(zip) { CloseOutput = false })
+            {
+                // for the moment this MUST be object so that the $type property is included
+                // If it is not, then an old receiver (eg, old tentacle) will not be able to understand messages from a new sender (server)
+                // Once ALL sources and targets are deserializing to MessageEnvelope<T>, (ReadBsonMessage) then this can be changed to T
+                serializer.Serialize(bson, new MessageEnvelope<object> { Message = message });
+            }
+        }
+
+        public T ReadMessage<T>(Stream stream)
+        {
+            using (var zip = new DeflateStream(stream, CompressionMode.Decompress, true))
+            using (var bson = new BsonDataReader(zip) { CloseInput = false })
+            {
+                var messageEnvelope = serializer.Deserialize<MessageEnvelope<T>>(bson);
+                if (messageEnvelope == null)
+                    throw new Exception("messageEnvelope is null");
+                
+                return messageEnvelope.Message;
+            }
+        }
+        
+        // By making this a generic type, each message specifies the exact type it sends/expects
+        // And it is impossible to deserialize the wrong type - any mismatched type will refuse to deserialize
+        class MessageEnvelope<T>
+        {
+            public T Message { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Once the recent Halibut changes were made live on customer instances, two issues were noticed on a customer instance: https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1630005868012600

The two exceptions were:
> Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
> at System.Collections.Generic.HashSet`1.AddIfNotPresent(T value, Int32& location)
> at Halibut.HalibutRuntime.CreateClient[TService](ServiceEndPoint endpoint, CancellationToken 
> ...

and:

> Type specified in JSON 'Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared' was not resolved. Path 'Message.result.$type'.
> Server exception:
> Newtonsoft.Json.JsonSerializationException: Type specified in JSON 'Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared' was not resolved. Path 'Message.result.$type'.
> at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ResolveTypeName(JsonReader reader, Type& objectType, JsonContract& contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, String qualifiedTypeName)
> ...

The first appears to be caused by multiple tentacle clients being instantiated at the same time (different threads), which caused the non-thread-safe HashSet error.  This would generally only happen at start up, as once the client types are known the collection would not change, and not throw the error.  I tried to write a test to cause this exception, and while I did manage to reproduce the exception, it was very much a random thread-sync issue.  I did not keep this test as I felt if would be of low value, but did use it to "test" the fixes, which was simply to protect the HashSet from concurrent use.

The second was harder to understand, but from what I could determine, it was caused by the Halibut Listener being started, and then a message being received before the client type was registered on the serializer.  In general this should not be a problem, as we cannot receive a message from a tentacle instance before the client is ready to receive such messages.  This is because Services take messages at any time, but Clients only receive messages in response to a request.  So any message received before a client sends it should be from a client talking to the previous instance of the server, so the message should be dropped anyway (no client would receive the message).  However, the issue was in the sequence:

When the listener receives a message it starts a message loop to receive all inbound messages (until terminal message, error, or timeout).  The listener will then decode the message, and pass it on to the right client.  But, if that message loop was started before the client type was registered (on client instantiation), then even when the client sends a message and gets the response, if the message loop has not re-started, then the type is not known, the message is not de-serialized, and the communication fails.  I enhanced a test to create this situation.  I found that if the second client was created before the first one sent it's message, , or if the message loop timed out (by reducing the PollingQueueWaitTimeout in App.config, and introducing a thread.sleep between the two message sends), then the test passed (prior to the fix).  With the fix, the test now passes.  

The first issue could be "resolved" by re-starting the server, as it is unlikely for the thread contention to re-occur on restart.
The second issue could be "resolved" by re-running the task, as the error in the first attempt would cause the message loop to restart.  Then for the re-run, it would have all the types correctly registered, so the messages would be sent & received correctly.

This change fixes both issues by extracting the message serialization into a new thread-safe class, which ensures that all known service and client types are known by the type binder used to serialize/de-serialize the messages