### PR TITLE
Update netcoreapp to 3.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -106,7 +106,7 @@ Task("PublishLinuxTests")
     DotNetCorePublish("./source/Halibut.Tests/Halibut.Tests.csproj", new DotNetCorePublishSettings
     {
         Configuration = configuration,
-        Framework = "netcoreapp2.2",
+        Framework = "netcoreapp3.1",
         Runtime = "linux-x64",
         OutputDirectory = new DirectoryPath($"{artifactsDir}publish/linux-x64")
     });

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 #tool "nuget:?package=gitlink&version=3.1.0"
-#tool "nuget:?package=JetBrains.DotMemoryUnit&version=3.0.20171219.105559"
+#tool "nuget:?package=JetBrains.DotMemoryUnit&version=3.1.20200127.214830"
 #addin "Cake.FileHelpers&version=3.2.0"
 
 //////////////////////////////////////////////////////////////////////
@@ -95,7 +95,7 @@ Task("Test")
             args.Append("--no-build");
             return args;
         },
-        ToolPath = "./tools/JetBrains.dotMemoryUnit.3.0.20171219.105559/lib/tools/dotMemoryUnit.exe"
+        ToolPath = "./tools/JetBrains.dotMemoryUnit.3.1.20200127.214830/lib/tools/dotMemoryUnit.exe"
     });
 });
 

--- a/source/Halibut.CertificateGenerator/CertificateGenerator.cs
+++ b/source/Halibut.CertificateGenerator/CertificateGenerator.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Prng;
 using Org.BouncyCastle.Math;
@@ -66,10 +67,11 @@ namespace Halibut.CertificateGenerator
             certGen.SetNotAfter(DateTime.Today.AddYears(100));
             certGen.SetSubjectDN(new X509Name(ord, attrs));
             certGen.SetPublicKey(cerKp.Public);
-            certGen.SetSignatureAlgorithm("SHA1WithRSA");
             certGen.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(false));
             certGen.AddExtension(X509Extensions.AuthorityKeyIdentifier, true, new AuthorityKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(cerKp.Public)));
-            var x509 = certGen.Generate(cerKp.Private);
+            
+            var signatureFactory = new Asn1SignatureFactory("SHA1WithRSA", cerKp.Private);
+            var x509 = certGen.Generate(signatureFactory);
 
             var x509Certificate = DotNetUtilities.ToX509Certificate(x509);
             return new X509Certificate2(x509Certificate)

--- a/source/Halibut.CertificateGenerator/Halibut.CertificateGenerator.csproj
+++ b/source/Halibut.CertificateGenerator/Halibut.CertificateGenerator.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle" Version="1.7.0" />
+    <PackageReference Include="BouncyCastle" Version="1.8.9" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/source/Halibut.SampleClient/Halibut.SampleClient.csproj
+++ b/source/Halibut.SampleClient/Halibut.SampleClient.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>
 

--- a/source/Halibut.SampleClient/Halibut.SampleClient.csproj
+++ b/source/Halibut.SampleClient/Halibut.SampleClient.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/source/Halibut.SampleLoadTest/Halibut.SampleLoadTest.csproj
+++ b/source/Halibut.SampleLoadTest/Halibut.SampleLoadTest.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Halibut.SampleLoadTest/Halibut.SampleLoadTest.csproj
+++ b/source/Halibut.SampleLoadTest/Halibut.SampleLoadTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.0.0</VersionPrefix>
-    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Halibut.SampleLoadTest</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Halibut.SampleLoadTest</PackageId>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>
 

--- a/source/Halibut.SamplePolling/Halibut.SamplePolling.csproj
+++ b/source/Halibut.SamplePolling/Halibut.SamplePolling.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Halibut.SamplePolling/Halibut.SamplePolling.csproj
+++ b/source/Halibut.SamplePolling/Halibut.SamplePolling.csproj
@@ -10,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="2.3.0" />
-        <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
+        <PackageReference Include="Serilog" Version="2.10.0" />
+        <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Halibut.SampleServer/Halibut.SampleServer.csproj
+++ b/source/Halibut.SampleServer/Halibut.SampleServer.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>
 

--- a/source/Halibut.SampleServer/Halibut.SampleServer.csproj
+++ b/source/Halibut.SampleServer/Halibut.SampleServer.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/source/Halibut.Tests/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/DiscoveryClientFixture.cs
@@ -38,8 +38,8 @@ namespace Halibut.Tests
             var client = new DiscoveryClient();
             var discovered = client.Discover(new ServiceEndPoint(endpoint.BaseUri, ""));
 
-            discovered.RemoteThumbprint.ShouldBeEquivalentTo(endpoint.RemoteThumbprint);
-            discovered.BaseUri.ShouldBeEquivalentTo(endpoint.BaseUri);
+            discovered.RemoteThumbprint.Should().BeEquivalentTo(endpoint.RemoteThumbprint);
+            discovered.BaseUri.Should().BeEquivalentTo(endpoint.BaseUri);
         }
 
         [Test]

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -86,7 +86,7 @@ namespace Halibut.Tests
                 }
                 else
                 {
-                    new [] {"No such device or address", "Resource temporarily unavailable"}.Any(message.Contains).Should().BeTrue();
+                    new [] {"No such device or address", "Resource temporarily unavailable"}.Any(message.Contains).Should().BeTrue($"Message does not match known strings: {message}");
                 }
             }
         }

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -86,7 +86,8 @@ namespace Halibut.Tests
                 }
                 else
                 {
-                    new [] {"No such device or address", "Resource temporarily unavailable"}.Any(message.Contains).Should().BeTrue($"Message does not match known strings: {message}");
+                    // Failed with: An error occurred when sending a request to 'https://sduj08ud9382ujd98dw9fh934hdj2389u982:8000/', before the request could begin: Name or service not known, but found False.
+                    new [] {"No such device or address", "Resource temporarily unavailable", "Name or service not known"}.Any(message.Contains).Should().BeTrue($"Message does not match known strings: {message}");
                 }
             }
         }

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -36,18 +36,18 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.1.20200127.214830" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
-    <PackageReference Include="Assent" Version="1.3.1" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.1" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.6.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+    <PackageReference Include="Assent" Version="1.7.0" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.1" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.26" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -8,10 +8,10 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs" />
@@ -46,11 +46,11 @@
     <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.1" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.6.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
-    <PackageReference Include="Serilog" Version="2.3.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.0.20171219.105559" />
+    <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.1.20200127.214830" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Assent" Version="1.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -50,13 +50,6 @@
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT</DefineConstants>
   </PropertyGroup>

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -609,7 +609,7 @@ namespace Halibut.Transport.Protocol
         public Type DisallowedType { get; }
         public string Path { get; }
     }
-    public class WebSocketStream : Stream, IDisposable
+    public class WebSocketStream : Stream, IDisposable, IAsyncDisposable
     {
         public WebSocketStream(WebSocket context) { }
         public bool CanRead { get; }

--- a/source/Halibut.Tests/TcpConnectionFactoryFixture.cs
+++ b/source/Halibut.Tests/TcpConnectionFactoryFixture.cs
@@ -25,7 +25,7 @@ namespace Halibut.Tests
             client.Invoking(c =>
             {
                 var dualMode = c.Client.DualMode;
-            }).ShouldThrow<NotSupportedException>();
+            }).Should().Throw<NotSupportedException>();
         }
     }
 }

--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -34,7 +34,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 triggered = true;
             });
             Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(100), CancellationToken.None);
-            act.ShouldThrow<TimeoutException>();
+            await act.Should().ThrowAsync<TimeoutException>();
             triggered.Should().Be(false, "we should have stopped waiting on the task when timeout happened");
             await Task.Delay(200);
             triggered.Should().Be(true, "task should have continued executing in the background");
@@ -61,7 +61,7 @@ namespace Halibut.Tests.Util.AsyncEx
             });
 #pragma warning restore 4014
             Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(150), cancellationTokenSource.Token);
-            act.ShouldThrow<TaskCanceledException>();
+            await act.Should().ThrowAsync<OperationCanceledException>();
             triggered.Should().Be(false, "we should have stopped waiting on the task when cancellation happened");
             await Task.Delay(200);
             triggered.Should().Be(true, "task should have continued executing in the background (not entirely ideal, but this task is designed to handle non-cancelable tasks)");
@@ -89,7 +89,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
                 cancellationTokenSource.Cancel();
             });
-            await VerifyNoUnobservedExceptions<TaskCanceledException>(Task.Run(async () =>
+            await VerifyNoUnobservedExceptions<OperationCanceledException>(Task.Run(async () =>
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(200));
                 throw new ApplicationException("this task threw an exception after timeout");
@@ -106,7 +106,7 @@ namespace Halibut.Tests.Util.AsyncEx
             try
             {
                 Func<Task> act = async () => await task;
-                act.ShouldThrow<T>();
+                await act.Should().ThrowAsync<T>();
 
                 //delay long enough to ensure the task throws its exception
                 await Task.Delay(200);

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -35,10 +35,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -26,15 +26,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Updating samples and test applications to netcoreapp 3.1 instead of 2.2, which is End-Of-Life