### PR TITLE
Support delayed creation of DataStream.

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -17,13 +17,14 @@ namespace Halibut
     {
         public DataStream() { }
         public DataStream(long length, Action<Stream> writer) { }
-        public DataStream(Func<Halibut.DataStream> delayedStreamCreation) { }
         public Guid Id { get; set; }
         public long Length { get; set; }
         private Action<Stream> writer {  }
         public bool Equals(Halibut.DataStream other) { }
         public bool Equals(Object obj) { }
         public static Halibut.DataStream FromBytes(Byte[] data) { }
+        public static Halibut.DataStream FromLazy(Lazy<Halibut.DataStream> streamCreator) { }
+        public static Halibut.DataStream FromLazy(Func<Halibut.DataStream> streamCreator) { }
         public static Halibut.DataStream FromStream(Stream source, Action<int> updateProgress) { }
         public static Halibut.DataStream FromStream(Stream source) { }
         public static Halibut.DataStream FromString(string text) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -17,8 +17,10 @@ namespace Halibut
     {
         public DataStream() { }
         public DataStream(long length, Action<Stream> writer) { }
+        public DataStream(Guid guid, Func<Halibut.DataStream> delayedStreamCreation) { }
         public Guid Id { get; set; }
         public long Length { get; set; }
+        private Action<Stream> writer {  }
         public bool Equals(Halibut.DataStream other) { }
         public bool Equals(Object obj) { }
         public static Halibut.DataStream FromBytes(Byte[] data) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -17,7 +17,7 @@ namespace Halibut
     {
         public DataStream() { }
         public DataStream(long length, Action<Stream> writer) { }
-        public DataStream(Guid guid, Func<Halibut.DataStream> delayedStreamCreation) { }
+        public DataStream(Func<Halibut.DataStream> delayedStreamCreation) { }
         public Guid Id { get; set; }
         public long Length { get; set; }
         private Action<Stream> writer {  }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -17,13 +17,14 @@ namespace Halibut
     {
         public DataStream() { }
         public DataStream(long length, Action<Stream> writer) { }
-        public DataStream(Func<Halibut.DataStream> delayedStreamCreation) { }
         public Guid Id { get; set; }
         public long Length { get; set; }
         private Action<Stream> writer {  }
         public bool Equals(Halibut.DataStream other) { }
         public bool Equals(Object obj) { }
         public static Halibut.DataStream FromBytes(Byte[] data) { }
+        public static Halibut.DataStream FromLazy(Lazy<Halibut.DataStream> streamCreator) { }
+        public static Halibut.DataStream FromLazy(Func<Halibut.DataStream> streamCreator) { }
         public static Halibut.DataStream FromStream(Stream source, Action<int> updateProgress) { }
         public static Halibut.DataStream FromStream(Stream source) { }
         public static Halibut.DataStream FromString(string text) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -17,8 +17,10 @@ namespace Halibut
     {
         public DataStream() { }
         public DataStream(long length, Action<Stream> writer) { }
+        public DataStream(Guid guid, Func<Halibut.DataStream> delayedStreamCreation) { }
         public Guid Id { get; set; }
         public long Length { get; set; }
+        private Action<Stream> writer {  }
         public bool Equals(Halibut.DataStream other) { }
         public bool Equals(Object obj) { }
         public static Halibut.DataStream FromBytes(Byte[] data) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -17,7 +17,7 @@ namespace Halibut
     {
         public DataStream() { }
         public DataStream(long length, Action<Stream> writer) { }
-        public DataStream(Guid guid, Func<Halibut.DataStream> delayedStreamCreation) { }
+        public DataStream(Func<Halibut.DataStream> delayedStreamCreation) { }
         public Guid Id { get; set; }
         public long Length { get; set; }
         private Action<Stream> writer {  }

--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -8,16 +8,17 @@ namespace Halibut
 {
     public class DataStream : IEquatable<DataStream>, IDataStreamInternal
     {
-        Action<Stream> writer { get
+        Action<Stream> writer
+        {
+            get
             {
                 EnsureLengthAndStreamInitializedFromDelayedCreation();
                 return _writer;
-            } 
+            }
         }
 
-        [JsonIgnore]
-        Action<Stream> _writer;
-        
+        [JsonIgnore] Action<Stream> _writer;
+
         IDataStreamReceiver receiver;
 
         [JsonConstructor]
@@ -29,11 +30,10 @@ namespace Halibut
         {
             Length = length;
             Id = Guid.NewGuid();
-            this._writer = writer;
+            _writer = writer;
         }
-        
-        
-        public DataStream(Guid guid, Func<DataStream> delayedStreamCreation)
+
+        public DataStream(Func<DataStream> delayedStreamCreation)
         {
             Id = Guid.NewGuid();
             _delayedStreamCreation = delayedStreamCreation;
@@ -57,21 +57,19 @@ namespace Halibut
             }
         }
 
-        [JsonIgnore]
-        private long _length = 0;
+        [JsonIgnore] long _length;
 
-        [JsonIgnore]
-        Func<DataStream> _delayedStreamCreation = null;
+        [JsonIgnore] Func<DataStream> _delayedStreamCreation;
 
-        private void EnsureLengthAndStreamInitializedFromDelayedCreation()
+        void EnsureLengthAndStreamInitializedFromDelayedCreation()
         {
             if (_delayedStreamCreation != null)
             {
                 try
                 {
                     var r = _delayedStreamCreation();
-                    this._writer = r.writer;
-                    this._length = r.Length;
+                    _writer = r.writer;
+                    _length = r.Length;
                 }
                 finally
                 {
@@ -90,8 +88,7 @@ namespace Halibut
             var maxMemoryStreamLength = int.MaxValue;
             if (Length >= maxMemoryStreamLength)
                 return new TemporaryFileDataStreamReceiver(writer);
-            else
-                return new InMemoryDataStreamReceiver(writer);
+            return new InMemoryDataStreamReceiver(writer);
         }
 
         public bool Equals(DataStream other)
@@ -105,8 +102,8 @@ namespace Halibut
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((DataStream)obj);
+            if (obj.GetType() != GetType()) return false;
+            return Equals((DataStream) obj);
         }
 
         public override int GetHashCode()
@@ -146,13 +143,13 @@ namespace Halibut
 
         public static DataStream FromStream(Stream source, Action<int> updateProgress)
         {
-            var streamer = new StreamingDataStream(source, updateProgress ?? ((progress) => { }));
+            var streamer = new StreamingDataStream(source, updateProgress ?? (progress => { }));
             return new DataStream(source.Length, streamer.CopyAndReportProgress);
         }
 
         public static DataStream FromStream(Stream source)
         {
-            return FromStream(source, (progress) => { });
+            return FromStream(source, progress => { });
         }
 
         class StreamingDataStream
@@ -173,7 +170,7 @@ namespace Halibut
                 var writeBuffer = new byte[BufferSize];
 
                 var progress = 0;
-                
+
                 var totalLength = source.Length;
                 long copiedSoFar = 0;
                 source.Seek(0, SeekOrigin.Begin);
@@ -188,7 +185,7 @@ namespace Halibut
 
                     copiedSoFar += count;
 
-                    var progressNow = (int)((double)copiedSoFar / totalLength * 100.00);
+                    var progressNow = (int) ((double) copiedSoFar / totalLength * 100.00);
                     if (progressNow == progress)
                         continue;
                     updateProgress(progressNow);
@@ -203,7 +200,7 @@ namespace Halibut
 
             static void Swap<T>(ref T x, ref T y)
             {
-                T tmp = x;
+                var tmp = x;
                 x = y;
                 y = tmp;
             }


### PR DESCRIPTION
Support creating a DataStream from a `Lazy<DataStream>`, allowing for the `Length` or `writer` to be created at the time either is required.