### PR TITLE
Fixes a bug caused by exceptions in DataStreams.

### DIFF
--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using FluentAssertions;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
@@ -138,6 +140,57 @@ namespace Halibut.Tests
                 var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentaclePollingPublicThumbprint);
 
                 Assert.Throws<HalibutClientException>(() => echo.SayHello("World"));
+            }
+        }
+        
+        [Test]
+        public void FailWhenServerThrowsDuringADataStreamOnListening()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IReadDataSteamService>(() => new ReadDataStreamService());
+            
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+            {
+                var tentaclePort = tentacleListening.Listen();
+                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+
+                var readDataSteamService = octopus.CreateClient<IReadDataSteamService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+
+                // Previously tentacle would eventually stop responding only after many failed calls.
+                // This loop ensures (at the time) the test shows the problem.
+                for (int i = 0; i < 128; i++)
+                {
+                    Assert.Throws<HalibutClientException>(() => readDataSteamService.SendData(new DataStream(10000, stream => throw new Exception("Oh noes"))));
+                }
+                
+                long recieved = readDataSteamService.SendData(DataStream.FromString("hello"));
+                recieved.Should().Be(5);
+            }
+        }
+        
+        [Test]
+        public void FailWhenServerThrowsDuringADataStreamOnPolling()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IReadDataSteamService>(() => new ReadDataStreamService());
+            
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+            {
+                var octopusPort = octopus.Listen();
+                octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + octopusPort), Certificates.OctopusPublicThumbprint));
+
+                var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+                
+                var readDataSteamService = octopus.CreateClient<IReadDataSteamService>("poll://SQ-TENTAPOLL", Certificates.TentacleListeningPublicThumbprint);
+
+                Assert.Throws<HalibutClientException>(() => readDataSteamService.SendData(new DataStream(10000, stream => throw new Exception("Oh noes"))));
+
+                long recieved = readDataSteamService.SendData(DataStream.FromString("hello"));
+                recieved.Should().Be(5);
             }
         }
     }

--- a/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
+++ b/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
@@ -2,6 +2,6 @@ namespace Halibut.Tests.TestServices
 {
     public interface IReadDataSteamService
     {
-        public long SendData(DataStream dataStream);
+        long SendData(DataStream dataStream);
     }
 }

--- a/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
+++ b/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
@@ -1,0 +1,7 @@
+namespace Halibut.Tests.TestServices
+{
+    public interface IReadDataSteamService
+    {
+        public long SendData(DataStream dataStream);
+    }
+}

--- a/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
@@ -12,7 +12,7 @@ namespace Halibut.Tests.TestServices
                 var buf = new byte[1024];
                 while (true)
                 {
-                    int read = reader.Read(buf);
+                    int read = reader.Read(buf, 0, buf.Length);
                     if(read == 0) break;
                     total += read;
                 }

--- a/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
@@ -1,0 +1,24 @@
+using System.Xml.Schema;
+
+namespace Halibut.Tests.TestServices
+{
+    public class ReadDataStreamService : IReadDataSteamService
+    {
+        public long SendData(DataStream dataStream)
+        {
+            long total = 0;
+            dataStream.Receiver().Read(reader =>
+            {
+                var buf = new byte[1024];
+                while (true)
+                {
+                    int read = reader.Read(buf);
+                    if(read == 0) break;
+                    total += read;
+                }
+            });
+            
+            return total;
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -261,13 +261,15 @@ namespace Halibut.Transport.Protocol
         TemporaryFileStream CopyStreamToFile(Guid id, long length, BinaryReader reader)
         {
             var path = Path.Combine(Path.GetTempPath(), string.Format("{0}_{1}", id.ToString(), Interlocked.Increment(ref streamCount)));
+            long bytesLeftToRead = length;
             using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
             {
                 var buffer = new byte[1024 * 128];
-                while (length > 0)
+                while (bytesLeftToRead > 0)
                 {
-                    var read = reader.Read(buffer, 0, (int)Math.Min(buffer.Length, length));
-                    length -= read;
+                    var read = reader.Read(buffer, 0, (int)Math.Min(buffer.Length, bytesLeftToRead));
+                    if (read == 0) throw new ProtocolException($"Stream with length {length} was closed after only reading {length - bytesLeftToRead} bytes.");
+                    bytesLeftToRead -= read;
                     fileStream.Write(buffer, 0, read);
                 }
             }


### PR DESCRIPTION
This change fixes a bug where the remote would have 100% CPU load and
eventually stop servicing request when the sender throws an exception in
the `DataStream`.

The issue was the return value of the `read()` method was not
respected. The doc for this method says:
```
<returns>The number of bytes read into <paramref name="buffer" />. This might be less than the number of bytes requested if that many bytes are not available, or it might be zero if the end of the stream is reached.</returns>
```
The fix is to simply detect a return value of `0` indicating the stream
is closed rather than continue to try and read from the stream.

Fixes: https://github.com/OctopusDeploy/Halibut/issues/141

May be related to: https://github.com/OctopusDeploy/Halibut/issues/117