### PR TITLE
Fix a performance regression in Halibut by re-using the newtonsoft ContractResolver

### DIFF
--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -36,7 +36,7 @@ namespace Halibut.Tests
                     var thread = new Thread(() =>
                     {
                         messagesAreSentTheSameTimeSemaphore.WaitOne();
-                        var recieved = readDataSteamService.SendDataMany(dataStreams);
+                        var recieved = readDataSteamService.SendData(dataStreams);
                         recieved.Should().Be(5 * dataStreams.Length);
                     });
                     thread.Start();

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Transport.Protocol;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class ParallelRequestsFixture
+    {
+        [Test]
+        public void SendMessagesToAListeningTentacleInParallel()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IReadDataSteamService>(() => new ReadDataStreamService());
+            
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+            {
+                var tentaclePort = tentacleListening.Listen();
+                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+
+                var readDataSteamService = octopus.CreateClient<IReadDataSteamService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+
+                var dataStreams = CreateDataStreams();
+
+                Semaphore messagesAreSentTheSameTimeSemaphore = new Semaphore(0, dataStreams.Length);
+
+                var threads = new List<Thread>();
+                for (int i = 0; i < 64; i++)
+                {
+                    var thread = new Thread(() =>
+                    {
+                        messagesAreSentTheSameTimeSemaphore.WaitOne();
+                        var recieved = readDataSteamService.SendDataMany(dataStreams);
+                        recieved.Should().Be(5 * dataStreams.Length);
+                    });
+                    thread.Start();
+                    threads.Add(thread);
+                }
+
+                messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
+
+                WaitForAllThreads(threads);
+            }
+        }
+
+        static DataStream[] CreateDataStreams()
+        {
+            // Lots of DataStreams since they are handled in a special way, and we have had threading issues
+            // with these previously.
+            DataStream[] dataStreams = new DataStream[128];
+            for (int i = 0; i < dataStreams.Length; i++)
+            {
+                dataStreams[i] = DataStream.FromString("Hello");
+            }
+
+            return dataStreams;
+        }
+        
+        static void WaitForAllThreads(List<Thread> threads)
+        {
+            foreach (var thread in threads)
+            {
+                thread.Join();
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
+++ b/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
@@ -2,8 +2,6 @@ namespace Halibut.Tests.TestServices
 {
     public interface IReadDataSteamService
     {
-        long SendData(DataStream dataStream);
-
-        long SendDataMany(DataStream[] dataStreams);
+        long SendData(params DataStream[] dataStreams);
     }
 }

--- a/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
+++ b/source/Halibut.Tests/TestServices/IReadDataSteamService.cs
@@ -3,5 +3,7 @@ namespace Halibut.Tests.TestServices
     public interface IReadDataSteamService
     {
         long SendData(DataStream dataStream);
+
+        long SendDataMany(DataStream[] dataStreams);
     }
 }

--- a/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
@@ -20,5 +20,16 @@ namespace Halibut.Tests.TestServices
             
             return total;
         }
+
+        public long SendDataMany(DataStream[] dataStreams)
+        {
+            long count = 0;
+            foreach (var dataStream in dataStreams)
+            {
+                count += SendData(dataStream);
+            }
+
+            return count;
+        }
     }
 }

--- a/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/ReadDataStreamService.cs
@@ -4,7 +4,7 @@ namespace Halibut.Tests.TestServices
 {
     public class ReadDataStreamService : IReadDataSteamService
     {
-        public long SendData(DataStream dataStream)
+        long SendData(DataStream dataStream)
         {
             long total = 0;
             dataStream.Receiver().Read(reader =>
@@ -21,7 +21,7 @@ namespace Halibut.Tests.TestServices
             return total;
         }
 
-        public long SendDataMany(DataStream[] dataStreams)
+        public long SendData(params DataStream[] dataStreams)
         {
             long count = 0;
             foreach (var dataStream in dataStreams)

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -4,18 +4,35 @@ using Newtonsoft.Json.Serialization;
 
 namespace Halibut.Transport.Protocol
 {
-    public class HalibutContractResolver : DefaultContractResolver
+    public class HalibutContractResolver : IContractResolver
     {
-        public override JsonContract ResolveContract(Type type)
+        static IContractResolver baseContractResolver = new DefaultContractResolver();
+        static volatile bool HaveAddedCaptureOnSerializeCallback = false;
+        
+        public JsonContract ResolveContract(Type type)
         {
-            var contract = base.ResolveContract(type);
             if (type == typeof(DataStream))
             {
-                contract.OnSerializedCallbacks.Add(CaptureOnSerialize);
-                contract.OnDeserializedCallbacks.Add(CaptureOnDeserialize);
+                var contract = baseContractResolver.ResolveContract(type);
+                // The contract is globally shared, so we need to make sure multiple threads don't try to edit it at the same time. 
+                if (!HaveAddedCaptureOnSerializeCallback)
+                {
+                    lock (baseContractResolver)
+                    {
+                        if (!HaveAddedCaptureOnSerializeCallback)
+                        {
+                            contract.OnSerializedCallbacks.Add(CaptureOnSerialize);
+                            contract.OnDeserializedCallbacks.Add(CaptureOnDeserialize);
+                            HaveAddedCaptureOnSerializeCallback = true;
+                        }
+                    }
+                    
+                }
+                
+                return contract;
             }
-
-            return contract;
+            
+            return baseContractResolver.ResolveContract(type);
         }
 
         static void CaptureOnSerialize(object o, StreamingContext context)

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -13,7 +13,7 @@ namespace Halibut.Transport.Protocol
             if (type == typeof(DataStream))
             {
                 var contract = base.ResolveContract(type);
-                // The contract is globally shared, so we need to make sure multiple threads don't try to edit it at the same time. 
+                // The contract is shared, so we need to make sure multiple threads don't try to edit it at the same time. 
                 if (!HaveAddedCaptureOnSerializeCallback)
                 {
                     lock (this)

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -6,8 +6,8 @@ namespace Halibut.Transport.Protocol
 {
     public class HalibutContractResolver : IContractResolver
     {
-        static IContractResolver baseContractResolver = new DefaultContractResolver();
-        static volatile bool HaveAddedCaptureOnSerializeCallback = false;
+        IContractResolver baseContractResolver = new DefaultContractResolver();
+        volatile bool HaveAddedCaptureOnSerializeCallback = false;
         
         public JsonContract ResolveContract(Type type)
         {

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -4,20 +4,19 @@ using Newtonsoft.Json.Serialization;
 
 namespace Halibut.Transport.Protocol
 {
-    public class HalibutContractResolver : IContractResolver
+    public class HalibutContractResolver : DefaultContractResolver
     {
-        IContractResolver baseContractResolver = new DefaultContractResolver();
         volatile bool HaveAddedCaptureOnSerializeCallback = false;
         
-        public JsonContract ResolveContract(Type type)
+        public override JsonContract ResolveContract(Type type)
         {
             if (type == typeof(DataStream))
             {
-                var contract = baseContractResolver.ResolveContract(type);
+                var contract = base.ResolveContract(type);
                 // The contract is globally shared, so we need to make sure multiple threads don't try to edit it at the same time. 
                 if (!HaveAddedCaptureOnSerializeCallback)
                 {
-                    lock (baseContractResolver)
+                    lock (this)
                     {
                         if (!HaveAddedCaptureOnSerializeCallback)
                         {
@@ -32,7 +31,7 @@ namespace Halibut.Transport.Protocol
                 return contract;
             }
             
-            return baseContractResolver.ResolveContract(type);
+            return base.ResolveContract(type);
         }
 
         static void CaptureOnSerialize(object o, StreamingContext context)

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -14,10 +14,6 @@ namespace Halibut.Transport.Protocol
 
         readonly HashSet<Type> messageContractTypes = new HashSet<Type>();
         
-        // NOTE: Do not share the serializer between Read/Write, the HalibutContractResolver adds OnSerializedCallbacks which are specific to the 
-        // operation that is in-progress (and if the list is being enumerated at the time causes an exception).  And probably adds a duplicate each time the 
-        // type is detected. It also makes use of a static, StreamCapture.Current - which seems like a bad™ idea, perhaps this can be straightened out? 
-        // For now, just ensuring each operation does not interfere with each other.
         JsonSerializer CreateSerializer()
         {
             var jsonSerializer = JsonSerializer.Create();

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -10,6 +10,8 @@ namespace Halibut.Transport.Protocol
 {
     public class MessageSerializer : IMessageSerializer
     {
+        static readonly HalibutContractResolver halibutContractResolver = new HalibutContractResolver();
+        
         readonly RegisteredSerializationBinder binder = new RegisteredSerializationBinder();
 
         readonly HashSet<Type> messageContractTypes = new HashSet<Type>();
@@ -18,7 +20,7 @@ namespace Halibut.Transport.Protocol
         {
             var jsonSerializer = JsonSerializer.Create();
             jsonSerializer.Formatting = Formatting.None;
-            jsonSerializer.ContractResolver = new HalibutContractResolver();
+            jsonSerializer.ContractResolver = halibutContractResolver;
             jsonSerializer.TypeNameHandling = TypeNameHandling.Auto;
             jsonSerializer.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
             jsonSerializer.DateFormatHandling = DateFormatHandling.IsoDateFormat;


### PR DESCRIPTION
Newton soft recommends that `ContractResolver`s should be re-used see the [performance doc](https://www.newtonsoft.com/json/help/html/Performance.htm). Also the [newtonsoft example](https://www.newtonsoft.com/json/help/html/contractresolver.htm) of how to implement a contract resolver, which shows creating a static instance of the `ContractResolver`.

I created a simple test that made 1k requests to send just a Small DataStream to a polling tentacle the speed up was:
```
before: 47.7s
after: 7.6s
```

In [this change](https://github.com/OctopusDeploy/Halibut/commit/b325aeb4cce5a9ff0b663c67ccabb3bd5d04cb34) Halibut had a regression where its speed was reduced to fix a bug. I created a test `ParallelRequestsFixture` which shows the concurrent editing issue when we re-use `ContractResolver` with the existing code:

![image](https://user-images.githubusercontent.com/7076477/165198837-72b7b8b8-4be6-4bd1-9d97-846da64112e3.png)

With the locking, the test passes.