### PR TITLE
Use a buffered stream for higher performance.

### DIFF
--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -37,7 +37,6 @@ namespace Halibut.Transport
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
 
             var stream = new BufferedStream(client.GetStream());
-            // var stream = client.GetStream();
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
             var ssl = new SslStream(stream, false, certificateValidator.Validate, UserCertificateSelectionCallback);

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -35,7 +36,8 @@ namespace Halibut.Transport
             var client = CreateConnectedTcpClient(serviceEndpoint, log, cancellationToken);
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
 
-            var stream = client.GetStream();
+            var stream = new BufferedStream(client.GetStream());
+            // var stream = client.GetStream();
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
             var ssl = new SslStream(stream, false, certificateValidator.Validate, UserCertificateSelectionCallback);


### PR DESCRIPTION
For sending 1000 small files the speed up us `7.4s` to `4s`.

The code to measure this is:

```
public class SpeedTest
    {
        [Test]
        public void FailWhenServerThrowsDuringADataStreamOnPolling2()
        {
            var services = new DelegateServiceFactory();
            services.Register<IReadDataSteamService>(() => new ReadDataStreamService());

            using (var octopus = new HalibutRuntime(Certificates.Octopus))
            using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
            {
                var octopusPort = octopus.Listen();
                octopus.Trust(Certificates.TentaclePollingPublicThumbprint);

                tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + octopusPort), Certificates.OctopusPublicThumbprint));

                var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);

                var readDataSteamService = octopus.CreateClient<IReadDataSteamService>("poll://SQ-TENTAPOLL", Certificates.TentacleListeningPublicThumbprint);

                var ds = DataStream.FromString("Hello how are ye");
                Stopwatch watch = new Stopwatch();
                watch.Start();
                for (int i = 0; i < 1000; i++)
                {
                    readDataSteamService.SendData(ds);
                    ;
                }
                Console.WriteLine(watch.Elapsed.TotalMilliseconds);

                long recieved = readDataSteamService.SendData(DataStream.FromString("hello"));
                recieved.Should().Be(5);
            }
        }
    }
```