### PR TITLE
Revert "Use a buffered stream for higher performance."

### DIFF
--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -36,7 +35,7 @@ namespace Halibut.Transport
             var client = CreateConnectedTcpClient(serviceEndpoint, log, cancellationToken);
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
 
-            var stream = new BufferedStream(client.GetStream());
+            var stream = client.GetStream();
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
             var ssl = new SslStream(stream, false, certificateValidator.Validate, UserCertificateSelectionCallback);


### PR DESCRIPTION
Reverts OctopusDeploy/Halibut#144

To fix https://github.com/OctopusDeploy/Halibut/issues/145