### PR TITLE
re-use JSON library static defaults where possible

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -483,6 +483,7 @@ namespace Halibut.Transport.Protocol
     public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
     {
         public HalibutContractResolver() { }
+        internal static Newtonsoft.Json.Serialization.IContractResolver Instance {  }
         public Newtonsoft.Json.Serialization.JsonContract ResolveContract(Type type) { }
     }
     public interface IMessageExchangeStream
@@ -550,7 +551,7 @@ namespace Halibut.Transport.Protocol
     {
         public ProtocolException(string message) { }
     }
-    public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.ISerializationBinder
+    public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.DefaultSerializationBinder, Newtonsoft.Json.Serialization.ISerializationBinder
     {
         public RegisteredSerializationBinder() { }
         public void BindToName(Type serializedType, String& assemblyName, String& typeName) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -490,6 +490,7 @@ namespace Halibut.Transport.Protocol
     public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
     {
         public HalibutContractResolver() { }
+        internal static Newtonsoft.Json.Serialization.IContractResolver Instance {  }
         public Newtonsoft.Json.Serialization.JsonContract ResolveContract(Type type) { }
     }
     public interface IMessageExchangeStream
@@ -557,7 +558,7 @@ namespace Halibut.Transport.Protocol
     {
         public ProtocolException(string message) { }
     }
-    public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.ISerializationBinder
+    public class RegisteredSerializationBinder : Newtonsoft.Json.Serialization.DefaultSerializationBinder, Newtonsoft.Json.Serialization.ISerializationBinder
     {
         public RegisteredSerializationBinder() { }
         public void BindToName(Type serializedType, String& assemblyName, String& typeName) { }

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -6,6 +6,8 @@ namespace Halibut.Transport.Protocol
 {
     public class HalibutContractResolver : DefaultContractResolver
     {
+        internal static IContractResolver Instance { get; } = new HalibutContractResolver();
+
         volatile bool HaveAddedCaptureOnSerializeCallback = false;
         
         public override JsonContract ResolveContract(Type type)

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -10,17 +10,14 @@ namespace Halibut.Transport.Protocol
 {
     public class MessageSerializer : IMessageSerializer
     {
-        static readonly HalibutContractResolver halibutContractResolver = new HalibutContractResolver();
-        
         readonly RegisteredSerializationBinder binder = new RegisteredSerializationBinder();
-
         readonly HashSet<Type> messageContractTypes = new HashSet<Type>();
         
         JsonSerializer CreateSerializer()
         {
             var jsonSerializer = JsonSerializer.Create();
             jsonSerializer.Formatting = Formatting.None;
-            jsonSerializer.ContractResolver = halibutContractResolver;
+            jsonSerializer.ContractResolver = HalibutContractResolver.Instance;
             jsonSerializer.TypeNameHandling = TypeNameHandling.Auto;
             jsonSerializer.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
             jsonSerializer.DateFormatHandling = DateFormatHandling.IsoDateFormat;

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -6,12 +6,11 @@ using Newtonsoft.Json.Serialization;
 
 namespace Halibut.Transport.Protocol
 {
-    public class RegisteredSerializationBinder : ISerializationBinder
+    public class RegisteredSerializationBinder : DefaultSerializationBinder
     {
         readonly Type[] protocolTypes = new[] { typeof(ResponseMessage), typeof(RequestMessage) };
         readonly HashSet<Type> allowedTypes = new HashSet<Type>();
-        readonly ISerializationBinder baseBinder = new DefaultSerializationBinder();
-        
+
         public RegisteredSerializationBinder()
         {
             foreach (var protocolType in protocolTypes)
@@ -92,18 +91,19 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        public Type BindToType(string assemblyName, string typeName)
+        public override Type BindToType(string assemblyName, string typeName)
         {
-            var type = baseBinder.BindToType(assemblyName, typeName);
+            var type = base.BindToType(assemblyName, typeName);
             lock (allowedTypes)
             {
                 return allowedTypes.Contains(type) ? type : null;
             }
         }
 
-        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        // kept for backwards compatibility
+        public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            baseBinder.BindToName(serializedType, out assemblyName, out typeName);
+            base.BindToName(serializedType, out assemblyName, out typeName);
         }
     }
 }


### PR DESCRIPTION
Currently we new up a new `ContractResolver` for every request to Halibut. This PR brings the serializer into line with the way the base resolvers work, exposing a static instance that can be reused, in order to cache contracts.