### PR TITLE
Add `IMessageSerializer` to `HalibutRuntimeBuilder` 

### DIFF
--- a/source/Halibut.Tests/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/ConnectionManagerFixture.cs
@@ -78,7 +78,7 @@ namespace Halibut.Tests
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog log)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializer(), log), log);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), log), log);
         }
     }
 }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -75,7 +75,7 @@ namespace Halibut
         public HalibutRuntimeBuilder() { }
         public Halibut.HalibutRuntime Build() { }
         public Halibut.HalibutRuntimeBuilder WithLogFactory(Halibut.Diagnostics.ILogFactory logFactory) { }
-        public Halibut.HalibutRuntimeBuilder WithMessageSerializer(Halibut.Transport.Protocol.IMessageSerializer messageSerializer) { }
+        public Halibut.HalibutRuntimeBuilder WithMessageSerializer(Action<Halibut.Transport.Protocol.MessageSerializerBuilder> configureBuilder) { }
         public Halibut.HalibutRuntimeBuilder WithPendingRequestQueueFactory(Halibut.ServiceModel.IPendingRequestQueueFactory queueFactory) { }
         public Halibut.HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate) { }
         public Halibut.HalibutRuntimeBuilder WithServiceFactory(Halibut.ServiceModel.IServiceFactory serviceFactory) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -80,6 +80,7 @@ namespace Halibut
         public Halibut.HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate) { }
         public Halibut.HalibutRuntimeBuilder WithServiceFactory(Halibut.ServiceModel.IServiceFactory serviceFactory) { }
         public Halibut.HalibutRuntimeBuilder WithTrustProvider(Halibut.ServiceModel.ITrustProvider trustProvider) { }
+        public Halibut.HalibutRuntimeBuilder WithTypeRegistry(Halibut.Transport.Protocol.ITypeRegistry typeRegistry) { }
     }
     public interface IDataStreamReceiver
     {
@@ -484,6 +485,7 @@ namespace Halibut.Transport.Protocol
     public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
     {
         public HalibutContractResolver() { }
+        internal static Newtonsoft.Json.Serialization.IContractResolver Instance {  }
         public Newtonsoft.Json.Serialization.JsonContract ResolveContract(Type type) { }
     }
     public interface IMessageExchangeStream
@@ -512,6 +514,13 @@ namespace Halibut.Transport.Protocol
         public InMemoryDataStreamReceiver(Action<Stream> writer) { }
         public void Read(Action<Stream> reader) { }
         public void SaveTo(string filePath) { }
+    }
+    public interface ITypeRegistry
+    {
+        public void AddToMessageContract(Type[] types) { }
+        public bool IsInAllowedTypes(Type type) { }
+        public void Register(Type[] registeredServiceTypes) { }
+        public void RegisterType(Type type, string path, bool ignoreObject) { }
     }
     public class MessageExchangeProtocol
     {
@@ -546,6 +555,13 @@ namespace Halibut.Transport.Protocol
         public void AddToMessageContract(Type[] types) { }
         public T ReadMessage<T>(Stream stream) { }
         public void WriteMessage<T>(Stream stream, T message) { }
+    }
+    public class MessageSerializerBuilder
+    {
+        public MessageSerializerBuilder() { }
+        public Halibut.Transport.Protocol.MessageSerializer Build() { }
+        public Halibut.Transport.Protocol.MessageSerializerBuilder WithSerializerBuilder(Func<Newtonsoft.Json.JsonSerializer> createSerializer) { }
+        public Halibut.Transport.Protocol.MessageSerializerBuilder WithTypeRegistry(Halibut.Transport.Protocol.ITypeRegistry typeRegistry) { }
     }
     public class ProtocolException : Exception, ISerializable
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -560,7 +560,7 @@ namespace Halibut.Transport.Protocol
     {
         public MessageSerializerBuilder() { }
         public Halibut.Transport.Protocol.MessageSerializer Build() { }
-        public Halibut.Transport.Protocol.MessageSerializerBuilder WithSerializerBuilder(Func<Newtonsoft.Json.JsonSerializer> createSerializer) { }
+        public Halibut.Transport.Protocol.MessageSerializerBuilder WithSerializerSettings(Action<Newtonsoft.Json.JsonSerializerSettings> configure) { }
         public Halibut.Transport.Protocol.MessageSerializerBuilder WithTypeRegistry(Halibut.Transport.Protocol.ITypeRegistry typeRegistry) { }
     }
     public class ProtocolException : Exception, ISerializable

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -75,6 +75,7 @@ namespace Halibut
         public HalibutRuntimeBuilder() { }
         public Halibut.HalibutRuntime Build() { }
         public Halibut.HalibutRuntimeBuilder WithLogFactory(Halibut.Diagnostics.ILogFactory logFactory) { }
+        public Halibut.HalibutRuntimeBuilder WithMessageSerializer(Halibut.Transport.Protocol.IMessageSerializer messageSerializer) { }
         public Halibut.HalibutRuntimeBuilder WithPendingRequestQueueFactory(Halibut.ServiceModel.IPendingRequestQueueFactory queueFactory) { }
         public Halibut.HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate) { }
         public Halibut.HalibutRuntimeBuilder WithServiceFactory(Halibut.ServiceModel.IServiceFactory serviceFactory) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -75,7 +75,7 @@ namespace Halibut
         public HalibutRuntimeBuilder() { }
         public Halibut.HalibutRuntime Build() { }
         public Halibut.HalibutRuntimeBuilder WithLogFactory(Halibut.Diagnostics.ILogFactory logFactory) { }
-        public Halibut.HalibutRuntimeBuilder WithMessageSerializer(Halibut.Transport.Protocol.IMessageSerializer messageSerializer) { }
+        public Halibut.HalibutRuntimeBuilder WithMessageSerializer(Action<Halibut.Transport.Protocol.MessageSerializerBuilder> configureBuilder) { }
         public Halibut.HalibutRuntimeBuilder WithPendingRequestQueueFactory(Halibut.ServiceModel.IPendingRequestQueueFactory queueFactory) { }
         public Halibut.HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate) { }
         public Halibut.HalibutRuntimeBuilder WithServiceFactory(Halibut.ServiceModel.IServiceFactory serviceFactory) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -567,7 +567,7 @@ namespace Halibut.Transport.Protocol
     {
         public MessageSerializerBuilder() { }
         public Halibut.Transport.Protocol.MessageSerializer Build() { }
-        public Halibut.Transport.Protocol.MessageSerializerBuilder WithSerializerBuilder(Func<Newtonsoft.Json.JsonSerializer> createSerializer) { }
+        public Halibut.Transport.Protocol.MessageSerializerBuilder WithSerializerSettings(Action<Newtonsoft.Json.JsonSerializerSettings> configure) { }
         public Halibut.Transport.Protocol.MessageSerializerBuilder WithTypeRegistry(Halibut.Transport.Protocol.ITypeRegistry typeRegistry) { }
     }
     public class ProtocolException : Exception, ISerializable, _Exception

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -75,6 +75,7 @@ namespace Halibut
         public HalibutRuntimeBuilder() { }
         public Halibut.HalibutRuntime Build() { }
         public Halibut.HalibutRuntimeBuilder WithLogFactory(Halibut.Diagnostics.ILogFactory logFactory) { }
+        public Halibut.HalibutRuntimeBuilder WithMessageSerializer(Halibut.Transport.Protocol.IMessageSerializer messageSerializer) { }
         public Halibut.HalibutRuntimeBuilder WithPendingRequestQueueFactory(Halibut.ServiceModel.IPendingRequestQueueFactory queueFactory) { }
         public Halibut.HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate) { }
         public Halibut.HalibutRuntimeBuilder WithServiceFactory(Halibut.ServiceModel.IServiceFactory serviceFactory) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -80,6 +80,7 @@ namespace Halibut
         public Halibut.HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate) { }
         public Halibut.HalibutRuntimeBuilder WithServiceFactory(Halibut.ServiceModel.IServiceFactory serviceFactory) { }
         public Halibut.HalibutRuntimeBuilder WithTrustProvider(Halibut.ServiceModel.ITrustProvider trustProvider) { }
+        public Halibut.HalibutRuntimeBuilder WithTypeRegistry(Halibut.Transport.Protocol.ITypeRegistry typeRegistry) { }
     }
     public interface IDataStreamReceiver
     {
@@ -491,6 +492,7 @@ namespace Halibut.Transport.Protocol
     public class HalibutContractResolver : Newtonsoft.Json.Serialization.DefaultContractResolver, Newtonsoft.Json.Serialization.IContractResolver
     {
         public HalibutContractResolver() { }
+        internal static Newtonsoft.Json.Serialization.IContractResolver Instance {  }
         public Newtonsoft.Json.Serialization.JsonContract ResolveContract(Type type) { }
     }
     public interface IMessageExchangeStream
@@ -519,6 +521,13 @@ namespace Halibut.Transport.Protocol
         public InMemoryDataStreamReceiver(Action<Stream> writer) { }
         public void Read(Action<Stream> reader) { }
         public void SaveTo(string filePath) { }
+    }
+    public interface ITypeRegistry
+    {
+        public void AddToMessageContract(Type[] types) { }
+        public bool IsInAllowedTypes(Type type) { }
+        public void Register(Type[] registeredServiceTypes) { }
+        public void RegisterType(Type type, string path, bool ignoreObject) { }
     }
     public class MessageExchangeProtocol
     {
@@ -553,6 +562,13 @@ namespace Halibut.Transport.Protocol
         public void AddToMessageContract(Type[] types) { }
         public T ReadMessage<T>(Stream stream) { }
         public void WriteMessage<T>(Stream stream, T message) { }
+    }
+    public class MessageSerializerBuilder
+    {
+        public MessageSerializerBuilder() { }
+        public Halibut.Transport.Protocol.MessageSerializer Build() { }
+        public Halibut.Transport.Protocol.MessageSerializerBuilder WithSerializerBuilder(Func<Newtonsoft.Json.JsonSerializer> createSerializer) { }
+        public Halibut.Transport.Protocol.MessageSerializerBuilder WithTypeRegistry(Halibut.Transport.Protocol.ITypeRegistry typeRegistry) { }
     }
     public class ProtocolException : Exception, ISerializable, _Exception
     {

--- a/source/Halibut.Tests/RegisteredSerializationBinderFixture.cs
+++ b/source/Halibut.Tests/RegisteredSerializationBinderFixture.cs
@@ -12,7 +12,8 @@ namespace Halibut.Tests
         [Test]
         public void BindMethods_WithValidClass_FindsAllMethodTypes()
         {
-            var binder = new RegisteredSerializationBinder();
+            var typeRegistry = new TypeRegistry();
+            var binder = new RegisteredSerializationBinder(typeRegistry);
             binder.Register(typeof(IExampleService));
             binder.BindToName(typeof(ExampleProperties), out var assemblyName, out var typeName);
             var t = binder.BindToType(assemblyName, typeName);
@@ -70,7 +71,8 @@ namespace Halibut.Tests
         [TestCase(typeof(IObjectExampleService))]
         public void Register_WithInvalidTypes_WillThrow(params Type[] types)
         {
-            var binder = new RegisteredSerializationBinder();
+            var typeRegistry = new TypeRegistry();
+            var binder = new RegisteredSerializationBinder(typeRegistry);
             Assert.Throws<TypeNotAllowedException>(() => { binder.Register(types); });
         }
         
@@ -97,7 +99,8 @@ namespace Halibut.Tests
         [Test]
         public void Circular_Types_CanBeResolved()
         {
-            var binder = new RegisteredSerializationBinder();
+            var typeRegistry = new TypeRegistry();
+            var binder = new RegisteredSerializationBinder(typeRegistry);
             binder.Register(typeof(IMCircular));
             binder.BindToName(typeof(CircularPart1), out var assemblyName1, out var typeName1);
             var t1 = binder.BindToType(assemblyName1, typeName1);

--- a/source/Halibut.Tests/SecureClientFixture.cs
+++ b/source/Halibut.Tests/SecureClientFixture.cs
@@ -70,7 +70,7 @@ namespace Halibut.Tests
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog logger)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializer(), logger), logger);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), logger), logger);
         }
     }
 }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -25,13 +25,13 @@ namespace Halibut
         readonly List<IDisposable> listeners = new List<IDisposable>();
         readonly ITrustProvider trustProvider;
         readonly ConcurrentDictionary<Uri, ServiceEndPoint> routeTable = new ConcurrentDictionary<Uri, ServiceEndPoint>();
-        readonly ServiceInvoker invoker;
+        readonly IServiceInvoker invoker;
         readonly ILogFactory logs;
         readonly ConnectionManager connectionManager = new ConnectionManager();
         readonly PollingClientCollection pollingClients = new PollingClientCollection();
         string friendlyHtmlPageContent = DefaultFriendlyHtmlPageContent;
         Dictionary<string, string> friendlyHtmlPageHeaders = new Dictionary<string, string>();
-        readonly MessageSerializer messageSerializer = new MessageSerializer();
+        readonly IMessageSerializer messageSerializer;
 
         [Obsolete]
         public HalibutRuntime(X509Certificate2 serverCertificate) : this(new NullServiceFactory(), serverCertificate, new DefaultTrustProvider())
@@ -54,7 +54,9 @@ namespace Halibut
             // if you change anything here, also change the below internal ctor
             this.serverCertificate = serverCertificate;
             this.trustProvider = trustProvider;
-            messageSerializer.AddToMessageContract(serviceFactory.RegisteredServiceTypes.ToArray());
+            var serializer = new MessageSerializer();
+            serializer.AddToMessageContract(serviceFactory.RegisteredServiceTypes.ToArray());
+            messageSerializer = serializer;
             invoker = new ServiceInvoker(serviceFactory);
             
             // these two are the reason we can't just call our internal ctor.
@@ -62,11 +64,11 @@ namespace Halibut
             queueFactory = new DefaultPendingRequestQueueFactory(logs);
         }
         
-        internal HalibutRuntime(IServiceFactory serviceFactory, X509Certificate2 serverCertificate, ITrustProvider trustProvider, IPendingRequestQueueFactory queueFactory, ILogFactory logFactory)
+        internal HalibutRuntime(IServiceFactory serviceFactory, X509Certificate2 serverCertificate, ITrustProvider trustProvider, IPendingRequestQueueFactory queueFactory, ILogFactory logFactory, IMessageSerializer messageSerializer)
         {
             this.serverCertificate = serverCertificate;
             this.trustProvider = trustProvider;
-            messageSerializer.AddToMessageContract(serviceFactory.RegisteredServiceTypes.ToArray());
+            this.messageSerializer = messageSerializer;
             invoker = new ServiceInvoker(serviceFactory);
             
             logs = logFactory;
@@ -192,8 +194,11 @@ namespace Halibut
         
         public TService CreateClient<TService>(ServiceEndPoint endpoint, CancellationToken cancellationToken)
         {
-            messageSerializer.AddToMessageContract(typeof(TService));
-            
+            if (messageSerializer is MessageSerializer serializer)
+            {
+                serializer.AddToMessageContract(typeof(TService));
+            }
+
 #if HAS_REAL_PROXY
 #pragma warning disable 618
             return (TService)new HalibutProxy(SendOutgoingRequest, typeof(TService), endpoint, cancellationToken).GetTransparentProxy();

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -6,6 +6,8 @@ namespace Halibut.Transport.Protocol
 {
     public class HalibutContractResolver : DefaultContractResolver
     {
+        internal static IContractResolver Instance { get; } = new HalibutContractResolver();
+
         volatile bool HaveAddedCaptureOnSerializeCallback = false;
         
         public override JsonContract ResolveContract(Type type)

--- a/source/Halibut/Transport/Protocol/ITypeRegistry.cs
+++ b/source/Halibut/Transport/Protocol/ITypeRegistry.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Halibut.Transport.Protocol
+{
+    public interface ITypeRegistry
+    {
+        void Register(params Type[] registeredServiceTypes);
+        void RegisterType(Type type, string path, bool ignoreObject);
+        bool IsInAllowedTypes(Type type);
+        void AddToMessageContract(params Type[] types);
+    }
+}

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -16,8 +16,10 @@ namespace Halibut.Transport.Protocol
             typeRegistry = new TypeRegistry();
             createSerializer = () =>
             {
+                var settings = MessageSerializerBuilder.CreateSerializer();
                 var binder = new RegisteredSerializationBinder(typeRegistry);
-                return MessageSerializerBuilder.CreateSerializer(binder);
+                settings.SerializationBinder = binder;
+                return JsonSerializer.Create(settings);
             };
         }
 

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Halibut.Transport.Protocol
 {
@@ -17,7 +16,7 @@ namespace Halibut.Transport.Protocol
 
         public MessageSerializerBuilder WithSerializerSettings(Action<JsonSerializerSettings> configure)
         {
-            this.configureSerializer = configure;
+            configureSerializer = configure;
             return this;
         }
 

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Halibut.Transport.Protocol
+{
+    public class MessageSerializerBuilder
+    {
+        ITypeRegistry typeRegistry;
+        Func<JsonSerializer> createSerializer;
+
+        public MessageSerializerBuilder WithTypeRegistry(ITypeRegistry typeRegistry)
+        {
+            this.typeRegistry = typeRegistry;
+            return this;
+        }
+
+        public MessageSerializerBuilder WithSerializerBuilder(Func<JsonSerializer> createSerializer)
+        {
+            this.createSerializer = createSerializer;
+            return this;
+        }
+
+        public MessageSerializer Build()
+        {
+            var typeRegistry = this.typeRegistry ?? new TypeRegistry();
+            var createSerializer = this.createSerializer ?? (() =>
+            {
+                var binder = new RegisteredSerializationBinder(typeRegistry);
+                return CreateSerializer(binder);
+            });
+            var messageSerializer = new MessageSerializer(typeRegistry, createSerializer);
+
+            return messageSerializer;
+        }
+
+        internal static JsonSerializer CreateSerializer(ISerializationBinder binder)
+        {
+            var jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                Formatting = Formatting.None,
+                ContractResolver = HalibutContractResolver.Instance,
+                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                SerializationBinder = binder
+            });
+
+            return jsonSerializer;
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -1,109 +1,38 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using Halibut.Util;
 using Newtonsoft.Json.Serialization;
 
 namespace Halibut.Transport.Protocol
 {
     public class RegisteredSerializationBinder : ISerializationBinder
     {
-        readonly Type[] protocolTypes = new[] { typeof(ResponseMessage), typeof(RequestMessage) };
-        readonly HashSet<Type> allowedTypes = new HashSet<Type>();
         readonly ISerializationBinder baseBinder = new DefaultSerializationBinder();
-        
-        public RegisteredSerializationBinder()
+        readonly Type[] protocolTypes = { typeof(ResponseMessage), typeof(RequestMessage) };
+        readonly ITypeRegistry typeRegistry;
+
+        public RegisteredSerializationBinder() : this(new TypeRegistry())
         {
-            foreach (var protocolType in protocolTypes)
-            {
-                RegisterType(protocolType, protocolType.Name, true);    
-            }
-        }
+        } // kept for backwards compatibility.
 
-        public void Register(params Type[] registeredServiceTypes)
+        internal RegisteredSerializationBinder(ITypeRegistry typeRegistry)
         {
-            foreach (var serviceType in registeredServiceTypes)
-            {
-                foreach (var method in serviceType.GetHalibutServiceMethods())
-                {
-                    RegisterType(method.ReturnType, $"{serviceType.Name}.{method.Name}:{method.ReturnType.Name}", false);
-                    
-                    foreach (var param in method.GetParameters())
-                    {
-                        RegisterType(param.ParameterType,$"{serviceType.Name}.{method.Name}(){param.Name}:{param.ParameterType.Name}", false);
-                    }
-                }
-            }
-        }
-        
-        void RegisterType(Type type, string path, bool ignoreObject)
-        {
-            if (!type.AllowedOnHalibutInterface())
-            {
-                if (ignoreObject)
-                {
-                    return;
-                }
-                
-                throw new TypeNotAllowedException(type, path);
-            }
-
-            lock (allowedTypes)
-            {
-                if (!allowedTypes.Add(type))
-                {
-                    // Seen this before, no need to go further
-                    return;
-                }
-            }
-
-            if (ShouldRegisterProperties(type))
-            {
-                foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-                {
-                    RegisterType(p.PropertyType, $"{path}.{p.Name}", ignoreObject);
-                }
-            }
-
-            foreach (var sub in SubTypesFor(type))
-            {
-                RegisterType(sub, $"{path}<{sub.Name}>", ignoreObject);
-            }
-        }
-
-        bool ShouldRegisterProperties(Type type)
-        {
-            return !type.IsEnum && !type.IsValueType && !type.IsPrimitive && !type.IsPointer && !type.HasElementType && type.Namespace != null && !type.Namespace.StartsWith("System");
-        }
-
-        IEnumerable<Type> SubTypesFor(Type type)
-        {
-            if (type.HasElementType)
-            {
-                yield return type.GetElementType();
-            }
-            
-            if (type.IsGenericType)
-            {
-                foreach (var t in type.GenericTypeArguments)
-                {
-                    yield return t;
-                }
-            }
+            this.typeRegistry = typeRegistry;
+            foreach (var protocolType in protocolTypes) typeRegistry.RegisterType(protocolType, protocolType.Name, true);
         }
 
         public Type BindToType(string assemblyName, string typeName)
         {
             var type = baseBinder.BindToType(assemblyName, typeName);
-            lock (allowedTypes)
-            {
-                return allowedTypes.Contains(type) ? type : null;
-            }
+            return typeRegistry.IsInAllowedTypes(type) ? type : null;
         }
 
         public void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
             baseBinder.BindToName(serializedType, out assemblyName, out typeName);
+        }
+
+        public void Register(params Type[] registeredServiceTypes) // kept for backwards compatibility
+        {
+            typeRegistry.Register(registeredServiceTypes);
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/TypeRegistry.cs
+++ b/source/Halibut/Transport/Protocol/TypeRegistry.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Halibut.Util;
+
+namespace Halibut.Transport.Protocol
+{
+    class TypeRegistry : ITypeRegistry
+    {
+        readonly HashSet<Type> messageContractTypes = new HashSet<Type>();
+        readonly HashSet<Type> allowedTypes = new HashSet<Type>();
+
+        public void Register(params Type[] registeredServiceTypes)
+        {
+            foreach (var serviceType in registeredServiceTypes)
+            {
+                foreach (var method in serviceType.GetHalibutServiceMethods())
+                {
+                    RegisterType(method.ReturnType, $"{serviceType.Name}.{method.Name}:{method.ReturnType.Name}", false);
+
+                    foreach (var param in method.GetParameters())
+                    {
+                        RegisterType(param.ParameterType,$"{serviceType.Name}.{method.Name}(){param.Name}:{param.ParameterType.Name}", false);
+                    }
+                }
+            }
+        }
+
+        public void RegisterType(Type type, string path, bool ignoreObject)
+        {
+            if (!type.AllowedOnHalibutInterface())
+            {
+                if (ignoreObject)
+                {
+                    return;
+                }
+
+                throw new TypeNotAllowedException(type, path);
+            }
+
+            lock (allowedTypes)
+            {
+                if (!allowedTypes.Add(type))
+                {
+                    // Seen this before, no need to go further
+                    return;
+                }
+            }
+
+            if (ShouldRegisterProperties(type))
+            {
+                foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    RegisterType(p.PropertyType, $"{path}.{p.Name}", ignoreObject);
+                }
+            }
+
+            foreach (var sub in SubTypesFor(type))
+            {
+                RegisterType(sub, $"{path}<{sub.Name}>", ignoreObject);
+            }
+        }
+
+        bool ShouldRegisterProperties(Type type)
+        {
+            return !type.IsEnum && !type.IsValueType && !type.IsPrimitive && !type.IsPointer && !type.HasElementType && type.Namespace != null && !type.Namespace.StartsWith("System");
+        }
+
+        IEnumerable<Type> SubTypesFor(Type type)
+        {
+            if (type.HasElementType)
+            {
+                yield return type.GetElementType();
+            }
+
+            if (type.IsGenericType)
+            {
+                foreach (var t in type.GenericTypeArguments)
+                {
+                    yield return t;
+                }
+            }
+        }
+
+        public bool IsInAllowedTypes(Type type)
+        {
+            lock (allowedTypes)
+            {
+                return allowedTypes.Contains(type);
+            }
+        }
+
+        public void AddToMessageContract(params Type[] types)
+        {
+            lock (messageContractTypes)
+            {
+                var newTypes = types.Where(t => messageContractTypes.Add(t)).ToArray();
+                Register(newTypes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows consumers of this library to add additional config to the message serializer, e.g:

```csharp
void Configure(JsonSerializerSettings settings)
{
    settings.Converters = new List<JsonConverter>
    {
        customConverter
    };
}

var halibutRuntime = new HalibutRuntimeBuilder()
    .WithMessageSerializer(builder => builder.WithSerializerSettings(Configure))
    .Build();
```