### PR TITLE
Only rewind decorate the message exchange on the listening side.

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -536,6 +536,7 @@ namespace Halibut.Transport.Protocol
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
     {
         public MessageExchangeStream(Stream stream, Halibut.Transport.Protocol.IMessageSerializer serializer, Halibut.Diagnostics.ILog log) { }
+        public MessageExchangeStream(Stream stream, Halibut.Transport.Protocol.IMessageSerializer serializer, Halibut.Diagnostics.ILog log, bool useRewindableBuffer) { }
         public bool ExpectNextOrEnd() { }
         public Task<bool> ExpectNextOrEndAsync() { }
         public void ExpectProceeed() { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -543,6 +543,7 @@ namespace Halibut.Transport.Protocol
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
     {
         public MessageExchangeStream(Stream stream, Halibut.Transport.Protocol.IMessageSerializer serializer, Halibut.Diagnostics.ILog log) { }
+        public MessageExchangeStream(Stream stream, Halibut.Transport.Protocol.IMessageSerializer serializer, Halibut.Diagnostics.ILog log, bool useRewindableBuffer) { }
         public bool ExpectNextOrEnd() { }
         public Task<bool> ExpectNextOrEndAsync() { }
         public void ExpectProceeed() { }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -101,14 +101,14 @@ namespace Halibut
             return Listen(new IPEndPoint(ipAddress, port));
         }
         
-        ExchangeProtocolBuilder ExchangeProtocolBuilder()
+        ExchangeProtocolBuilder ExchangeProtocolBuilder(bool useRewindableBuffer = false)
         {
-            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, messageSerializer, log), log);
+            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, messageSerializer, log, useRewindableBuffer), log);
         }
 
         public int Listen(IPEndPoint endpoint)
         {
-            var listener = new SecureListener(endpoint, serverCertificate, ExchangeProtocolBuilder(), HandleMessage, IsTrusted, logs, () => friendlyHtmlPageContent, () => friendlyHtmlPageHeaders, HandleUnauthorizedClientConnect);
+            var listener = new SecureListener(endpoint, serverCertificate, ExchangeProtocolBuilder(true), HandleMessage, IsTrusted, logs, () => friendlyHtmlPageContent, () => friendlyHtmlPageHeaders, HandleUnauthorizedClientConnect);
             lock (listeners)
             {
                 listeners.Add(listener);
@@ -119,7 +119,7 @@ namespace Halibut
 
         public void ListenWebSocket(string endpoint)
         {
-            var listener = new SecureWebSocketListener(endpoint, serverCertificate, ExchangeProtocolBuilder(), HandleMessage, IsTrusted, logs, () => friendlyHtmlPageContent, () => friendlyHtmlPageHeaders, HandleUnauthorizedClientConnect);
+            var listener = new SecureWebSocketListener(endpoint, serverCertificate, ExchangeProtocolBuilder(true), HandleMessage, IsTrusted, logs, () => friendlyHtmlPageContent, () => friendlyHtmlPageHeaders, HandleUnauthorizedClientConnect);
             lock (listeners)
             {
                 listeners.Add(listener);

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -26,12 +26,16 @@ namespace Halibut.Transport.Protocol
         readonly IMessageSerializer serializer;
         readonly Version currentVersion = new Version(1, 0);
 
-        public MessageExchangeStream(Stream stream, IMessageSerializer serializer, ILog log)
+        public MessageExchangeStream(Stream stream, IMessageSerializer serializer, ILog log) : this(stream, serializer, log, false)
+        {
+        }
+
+        public MessageExchangeStream(Stream stream, IMessageSerializer serializer, ILog log, bool useRewindableBuffer)
         {
             #if NETFRAMEWORK
             this.stream = stream;
             #else
-            this.stream = new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
+            this.stream = useRewindableBuffer ? new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize) : stream;
             #endif
             this.log = log;
             streamWriter = new StreamWriter(this.stream, new UTF8Encoding(false)) { NewLine = "\r\n" };


### PR DESCRIPTION
# Background

When https://github.com/OctopusDeploy/Halibut/pull/154 was introduced, it addressed issues with the `DeflateStream` buffer on the listening side of the Halibut connection. While it was only to address listeners, tests showed no harm having the client-side include the same fix to keep things simple.

This PR removes the the `DeflateStream` fix from the client-side, as it's not necessary to be there.

# Results

Halibut `SecureListener` classes now explicitly use the `DeflateStream` fix from from https://github.com/OctopusDeploy/Halibut/pull/154 inside their `MessageExchangeStream` . All other uses of `MessageExchangeStream` do not include the fix.

# How to review this PR
👀 
Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
