### PR TITLE
Add support for setting timeouts to the RewindableBufferStream allowing halibut to recover from dropped tcp connections.

### DIFF
--- a/source/Halibut/Transport/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/RewindableBufferStream.cs
@@ -108,6 +108,20 @@ namespace Halibut.Transport
         public override bool CanSeek => false;
         public override bool CanWrite => true;
 
+        public override bool CanTimeout => baseStream.CanTimeout;
+        
+        public override int ReadTimeout
+        {
+            get => baseStream.ReadTimeout;
+            set => baseStream.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => baseStream.WriteTimeout;
+            set => baseStream.WriteTimeout = value;
+        }
+
         public override long Length
             => throw new NotSupportedException();
 


### PR DESCRIPTION
# Background

The Halibut client maintains a pool of TCP connections which do not have keepalive enabled, sometimes these TCP connections can be killed. Ordinary Halibut handles this by checking the TCP connection with lowered TCP timeouts. Since the `RewindableBufferStream` did not support lowering the timeouts. So Halibut would wait 10 minutes which would exceed the `ConnectionErrorRetryTimeout` resulting in Halibut not creating a new TCP connection to execute the request with.

# Results

`RewindableBufferStream` now supports lowering the timeout.

## Before

```
We got response Hello
The time is: 6/7/2022 2:37:34 am
sleeping for: 271 seconds, goodnight
Woke up at: 6/7/2022 2:42:05 am
Unhandled exception. Halibut.HalibutClientException: An error occurred when sending a request to 'https://20.5.209.198:80/', before the request could begin: Unable to read data from the transport connection: Connection timed out.
 ---> Halibut.Transport.Protocol.ConnectionInitializationFailedException: Unable to read data from the transport connection: Connection timed out.
 ---> System.IO.IOException: Unable to read data from the transport connection: Connection timed out.
 ---> System.Net.Sockets.SocketException (110): Connection timed out
   --- End of inner exception stack trace ---
   at System.Net.Sockets.NetworkStream.Read(Span`1 buffer)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](TIOAdapter adapter, Memory`1 buffer)
   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.RewindableBufferStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.StreamReader.ReadBuffer()
   at System.IO.StreamReader.ReadLine()
   at Halibut.Transport.Protocol.MessageExchangeStream.ReadLine()
   at Halibut.Transport.Protocol.MessageExchangeStream.ExpectProceeed()
   at Halibut.Transport.Protocol.MessageExchangeProtocol.PrepareExchangeAsClient()
   --- End of inner exception stack trace ---
   at Halibut.Transport.Protocol.MessageExchangeProtocol.PrepareExchangeAsClient()
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ExchangeAsClient(RequestMessage request)
   at Halibut.HalibutRuntime.<>c__DisplayClass45_0.<SendOutgoingHttpsRequest>b__0(MessageExchangeProtocol protocol)
   at Halibut.Transport.SecureListeningClient.ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at Halibut.Transport.SecureListeningClient.HandleError(Exception lastError, Boolean retryAllowed)
   at Halibut.Transport.SecureListeningClient.ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken)
   at Halibut.HalibutRuntime.SendOutgoingHttpsRequest(RequestMessage request, CancellationToken cancellationToken)
   at Halibut.HalibutRuntime.SendOutgoingRequestAsync(RequestMessage request, CancellationToken cancellationToken)
   at Halibut.HalibutRuntime.SendOutgoingRequest(RequestMessage request, CancellationToken cancellationToken)
   at Halibut.ServiceModel.HalibutProxy.DispatchRequest(RequestMessage requestMessage)
   at Halibut.ServiceModel.HalibutProxy.Invoke(MethodInfo targetMethod, Object[] args)
--- End of stack trace from previous location ---
   at System.Reflection.DispatchProxyGenerator.Invoke(Object[] args)
   at generatedProxy_1.Echo(String )
   at Server.Program.RunClient(String certficatePath, String ipAndPort, Int32 sleepTime) in /home/auser/Documents/code/HalibutKeepAliveIssue/Server/Program.cs:line 51
   at Server.Program.Main(String[] args) in /home/auser/Documents/code/HalibutKeepAliveIssue/Server/Program.cs:line 28
   at Server.Program.<Main>(String[] args)

```

## After

```
Starting client
We got response Hello
The time is: 6/7/2022 3:45:15 am
sleeping for: 271 seconds, goodnight
Woke up at: 6/7/2022 3:49:46 am
We got response good
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
