### PR TITLE
Adds a test showing we can recover from tcp connections that die in the pool

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.300",
+        "version": "5.0.100",
         "rollForward": "latestFeature"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.100",
+        "version": "6.0.300",
         "rollForward": "latestFeature"
     }
 }

--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -26,7 +26,7 @@ namespace Halibut.Tests.Util
             listeningSocket.Listen(0);
             logger.Information("Listening on {LoadBalancerEndpoint}", listeningSocket.LocalEndPoint?.ToString());
 
-            var port = ((IPEndPoint?)listeningSocket.LocalEndPoint)!.Port;
+            var port = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
             PublicEndpoint = new UriBuilder(scheme, "localhost", port).Uri;
 
             Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);

--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Halibut.Tests.Util
+{
+    sealed class PortForwarder : IDisposable
+    {
+        readonly Uri originServer;
+        readonly Socket listeningSocket;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        public readonly List<TcpPump> Pumps = new List<TcpPump>();
+        readonly ILogger logger = Log.ForContext<PortForwarder>();
+
+        public PortForwarder(Uri originServer)
+        {
+            this.originServer = originServer;
+            var scheme = originServer.Scheme;
+
+            listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listeningSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listeningSocket.Listen(0);
+            logger.Information("Listening on {LoadBalancerEndpoint}", listeningSocket.LocalEndPoint?.ToString());
+
+            var port = ((IPEndPoint?)listeningSocket.LocalEndPoint)!.Port;
+            PublicEndpoint = new UriBuilder(scheme, "localhost", port).Uri;
+
+            Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
+        }
+
+        public Uri PublicEndpoint { get; }
+
+        async Task WorkerTask(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Yield();
+
+                try
+                {
+                    var clientSocket = await listeningSocket.AcceptAsync();
+                    
+                    var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
+                    var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+                    var pump = new TcpPump(clientSocket, originSocket, originEndPoint);
+                    pump.Stopped += OnPortForwarderStopped;
+                    lock (Pumps)
+                    {
+                        Pumps.Add(pump);
+                    }
+
+                    pump.Start();
+                }
+                catch (SocketException ex)
+                {
+                    // This will occur normally on teardown.
+                    logger.Verbose(ex, "Socket Error accepting new connection {Message}", ex.Message);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Error accepting new connection {Message}", ex.Message);
+                }
+            }
+        }
+
+        void OnPortForwarderStopped(object? sender, EventArgs e)
+        {
+            if (sender is TcpPump portForwarder)
+            {
+                portForwarder.Stopped -= OnPortForwarderStopped;
+                lock (Pumps)
+                {
+                    Pumps.Remove(portForwarder);
+                }
+
+                portForwarder.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            cancellationTokenSource.Cancel();
+            listeningSocket.Close();
+
+            lock (Pumps)
+            {
+                var clone = Pumps.ToArray();
+                Pumps.Clear();
+                foreach (var portForwarder in clone)
+                {
+                    portForwarder.Dispose();
+                }
+            }
+
+            listeningSocket.Dispose();
+            cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -68,7 +68,7 @@ namespace Halibut.Tests.Util
             }
         }
 
-        void OnPortForwarderStopped(object? sender, EventArgs e)
+        void OnPortForwarderStopped(object sender, EventArgs e)
         {
             if (sender is TcpPump portForwarder)
             {

--- a/source/Halibut.Tests/Util/TcpPump.cs
+++ b/source/Halibut.Tests/Util/TcpPump.cs
@@ -81,8 +81,6 @@ namespace Halibut.Tests.Util
 
             while (true)
             {
-                await PausePump();
-                
                 await Task.Yield();
 
                 if (cancellationToken.IsCancellationRequested) break;
@@ -91,9 +89,10 @@ namespace Halibut.Tests.Util
 
                 try
                 {
+                    await PausePump(cancellationToken);
                     var receivedByteCount = await readFrom.ReceiveAsync(inputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
                     if (receivedByteCount == 0) break;
-                    await PausePump();
+                    await PausePump(cancellationToken);
                     var outputBuffer = new ArraySegment<byte>(inputBuffer, 0, receivedByteCount);
                     await writeTo.SendAsync(outputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
                 }
@@ -112,11 +111,12 @@ namespace Halibut.Tests.Util
             }
         }
 
-        async Task PausePump()
+        async Task PausePump(CancellationToken cancellationToken)
         {
             while (IsPaused)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
+                cancellationToken.ThrowIfCancellationRequested();
             }
         }
 

--- a/source/Halibut.Tests/Util/TcpPump.cs
+++ b/source/Halibut.Tests/Util/TcpPump.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Halibut.Tests.Util
+{
+    public class TcpPump : IDisposable
+    {
+        readonly Socket clientSocket;
+        readonly EndPoint clientEndPoint;
+        readonly Socket originSocket;
+        readonly EndPoint originEndPoint;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        readonly ILogger logger = Log.ForContext<TcpPump>();
+        bool isDisposing;
+        bool isDisposed;
+        
+        public bool IsPaused { get; set; }
+
+        public TcpPump(Socket clientSocket, Socket originSocket, EndPoint originEndPoint)
+        {
+            this.clientSocket = clientSocket ?? throw new ArgumentNullException(nameof(clientSocket));
+            this.originSocket = originSocket ?? throw new ArgumentNullException(nameof(originSocket));
+            this.originEndPoint = originEndPoint ?? throw new ArgumentNullException(nameof(originEndPoint));
+            clientEndPoint = clientSocket.RemoteEndPoint ?? throw new ArgumentException("Remote endpoint is null", nameof(clientSocket));
+        }
+
+        public event EventHandler<EventArgs>? Stopped;
+
+        public void Start()
+        {
+            var cancellationToken = cancellationTokenSource.Token;
+
+            Task.Run(
+                async () =>
+                {
+                    logger.Verbose("Forwarding connection from {ClientEndPoint} to {OriginEndPoint}.", clientEndPoint.ToString(), originEndPoint.ToString());
+
+                    try
+                    {
+                        await originSocket.ConnectAsync(originEndPoint).ConfigureAwait(false);
+
+                        // If the connection was ok, then set-up a pump both ways
+                        var pump1 = Task.Run(async () => await PumpBytes(clientSocket, originSocket, cancellationToken).ConfigureAwait(false), cancellationToken);
+                        var pump2 = Task.Run(async () => await PumpBytes(originSocket, clientSocket, cancellationToken).ConfigureAwait(false), cancellationToken);
+
+                        // When one is finished, they are both "done" so stop them
+                        await Task.WhenAny(pump1, pump2).ConfigureAwait(false);
+                        logger.Verbose("Stopping connection forwarding from {ClientEndPoint} to {OriginEndPoint}.", clientEndPoint.ToString(), originEndPoint.ToString());
+                        if (!cancellationTokenSource.IsCancellationRequested)
+                        {
+                            cancellationTokenSource.Cancel();
+                        }
+
+                        // Wait for both pumps to be complete
+                        await Task.WhenAll(pump1, pump2).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Verbose(ex, "Forwarding between {ClientEndPoint} and {OriginEndPoint} failed.", clientEndPoint.ToString(), originEndPoint.ToString());
+                    }
+
+                    // We are done. Close everything.
+                    logger.Verbose("Stopped connection forwarding from {ClientEndPoint} to {OriginEndPoint}.", clientEndPoint.ToString(), originEndPoint.ToString());
+                    clientSocket.Close();
+                    originSocket.Close();
+
+                    // Let the users know we are done
+                    Stopped?.Invoke(this, EventArgs.Empty);
+                },
+                cancellationToken);
+        }
+
+        async Task PumpBytes(Socket readFrom, Socket writeTo, CancellationToken cancellationToken)
+        {
+            var inputBuffer = new byte[readFrom.ReceiveBufferSize];
+
+            while (true)
+            {
+                await PausePump();
+                
+                await Task.Yield();
+
+                if (cancellationToken.IsCancellationRequested) break;
+                if (!readFrom.Connected) break;
+                if (!writeTo.Connected) break;
+
+                try
+                {
+                    var receivedByteCount = await readFrom.ReceiveAsync(inputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+                    if (receivedByteCount == 0) break;
+                    await PausePump();
+                    var outputBuffer = new ArraySegment<byte>(inputBuffer, 0, receivedByteCount);
+                    await writeTo.SendAsync(outputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+                }
+                catch (SocketException socketException)
+                {
+                    logger.Verbose(socketException, "Received socket error {SocketErrorCode} {ReadEndPoint}.", socketException.SocketErrorCode, readFrom.ToString());
+                }
+                catch (OperationCanceledException canceledException)
+                {
+                    logger.Verbose(canceledException, "Received pump cancellation {ReadEndPoint}.", readFrom.ToString());
+                }
+                catch (Exception ex)
+                {
+                    logger.Warning(ex, "Received pump exception: {Message}.", ex.Message);
+                }
+            }
+        }
+
+        async Task PausePump()
+        {
+            while (IsPaused)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+            }
+        }
+
+        public void Dispose()
+        {
+            if (isDisposing || isDisposed) return;
+            isDisposing = true;
+
+            logger.Verbose("Port forwarder disposed.");
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+            isDisposed = true;
+        }
+
+        public void Pause()
+        {
+            IsPaused = true;
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/TcpPump.cs
+++ b/source/Halibut.Tests/Util/TcpPump.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests.Util
             clientEndPoint = clientSocket.RemoteEndPoint ?? throw new ArgumentException("Remote endpoint is null", nameof(clientSocket));
         }
 
-        public event EventHandler<EventArgs>? Stopped;
+        public event EventHandler<EventArgs> Stopped;
 
         public void Start()
         {
@@ -90,11 +90,12 @@ namespace Halibut.Tests.Util
                 try
                 {
                     await PausePump(cancellationToken);
-                    var receivedByteCount = await readFrom.ReceiveAsync(inputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+                    ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
+                    var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
                     if (receivedByteCount == 0) break;
                     await PausePump(cancellationToken);
                     var outputBuffer = new ArraySegment<byte>(inputBuffer, 0, receivedByteCount);
-                    await writeTo.SendAsync(outputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+                    await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
                 }
                 catch (SocketException socketException)
                 {

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -38,6 +38,8 @@ namespace Halibut.Tests
 
                 var sayHelloTask = Task.Run(() => echo.SayHello("Bob"));
 
+                // The test knows that Halibut should be using the shorter TcpClientHeartbeatReceiveTimeout when checking
+                // the TCP connection pulled out of the pool. Doing this reduces the test time in the failure case.
                 await Task.WhenAny(sayHelloTask, Task.Delay(HalibutLimits.TcpClientHeartbeatReceiveTimeout * 2));
 
                 sayHelloTask.IsCompleted.Should().BeTrue("We should be able to detect dead TCP connections and retry requests with a new TCP connection.");

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class WhenTheTcpConnectionStopsSendingData
+    {
+        [Test]
+        public async Task HalibutCanRecoverFromIdleTcpDisconnect()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+            {
+                var tentaclePort = tentacleListening.Listen();
+                using var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort));
+                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+                
+                var data = new byte[1024];
+                new Random().NextBytes(data);
+
+                var echo = octopus.CreateClient<IEchoService>("https://localhost:" + loadBalancer.PublicEndpoint.Port, Certificates.TentacleListeningPublicThumbprint);
+
+                echo.SayHello("Bob");
+
+                foreach (var portForwarder in loadBalancer.Pumps)
+                {
+                    portForwarder.Pause();
+                }
+
+                var sayHelloTask = Task.Run(() => echo.SayHello("Bob"));
+
+                await Task.WhenAny(sayHelloTask, Task.Delay(HalibutLimits.TcpClientHeartbeatReceiveTimeout * 2));
+
+                sayHelloTask.IsCompleted.Should().BeTrue("We should be able to detect dead TCP connections and retry requests with a new TCP connection.");
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -21,28 +21,30 @@ namespace Halibut.Tests
             using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
             {
                 var tentaclePort = tentacleListening.Listen();
-                using var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort));
-                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
-                
-                var data = new byte[1024];
-                new Random().NextBytes(data);
-
-                var echo = octopus.CreateClient<IEchoService>("https://localhost:" + loadBalancer.PublicEndpoint.Port, Certificates.TentacleListeningPublicThumbprint);
-
-                echo.SayHello("Bob");
-
-                foreach (var portForwarder in loadBalancer.Pumps)
+                using (var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort)))
                 {
-                    portForwarder.Pause();
+                    tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+                
+                    var data = new byte[1024];
+                    new Random().NextBytes(data);
+
+                    var echo = octopus.CreateClient<IEchoService>("https://localhost:" + loadBalancer.PublicEndpoint.Port, Certificates.TentacleListeningPublicThumbprint);
+
+                    echo.SayHello("Bob");
+
+                    foreach (var portForwarder in loadBalancer.Pumps)
+                    {
+                        portForwarder.Pause();
+                    }
+
+                    var sayHelloTask = Task.Run(() => echo.SayHello("Bob"));
+
+                    // The test knows that Halibut should be using the shorter TcpClientHeartbeatReceiveTimeout when checking
+                    // the TCP connection pulled out of the pool. Doing this reduces the test time in the failure case.
+                    await Task.WhenAny(sayHelloTask, Task.Delay(HalibutLimits.TcpClientHeartbeatReceiveTimeout + HalibutLimits.TcpClientHeartbeatReceiveTimeout));
+
+                    sayHelloTask.IsCompleted.Should().BeTrue("We should be able to detect dead TCP connections and retry requests with a new TCP connection.");
                 }
-
-                var sayHelloTask = Task.Run(() => echo.SayHello("Bob"));
-
-                // The test knows that Halibut should be using the shorter TcpClientHeartbeatReceiveTimeout when checking
-                // the TCP connection pulled out of the pool. Doing this reduces the test time in the failure case.
-                await Task.WhenAny(sayHelloTask, Task.Delay(HalibutLimits.TcpClientHeartbeatReceiveTimeout * 2));
-
-                sayHelloTask.IsCompleted.Should().BeTrue("We should be able to detect dead TCP connections and retry requests with a new TCP connection.");
             }
         }
     }


### PR DESCRIPTION
# Background

This adds a test for the fix in https://github.com/OctopusDeploy/Halibut/pull/160 showing that we can recover from TCP connections that become unresponsive in the pool.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
