### PR TITLE
Pass the ServiceEndPoint for the RequestMessage to the ApplyResponse method of the PendingRequestQueue

### DIFF
--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -286,7 +286,7 @@ namespace Halibut.ServiceModel
     public interface IPendingRequestQueue
     {
         public bool IsEmpty { get; }
-        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response, Halibut.ServiceEndPoint destination) { }
         public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
         public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
         public Task<Halibut.Transport.Protocol.ResponseMessage> QueueAndWaitAsync(Halibut.Transport.Protocol.RequestMessage request, System.Threading.CancellationToken cancellationToken) { }
@@ -330,7 +330,7 @@ namespace Halibut.ServiceModel
     {
         public PendingRequestQueue(Halibut.Diagnostics.ILog log) { }
         public bool IsEmpty { get; }
-        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response, Halibut.ServiceEndPoint destination) { }
         public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
         public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
         public Halibut.Transport.Protocol.ResponseMessage QueueAndWait(Halibut.Transport.Protocol.RequestMessage request) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -279,7 +279,7 @@ namespace Halibut.ServiceModel
     public interface IPendingRequestQueue
     {
         public bool IsEmpty { get; }
-        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response, Halibut.ServiceEndPoint destination) { }
         public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
         public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
         public Task<Halibut.Transport.Protocol.ResponseMessage> QueueAndWaitAsync(Halibut.Transport.Protocol.RequestMessage request, System.Threading.CancellationToken cancellationToken) { }
@@ -323,7 +323,7 @@ namespace Halibut.ServiceModel
     {
         public PendingRequestQueue(Halibut.Diagnostics.ILog log) { }
         public bool IsEmpty { get; }
-        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response) { }
+        public void ApplyResponse(Halibut.Transport.Protocol.ResponseMessage response, Halibut.ServiceEndPoint destination) { }
         public Halibut.Transport.Protocol.RequestMessage Dequeue() { }
         public Task<Halibut.Transport.Protocol.RequestMessage> DequeueAsync() { }
         public Halibut.Transport.Protocol.ResponseMessage QueueAndWait(Halibut.Transport.Protocol.RequestMessage request) { }

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -8,7 +8,7 @@ namespace Halibut.ServiceModel
     public interface IPendingRequestQueue
     {
         bool IsEmpty { get; }
-        void ApplyResponse(ResponseMessage response);
+        void ApplyResponse(ResponseMessage response, ServiceEndPoint destination);
         RequestMessage Dequeue();
         Task<RequestMessage> DequeueAsync();
         Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken);

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -120,7 +120,7 @@ namespace Halibut.ServiceModel
             }
         }
 
-        public void ApplyResponse(ResponseMessage response)
+        public void ApplyResponse(ResponseMessage response, ServiceEndPoint destination)
         {
             if (response == null)
                 return;

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -191,7 +191,7 @@ namespace Halibut.Transport.Protocol
                 if (nextRequest != null)
                 {
                     var response = stream.Receive<ResponseMessage>();
-                    pendingRequests.ApplyResponse(response);
+                    pendingRequests.ApplyResponse(response, nextRequest.Destination);
                 }
             }
             catch (Exception ex)
@@ -199,7 +199,7 @@ namespace Halibut.Transport.Protocol
                 if (nextRequest != null)
                 {
                     var response = ResponseMessage.FromException(nextRequest, ex);
-                    pendingRequests.ApplyResponse(response);
+                    pendingRequests.ApplyResponse(response, nextRequest.Destination);
                 }
                 return false;
             }
@@ -229,7 +229,7 @@ namespace Halibut.Transport.Protocol
                 if (nextRequest != null)
                 {
                     var response = stream.Receive<ResponseMessage>();
-                    pendingRequests.ApplyResponse(response);
+                    pendingRequests.ApplyResponse(response, nextRequest.Destination);
                 }
             }
             catch (Exception ex)
@@ -237,7 +237,7 @@ namespace Halibut.Transport.Protocol
                 if (nextRequest != null)
                 {
                     var response = ResponseMessage.FromException(nextRequest, ex);
-                    pendingRequests.ApplyResponse(response);
+                    pendingRequests.ApplyResponse(response, nextRequest.Destination);
                 }
                 return false;
             }


### PR DESCRIPTION
# Background

When using Halibut in Server as part of the Halibut SQL Queue Item we need to know the timeouts for a response message in a custom implementation of IPendingRequestQueue.

# Results

This PR exposes the ServiceEndPoint when handling a response in the IPendingRequestQueue

The PR introduces a breaking change in the public API so we plan to bump the semver major version number.

The breaking changes are isolated to server or tentacle only when using the new version so do not impact compatibility between server and tentacle running different versions of Halibut

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

- Tested with server running Halibut with these changes and tentacle (workers and deployment targets) running Halibut before the changes.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
