### PR TITLE
Fix timeouts seen with net6

### DIFF
--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -15,10 +15,12 @@ namespace Halibut.Tests.Util
         readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         public readonly List<TcpPump> Pumps = new List<TcpPump>();
         readonly ILogger logger = Log.ForContext<PortForwarder>();
+        readonly TimeSpan sendDelay;
 
-        public PortForwarder(Uri originServer)
+        public PortForwarder(Uri originServer, TimeSpan sendDelay)
         {
             this.originServer = originServer;
+            this.sendDelay = sendDelay;
             var scheme = originServer.Scheme;
 
             listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -47,7 +49,7 @@ namespace Halibut.Tests.Util
                     var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
                     var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
-                    var pump = new TcpPump(clientSocket, originSocket, originEndPoint);
+                    var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay);
                     pump.Stopped += OnPortForwarderStopped;
                     lock (Pumps)
                     {

--- a/source/Halibut.Tests/Util/SocketPump.cs
+++ b/source/Halibut.Tests/Util/SocketPump.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Tests.Util
+{
+
+    public class SocketPump
+    {
+        public delegate bool IsPumpPaused();
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        MemoryStream buffer = new MemoryStream();
+        IsPumpPaused isPumpPaused;
+        readonly TimeSpan sendDelay;
+
+        public SocketPump(IsPumpPaused isPumpPaused, TimeSpan sendDelay)
+        {
+            this.isPumpPaused = isPumpPaused;
+            this.sendDelay = sendDelay;
+        }
+
+        public async Task<SocketStatus> PumpBytes(Socket readFrom, Socket writeTo, CancellationToken cancellationToken)
+        {
+            await PausePump(cancellationToken);
+
+            // Only read if we have nothing to send or if data exists 
+            if (readFrom.Available > 0 || buffer.Length == 0)
+            {
+                var receivedByteCount = await ReadFromSocket(readFrom, buffer);
+                if (receivedByteCount == 0) return SocketStatus.SOCKET_CLOSED;
+                stopwatch = Stopwatch.StartNew();
+            }
+
+
+            await PausePump(cancellationToken);
+
+            if ((readFrom.Available == 0 && stopwatch.Elapsed >= sendDelay) || buffer.Length > 100 * 1024 * 1024)
+            {
+                // Send the data
+                await WriteToSocket(writeTo, buffer.GetBuffer(), (int)buffer.Length);
+                buffer.SetLength(0);
+            }
+            else
+            {
+                await Task.Delay(1, cancellationToken);
+            }
+
+            return SocketStatus.SOCKET_OPEN;
+        }
+
+        async Task PausePump(CancellationToken cancellationToken)
+        {
+            while (isPumpPaused())
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend)
+        {
+            var offset = 0;
+            while (totalBytesToSend - offset > 0)
+            {
+                var outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
+                offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
+            }
+
+        }
+
+        static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream)
+        {
+            var inputBuffer = new byte[readFrom.ReceiveBufferSize];
+            ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
+            var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
+
+            memoryStream.Write(inputBuffer, 0, receivedByteCount);
+            return receivedByteCount;
+        }
+
+
+        public enum SocketStatus
+        {
+            SOCKET_CLOSED,
+            SOCKET_OPEN
+        }
+    }
+}

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests
             using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
             {
                 var tentaclePort = tentacleListening.Listen();
-                using (var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort)))
+                using (var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort), TimeSpan.Zero))
                 {
                     tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
                 

--- a/source/Halibut/Transport/Protocol/ControlMessageReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessageReader.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Halibut.Transport.Protocol
 {
-    public class ControlMessageReader
+    internal class ControlMessageReader
     {
         internal string ReadUntilNonEmptyControlMessage(Stream stream)
         {

--- a/source/Halibut/Transport/Protocol/ControlMessagesReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessagesReader.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Halibut.Transport.Protocol
+{
+    public class ControlMessagesReader
+    {
+        internal string ReadUntilNonEmptyControlMessage(Stream stream)
+        {
+            while (true)
+            {
+                var line = ReadControlMessage(stream);
+                if (line.Length > 0) return line;
+            }
+        }
+
+        internal string ReadControlMessage(Stream stream)
+        {
+            StringBuilder sb = new StringBuilder();
+            while (true)
+            {
+                var line = stream.ReadByte();
+                if (line == -1) throw new EndOfStreamException();
+                if (line == '\r')
+                {
+                    line = stream.ReadByte();
+                    if (line == -1)
+                    {
+                        throw new EndOfStreamException();
+                    }
+
+                    if (line != '\n')
+                    {
+                        throw new Exception($"It is not clear what should be done with this character: dec value {line}");
+                    }
+
+                    // We have found the end of the line, ie we have found \r\n
+                    return sb.ToString();
+                }
+
+                sb.Append((char) line);
+            }
+        }
+
+        internal async Task<string> ReadUntilNonEmptyControlMessageAsync(Stream stream)
+        {
+            while (true)
+            {
+                var line = await ReadControlMessageAsync(stream);
+                if (line.Length > 0) return line;
+            }
+        }
+
+        internal async Task<string> ReadControlMessageAsync(Stream stream)
+        {
+            StringBuilder sb = new StringBuilder();
+            while (true)
+            {
+                var line = new byte[1];
+                var read = await stream.ReadAsync(line, 0, line.Length);
+                if (read == 0) throw new EndOfStreamException();
+                if (line[0] == '\r')
+                {
+                    read = await stream.ReadAsync(line, 0, line.Length);
+                    if (read == 0) throw new EndOfStreamException();
+
+                    if (line[0] != '\n')
+                    {
+                        throw new Exception($"It is not clear what should be done with this character: dec value {line}");
+                    }
+
+                    // We have found the end of control message
+                    return sb.ToString();
+                }
+
+                sb.Append((char) line[0]);
+            }
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -24,7 +24,7 @@ namespace Halibut.Transport.Protocol
         readonly StreamWriter streamWriter;
         readonly IMessageSerializer serializer;
         readonly Version currentVersion = new Version(1, 0);
-        readonly ControlMessagesReader controlMessagesReader = new ControlMessagesReader();
+        readonly ControlMessageReader controlMessageReader = new ControlMessageReader();
 
         public MessageExchangeStream(Stream stream, IMessageSerializer serializer, ILog log)
         {
@@ -93,7 +93,7 @@ namespace Halibut.Transport.Protocol
 
         public bool ExpectNextOrEnd()
         {
-            var line = controlMessagesReader.ReadUntilNonEmptyControlMessage(stream);
+            var line = controlMessageReader.ReadUntilNonEmptyControlMessage(stream);
             switch (line)
             {
                 case Next:
@@ -108,7 +108,7 @@ namespace Halibut.Transport.Protocol
 
         public async Task<bool> ExpectNextOrEndAsync()
         {
-            var line = await controlMessagesReader.ReadUntilNonEmptyControlMessageAsync(stream).ConfigureAwait(false);
+            var line = await controlMessageReader.ReadUntilNonEmptyControlMessageAsync(stream).ConfigureAwait(false);
             switch (line)
             {
                 case Next:
@@ -124,7 +124,7 @@ namespace Halibut.Transport.Protocol
         public void ExpectProceeed()
         {
             SetShortTimeouts();
-            var line = controlMessagesReader.ReadUntilNonEmptyControlMessage(stream);
+            var line = controlMessageReader.ReadUntilNonEmptyControlMessage(stream);
             if (line == null)
                 throw new AuthenticationException("XYZ");
             if (line != Proceed)
@@ -147,12 +147,12 @@ namespace Halibut.Transport.Protocol
 
         public RemoteIdentity ReadRemoteIdentity()
         {
-            var line = controlMessagesReader.ReadControlMessage(stream);
+            var line = controlMessageReader.ReadControlMessage(stream);
             
             
             if (string.IsNullOrEmpty(line)) throw new ProtocolException("Unable to receive the remote identity; the identity line was empty.");
             
-            var emptyLine = controlMessagesReader.ReadControlMessage(stream);
+            var emptyLine = controlMessageReader.ReadControlMessage(stream);
             if (emptyLine.Length != 0)
             {
                 throw new ProtocolException("Unable to receive the remote identity; the following line was not empty.");
@@ -174,7 +174,7 @@ namespace Halibut.Transport.Protocol
             {
                 log.Write(EventType.Error, "Response:");
                 log.Write(EventType.Error, line);
-                log.Write(EventType.Error, "TODO: streamReader.ReadToEnd()");
+                log.Write(EventType.Error, new StreamReader(stream, new UTF8Encoding(false)).ReadToEnd());
 
                 throw;
             }


### PR DESCRIPTION
# Background

Fixes a bug in which halibut under NET6 would throw: `System.IO.InvalidDataException: The archive entry was compressed using an unsupported compression` exceptions or the client would just get stuck and no more messages would be processed.


# Results

Fixes: https://github.com/OctopusDeploy/Halibut/issues/199

The issue was related to timings and wrapped streams with buffers.

The message coming down the wire looks something like:
```
NEXT\r\n
<Zipped BSON><datastreams>
```

halibut was using two streams to read off the wire:
* The **inner stream**: which is used to read the zip.
* The **StreamReader**: which wraps the inner stream to read the control messages such as `NEXT\r\n`.

The issue occurs when both the control message `NEXT\r\n`  and the `<Zipped BSON>` arrived at the same time. What happens is the `StreamReader` which has its own buffer of `1024` bytes would read not only the `NEXT\r\n` message from the inner stream it would read some of the following `<Zipped BSON>` or perhaps even read the entire `<Zipped BSON><datastreams>` section. This is how we get the `System.IO.InvalidDataException` or the timeouts.

The fix is to, remove the `StreamReader` and read directly from the stream. Reading of short control messages is now down byte by byte which is slower, by an unmeasured and likely non noticeable amount.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
