### PR TITLE
Adds a test

### DIFF
--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -15,10 +15,12 @@ namespace Halibut.Tests.Util
         readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         public readonly List<TcpPump> Pumps = new List<TcpPump>();
         readonly ILogger logger = Log.ForContext<PortForwarder>();
+        readonly TimeSpan sendDelay;
 
-        public PortForwarder(Uri originServer)
+        public PortForwarder(Uri originServer, TimeSpan sendDelay)
         {
             this.originServer = originServer;
+            this.sendDelay = sendDelay;
             var scheme = originServer.Scheme;
 
             listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -47,7 +49,7 @@ namespace Halibut.Tests.Util
                     var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
                     var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
-                    var pump = new TcpPump(clientSocket, originSocket, originEndPoint);
+                    var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay);
                     pump.Stopped += OnPortForwarderStopped;
                     lock (Pumps)
                     {

--- a/source/Halibut.Tests/Util/SocketPump.cs
+++ b/source/Halibut.Tests/Util/SocketPump.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Tests.Util;
+
+public class SocketPump
+{
+    public delegate bool IsPumpPaused();
+    
+    Stopwatch stopwatch = Stopwatch.StartNew();
+    MemoryStream buffer = new MemoryStream();
+    IsPumpPaused isPumpPaused;
+    readonly TimeSpan sendDelay;
+
+    public SocketPump(IsPumpPaused isPumpPaused, TimeSpan sendDelay)
+    {
+        this.isPumpPaused = isPumpPaused;
+        this.sendDelay = sendDelay;
+    }
+    
+    public async Task<SocketStatus> PumpBytes(Socket readFrom, Socket writeTo, CancellationToken cancellationToken)
+    {
+        await PausePump(cancellationToken);
+                    
+        // Only read if we have nothing to send or if data exists 
+        if(readFrom.Available > 0 || buffer.Length == 0)
+        {
+            var receivedByteCount = await ReadFromSocket(readFrom, buffer);
+            if (receivedByteCount == 0) return SocketStatus.SOCKET_CLOSED;
+            stopwatch = Stopwatch.StartNew();
+        }
+
+
+        await PausePump(cancellationToken);
+                    
+        if((readFrom.Available == 0 && stopwatch.Elapsed >= sendDelay) || buffer.Length > 100 * 1024 * 1024)
+        {
+            // Send the data
+            await WriteToSocket(writeTo, buffer.GetBuffer(), (int) buffer.Length);
+            buffer.SetLength(0);
+        }
+        else
+        {
+            await Task.Delay(1, cancellationToken);
+        }
+
+        return SocketStatus.SOCKET_OPEN;
+    }
+    
+    async Task PausePump(CancellationToken cancellationToken)
+    {
+        while (isPumpPaused())
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend)
+    {
+        var offset = 0;
+        while (totalBytesToSend - offset > 0)
+        {
+            var outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
+            offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
+        }
+        
+    }
+
+    static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream)
+    {
+        var inputBuffer = new byte[readFrom.ReceiveBufferSize];
+        ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
+        var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
+
+        memoryStream.Write(inputBuffer, 0, receivedByteCount);
+        return receivedByteCount;
+    }
+
+
+    public enum SocketStatus
+    {
+        SOCKET_CLOSED,
+        SOCKET_OPEN
+    }
+}

--- a/source/Halibut.Tests/Util/SocketPump.cs
+++ b/source/Halibut.Tests/Util/SocketPump.cs
@@ -5,86 +5,88 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Halibut.Tests.Util;
-
-public class SocketPump
+namespace Halibut.Tests.Util
 {
-    public delegate bool IsPumpPaused();
-    
-    Stopwatch stopwatch = Stopwatch.StartNew();
-    MemoryStream buffer = new MemoryStream();
-    IsPumpPaused isPumpPaused;
-    readonly TimeSpan sendDelay;
 
-    public SocketPump(IsPumpPaused isPumpPaused, TimeSpan sendDelay)
+    public class SocketPump
     {
-        this.isPumpPaused = isPumpPaused;
-        this.sendDelay = sendDelay;
-    }
-    
-    public async Task<SocketStatus> PumpBytes(Socket readFrom, Socket writeTo, CancellationToken cancellationToken)
-    {
-        await PausePump(cancellationToken);
-                    
-        // Only read if we have nothing to send or if data exists 
-        if(readFrom.Available > 0 || buffer.Length == 0)
+        public delegate bool IsPumpPaused();
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        MemoryStream buffer = new MemoryStream();
+        IsPumpPaused isPumpPaused;
+        readonly TimeSpan sendDelay;
+
+        public SocketPump(IsPumpPaused isPumpPaused, TimeSpan sendDelay)
         {
-            var receivedByteCount = await ReadFromSocket(readFrom, buffer);
-            if (receivedByteCount == 0) return SocketStatus.SOCKET_CLOSED;
-            stopwatch = Stopwatch.StartNew();
+            this.isPumpPaused = isPumpPaused;
+            this.sendDelay = sendDelay;
+        }
+
+        public async Task<SocketStatus> PumpBytes(Socket readFrom, Socket writeTo, CancellationToken cancellationToken)
+        {
+            await PausePump(cancellationToken);
+
+            // Only read if we have nothing to send or if data exists 
+            if (readFrom.Available > 0 || buffer.Length == 0)
+            {
+                var receivedByteCount = await ReadFromSocket(readFrom, buffer);
+                if (receivedByteCount == 0) return SocketStatus.SOCKET_CLOSED;
+                stopwatch = Stopwatch.StartNew();
+            }
+
+
+            await PausePump(cancellationToken);
+
+            if ((readFrom.Available == 0 && stopwatch.Elapsed >= sendDelay) || buffer.Length > 100 * 1024 * 1024)
+            {
+                // Send the data
+                await WriteToSocket(writeTo, buffer.GetBuffer(), (int)buffer.Length);
+                buffer.SetLength(0);
+            }
+            else
+            {
+                await Task.Delay(1, cancellationToken);
+            }
+
+            return SocketStatus.SOCKET_OPEN;
+        }
+
+        async Task PausePump(CancellationToken cancellationToken)
+        {
+            while (isPumpPaused())
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend)
+        {
+            var offset = 0;
+            while (totalBytesToSend - offset > 0)
+            {
+                var outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
+                offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
+            }
+
+        }
+
+        static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream)
+        {
+            var inputBuffer = new byte[readFrom.ReceiveBufferSize];
+            ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
+            var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
+
+            memoryStream.Write(inputBuffer, 0, receivedByteCount);
+            return receivedByteCount;
         }
 
 
-        await PausePump(cancellationToken);
-                    
-        if((readFrom.Available == 0 && stopwatch.Elapsed >= sendDelay) || buffer.Length > 100 * 1024 * 1024)
+        public enum SocketStatus
         {
-            // Send the data
-            await WriteToSocket(writeTo, buffer.GetBuffer(), (int) buffer.Length);
-            buffer.SetLength(0);
+            SOCKET_CLOSED,
+            SOCKET_OPEN
         }
-        else
-        {
-            await Task.Delay(1, cancellationToken);
-        }
-
-        return SocketStatus.SOCKET_OPEN;
-    }
-    
-    async Task PausePump(CancellationToken cancellationToken)
-    {
-        while (isPumpPaused())
-        {
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
-            cancellationToken.ThrowIfCancellationRequested();
-        }
-    }
-
-    static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend)
-    {
-        var offset = 0;
-        while (totalBytesToSend - offset > 0)
-        {
-            var outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
-            offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
-        }
-        
-    }
-
-    static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream)
-    {
-        var inputBuffer = new byte[readFrom.ReceiveBufferSize];
-        ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
-        var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
-
-        memoryStream.Write(inputBuffer, 0, receivedByteCount);
-        return receivedByteCount;
-    }
-
-
-    public enum SocketStatus
-    {
-        SOCKET_CLOSED,
-        SOCKET_OPEN
     }
 }

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests
             using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
             {
                 var tentaclePort = tentacleListening.Listen();
-                using (var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort)))
+                using (var loadBalancer = new PortForwarder(new Uri("https://localhost:" + tentaclePort), TimeSpan.Zero))
                 {
                     tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
                 


### PR DESCRIPTION
# Background

Adds a test for the timeout and errors seen in https://github.com/OctopusDeploy/Halibut/pull/198


# Results

The port forwarder is re-used to add latency and change how data arrives. The new behaviour allows configuring the port forwarder to buffer up data before sending until no data has been received in some number of milliseconds. This means if a sender sends the following:
```
write("foo");
flush();
write("bar");
flush();
```

Ordinarily the receiver would read `"foo"` from the stream and later read `"bar"`.  With the delay and buffering added in this PR, the sender will end up sending both messages in a single write so the above turns in to:

```
write("foobar")
```

This likely ends up with the reader reading `"foobar"` off the wire in a single read call.

This is how we reproduce problems in which halibut consumes too much of the wire when the data is available.

## Before

We did not have a test that reproduced the problem seen in https://github.com/OctopusDeploy/Halibut/pull/198

## After

Now we have a test that reproduces the problem seen in https://github.com/OctopusDeploy/Halibut/pull/198

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
