### PR TITLE
Sast/provide async read write methods for rewindable buffer stream

### DIFF
--- a/source/Halibut/Transport/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/RewindableBufferStream.cs
@@ -129,7 +129,12 @@ namespace Halibut.Transport
         {
             baseStream.Write(buffer, offset, count);
         }
-            
+
+        public async override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await base.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
 
         public override bool CanRead => true;
         public override bool CanSeek => false;


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

While investigating an issue related to threadpool starvation, we noticed a stack trace that indicated that the `RewindablebufferStream.Read`, a sync operation, becomes involved in an async pathway, since `SslStream`'s implementation of `Read` ultimately involves async behaviour.

![image](https://user-images.githubusercontent.com/117627039/210736307-ee77b88a-3bb1-4512-940b-1d6ef631f26c.png)

This PR overrides the `Stream.ReadAsync` and `Stream.WriteAsync` methods in `RewindableBufferStream` so that the synchronous default implementations of `Stream` are not relied on. It is hoped that specifically this will avoid thread exhaustion due to async-over-sync scenarios appearing, but is seen in any case to be in general a Good Thing by providing async overrides.

[sc-29089]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
