### PR TITLE
Pass the cancellation token to the inner stream when reading

### DIFF
--- a/source/Halibut.Tests/Transport/RewindableBufferStreamTests.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Transport;
 using NUnit.Framework;
@@ -42,6 +43,25 @@ namespace Halibut.Tests.Transport
                 {
                     Assert.AreEqual("Test", await streamReader.ReadToEndAsync());
                 }
+            }
+        }
+        
+        [Test]
+        public async Task ReadAsyncShouldPassTheCancellationTokenToTheUnderlyingStream()
+        {
+            using (var baseStream = new MemoryStream(16))
+            using (var sut = RewindableBufferStreamBuilder.Build(baseStream))
+            {
+                var inputBuffer = Encoding.ASCII.GetBytes("Test");
+                await baseStream.WriteAsync(inputBuffer, 0, inputBuffer.Length);
+
+                baseStream.Position = 0;
+
+                var readBuffer = new byte[inputBuffer.Length];
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                
+                Assert.ThrowsAsync<TaskCanceledException>(async () => await sut.ReadAsync(readBuffer, 0, readBuffer.Length, cts.Token));
             }
         }
 

--- a/source/Halibut.Tests/Transport/RewindableBufferStreamTests.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamTests.cs
@@ -62,7 +62,7 @@ namespace Halibut.Tests.Transport
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
                 
-                var readAsyncCall = async () => await sut.ReadAsync(readBuffer, 0, readBuffer.Length, cts.Token);
+                Func<Task<int>> readAsyncCall = async () => await sut.ReadAsync(readBuffer, 0, readBuffer.Length, cts.Token);
 
                 await readAsyncCall.Should().ThrowAsync<TaskCanceledException>();
             }

--- a/source/Halibut.Tests/Transport/RewindableBufferStreamTests.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Halibut.Transport;
 using NUnit.Framework;
 
@@ -61,7 +62,9 @@ namespace Halibut.Tests.Transport
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
                 
-                Assert.ThrowsAsync<TaskCanceledException>(async () => await sut.ReadAsync(readBuffer, 0, readBuffer.Length, cts.Token));
+                var readAsyncCall = async () => await sut.ReadAsync(readBuffer, 0, readBuffer.Length, cts.Token);
+
+                await readAsyncCall.Should().ThrowAsync<TaskCanceledException>();
             }
         }
 

--- a/source/Halibut/Transport/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/RewindableBufferStream.cs
@@ -114,7 +114,7 @@ namespace Halibut.Transport
                 return rewoundCount;
             }
 
-            var baseCount = await baseStream.ReadAsync(buffer, offset, count);
+            var baseCount = await baseStream.ReadAsync(buffer, offset, count, cancellationToken);
             WriteToRewindBuffer(buffer, offset, baseCount);
             return baseCount;
         }


### PR DESCRIPTION
# Background

Otherwise the read will hang forever, since under async the ReadTimeout is not respected.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
