### PR TITLE
Spike out adding transfer stats to halibut.

### DIFF
--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -214,12 +214,12 @@ namespace Halibut
         
         // https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#warning-sync-over-async
         [Obsolete("Consider implementing an async HalibutProxy instead")]
-        ResponseMessage SendOutgoingRequest(RequestMessage request, CancellationToken cancellationToken)
+        ResponseMessageWithTransferStatistics SendOutgoingRequest(RequestMessage request, CancellationToken cancellationToken)
         {
             return SendOutgoingRequestAsync(request, cancellationToken).GetAwaiter().GetResult();
         }
 
-        async Task<ResponseMessage> SendOutgoingRequestAsync(RequestMessage request, CancellationToken cancellationToken)
+        async Task<ResponseMessageWithTransferStatistics> SendOutgoingRequestAsync(RequestMessage request, CancellationToken cancellationToken)
         {
             var endPoint = request.Destination;
 
@@ -233,11 +233,11 @@ namespace Halibut
             }
         }
 
-        ResponseMessage SendOutgoingHttpsRequest(RequestMessage request, CancellationToken cancellationToken)
+        ResponseMessageWithTransferStatistics SendOutgoingHttpsRequest(RequestMessage request, CancellationToken cancellationToken)
         {
             var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
 
-            ResponseMessage response = null;
+            ResponseMessageWithTransferStatistics response = null;
             client.ExecuteTransaction(protocol =>
             {
                 response = protocol.ExchangeAsClient(request);
@@ -245,7 +245,7 @@ namespace Halibut
             return response;
         }
 
-        async Task<ResponseMessage> SendOutgoingPollingRequest(RequestMessage request, CancellationToken cancellationToken)
+        async Task<ResponseMessageWithTransferStatistics> SendOutgoingPollingRequest(RequestMessage request, CancellationToken cancellationToken)
         {
             var queue = GetQueue(request.Destination.BaseUri);
             return await queue.QueueAndWaitAsync(request, cancellationToken);

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Transport;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.ServiceModel
@@ -8,9 +9,9 @@ namespace Halibut.ServiceModel
     public interface IPendingRequestQueue
     {
         bool IsEmpty { get; }
-        void ApplyResponse(ResponseMessage response, ServiceEndPoint destination);
+        void ApplyResponse(ResponseMessageWithTransferStatistics response, ServiceEndPoint destination);
         RequestMessage Dequeue();
         Task<RequestMessage> DequeueAsync();
-        Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken);
+        Task<ResponseMessageWithTransferStatistics> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/TransferStatistics.cs
+++ b/source/Halibut/TransferStatistics.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Halibut
+{
+    public class TransferStatistics
+    {
+        public TransferStatistics(TimeSpan span, long bytesTransferred)
+        {
+            this.span = span;
+            BytesTransferred = bytesTransferred;
+        }
+        public TimeSpan span { get; }
+        public long BytesTransferred { get; }
+    }
+}

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -16,7 +16,7 @@ namespace Halibut.Transport.Protocol
         void IdentifyAsSubscriber(string subscriptionId);
         void IdentifyAsServer();
         RemoteIdentity ReadRemoteIdentity();
-        void Send<T>(T message);
-        T Receive<T>();
+        TransferStatistics Send<T>(T message);
+        ReceiveMessageWithStatistics<T> Receive<T>();
     }
 }

--- a/source/Halibut/Transport/ResponseMessageWithStatistics.cs
+++ b/source/Halibut/Transport/ResponseMessageWithStatistics.cs
@@ -1,0 +1,40 @@
+using System;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Transport
+{
+    public class ReceiveMessageWithStatistics<T>
+    {
+        public T receivedMessage { get; }
+        public TransferStatistics transferStatistics { get; }
+        public TimeSpan timeWaitingForFirstByteOfResponse { get; }
+
+        public ReceiveMessageWithStatistics(T receivedMessage, TransferStatistics transferStatistics, TimeSpan timeWaitingForFirstByteOfResponse)
+        {
+            this.receivedMessage = receivedMessage;
+            this.transferStatistics = transferStatistics;
+            this.timeWaitingForFirstByteOfResponse = timeWaitingForFirstByteOfResponse;
+        }
+    }
+
+    public class ResponseMessageWithTransferStatistics
+    {
+        public ResponseMessage receivedMessage { get; }
+        public TransferStatistics sendStatistics{ get; }
+        public TransferStatistics receiveStatistics{ get; }
+        public TimeSpan? timeWaitingForFirstByteOfResponse{ get; }
+
+        public ResponseMessageWithTransferStatistics(ResponseMessage receivedMessage, TimeSpan? timeWaitingForFirstByteOfResponse, TransferStatistics sendStatistics, TransferStatistics receiveStatistics)
+        {
+            this.timeWaitingForFirstByteOfResponse = timeWaitingForFirstByteOfResponse;
+            this.sendStatistics = sendStatistics;
+            this.receivedMessage = receivedMessage;
+            this.receiveStatistics = receiveStatistics;
+        }
+
+        public static ResponseMessageWithTransferStatistics WithoutAnyStats(ResponseMessage responseMessage)
+        {
+            return new ResponseMessageWithTransferStatistics(responseMessage, null, null, null);
+        }
+    }
+}

--- a/source/Halibut/Transport/TransferredBytesCountingStream.cs
+++ b/source/Halibut/Transport/TransferredBytesCountingStream.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Transport
+{
+    class TransferredBytesCountingStream : Stream
+    {
+        readonly Stream baseStream;
+        public long TotalWritten = 0;
+        public long TotalRead = 0;
+
+        public TransferredBytesCountingStream(Stream baseStream)
+        {
+            this.baseStream = baseStream;
+        }
+
+        public long TotalTransferred() => TotalWritten + TotalRead;
+
+        public override void Flush() => baseStream.Flush();
+        
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var baseCount = baseStream.Read(buffer, offset, count);
+            TotalRead += baseCount;
+            return baseCount;
+        }
+
+        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var baseCount = await baseStream.ReadAsync(buffer, offset, count, cancellationToken);
+            TotalRead += baseCount;
+            return baseCount;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => baseStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => baseStream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            baseStream.Write(buffer, offset, count);
+            TotalWritten += count;
+        }
+
+        public async override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await baseStream.WriteAsync(buffer, offset, count, cancellationToken);
+            TotalWritten += count;
+        }
+
+        public override bool CanRead => baseStream.CanRead;
+        public override bool CanSeek => baseStream.CanSeek;
+        public override bool CanWrite => baseStream.CanWrite;
+
+        public override bool CanTimeout => baseStream.CanTimeout;
+        
+        public override int ReadTimeout
+        {
+            get => baseStream.ReadTimeout;
+            set => baseStream.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => baseStream.WriteTimeout;
+            set => baseStream.WriteTimeout = value;
+        }
+
+        public override long Length => baseStream.Length;
+
+        public override long Position
+        {
+            get => baseStream.Position;
+            set => baseStream.Position = value;
+        }
+    }
+}


### PR DESCRIPTION
# Background

Spikes out adding transfer stats (from what the client sees) to halibit.

This aims to record:
* Time it takes to send a request and number of bytes sent.
* Time it takes to receive a response and the number of bytes recieved.
* Time it takes waiting for the start of a response to begin coming back (not implemented).

It looks like adding that is possible but it gets tricky if we want the caller (the client which calls a method on the halibut proxy) to somehow be able to get at those logs. We could probably provide some sort of call back when the proxy is generated however to do that we would need to store that data in the queue.

This doesn't handle the cases of errors e.g. if something goes wrong receiving a message we wont report any transfer stats around sending or receiving. This becomes worse when polling communication is used since the client will just "walk away" if sending/receiving a message takes to long. If we did end up with stats they would be lost.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
