### PR TITLE
Add a test around killing a polling TCP connection mid request

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp6</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs" />

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -11,7 +11,7 @@
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs" />

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT;DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>

--- a/source/Halibut.Tests/TestServices/DoSomeActionService.cs
+++ b/source/Halibut.Tests/TestServices/DoSomeActionService.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Halibut.Tests.TestServices
+{
+    public class DoSomeActionService : IDoSomeActionService
+    {
+        public Action ActionDelegate { get; set; }
+
+        public DoSomeActionService() : this(() => { })
+        {
+            
+        }
+        public DoSomeActionService(Action action)
+        {
+            this.ActionDelegate = action;
+        }
+
+        public void Action()
+        {
+            ActionDelegate();
+        }
+    }
+}

--- a/source/Halibut.Tests/TestServices/IDoSomeActionService.cs
+++ b/source/Halibut.Tests/TestServices/IDoSomeActionService.cs
@@ -1,0 +1,7 @@
+namespace Halibut.Tests.TestServices
+{
+    public interface IDoSomeActionService
+    {
+        public void Action();
+    }
+}

--- a/source/Halibut.Tests/TestServices/IDoSomeActionService.cs
+++ b/source/Halibut.Tests/TestServices/IDoSomeActionService.cs
@@ -2,6 +2,6 @@ namespace Halibut.Tests.TestServices
 {
     public interface IDoSomeActionService
     {
-        public void Action();
+        void Action();
     }
 }

--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -118,7 +118,7 @@ namespace Halibut.Tests.Util
             
             try
             {
-                listeningSocket.Dispose();
+                cancellationTokenSource.Dispose();
             }
             catch (Exception e)
             {

--- a/source/Halibut.Tests/Util/SocketPump.cs
+++ b/source/Halibut.Tests/Util/SocketPump.cs
@@ -30,7 +30,7 @@ namespace Halibut.Tests.Util
             // Only read if we have nothing to send or if data exists 
             if (readFrom.Available > 0 || buffer.Length == 0)
             {
-                var receivedByteCount = await ReadFromSocket(readFrom, buffer);
+                var receivedByteCount = await ReadFromSocket(readFrom, buffer, cancellationToken);
                 if (receivedByteCount == 0) return SocketStatus.SOCKET_CLOSED;
                 stopwatch = Stopwatch.StartNew();
             }
@@ -41,7 +41,7 @@ namespace Halibut.Tests.Util
             if ((readFrom.Available == 0 && stopwatch.Elapsed >= sendDelay) || buffer.Length > 100 * 1024 * 1024)
             {
                 // Send the data
-                await WriteToSocket(writeTo, buffer.GetBuffer(), (int)buffer.Length);
+                await WriteToSocket(writeTo, buffer.GetBuffer(), (int)buffer.Length, cancellationToken);
                 buffer.SetLength(0);
             }
             else
@@ -54,6 +54,7 @@ namespace Halibut.Tests.Util
 
         async Task PausePump(CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             while (isPumpPaused())
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
@@ -61,22 +62,22 @@ namespace Halibut.Tests.Util
             }
         }
 
-        static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend)
+        static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend, CancellationToken cancellationToken)
         {
             var offset = 0;
             while (totalBytesToSend - offset > 0)
             {
                 var outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
-                offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
+                offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
             }
 
         }
 
-        static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream)
+        static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream, CancellationToken cancellationToken)
         {
             var inputBuffer = new byte[readFrom.ReceiveBufferSize];
             ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
-            var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
+            var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 
             memoryStream.Write(inputBuffer, 0, receivedByteCount);
             return receivedByteCount;

--- a/source/Halibut.Tests/Util/SocketPump.cs
+++ b/source/Halibut.Tests/Util/SocketPump.cs
@@ -57,7 +57,7 @@ namespace Halibut.Tests.Util
             cancellationToken.ThrowIfCancellationRequested();
             while (isPumpPaused())
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
             }
         }

--- a/source/Halibut.Tests/Util/TcpPump.cs
+++ b/source/Halibut.Tests/Util/TcpPump.cs
@@ -120,6 +120,9 @@ namespace Halibut.Tests.Util
             cancellationTokenSource.Cancel();
             cancellationTokenSource.Dispose();
             isDisposed = true;
+            
+            clientSocket.Close();
+            originSocket.Close();
         }
 
         public void Pause()

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse
+    {
+        [Test]
+        public async Task ToPolling_AResponseShouldBeQuicklyReturned()
+        {
+            var services = new DelegateServiceFactory();
+            DoSomeActionService doSomeActionService = new DoSomeActionService();
+            services.Register<IDoSomeActionService>(() => doSomeActionService);
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            {
+                var octopusPort = octopus.Listen();
+                using (var portForwarder = new PortForwarder(new Uri("https://localhost:" + octopusPort), TimeSpan.Zero))
+                using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+                {
+                        
+                    octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                    tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port), Certificates.OctopusPublicThumbprint));
+
+                    var svc = octopus.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+                    doSomeActionService.ActionDelegate = () => portForwarder.Dispose();
+                    
+                    // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
+                    var killPortForwarderTask = Task.Run(() => svc.Action());
+                    
+                    await Task.WhenAny(killPortForwarderTask, Task.Delay(TimeSpan.FromSeconds(10)));
+                    
+                    killPortForwarderTask.Status.Should().Be(TaskStatus.Faulted, "We should immediately get an error response.");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

Adds a test showing what happens when a TCP connection to a polling tentacle is killed while waiting for the Response to come back.

The test shows that the killed connection is immediately detected and a error response is immediately put back on to the queue.

This also does some clean up around the port forwarder which I previously had done for some other investigation. The changes are:
* Support disposing of the port forwarder twice required for this change.
* Make the port forwarder respect cancellation such that it will stop pumping bytes as soon as it is disposed.
* Disposing all the things rather than stop disposing at the first exception (may not be required for this test).

[SC-43094]
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
