### PR TITLE
Reset the reconnection backoff strategy for a Polling Client once a connection is successfully established to the Service

### DIFF
--- a/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
+++ b/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class PollingClientConnectionHandlingFixture
+    {
+        [Test]
+        public void PollingClientShouldConnectQuickly()
+        {
+            var started = DateTime.UtcNow;
+            var calls = new List<DateTime>();
+
+            var (server, tentacle, portForwarder, _, doSomeActionService) = SetupPollingServerAndTentacle(() =>
+            {
+                calls.Add(DateTime.UtcNow);
+            });
+
+            using (server)
+            using (tentacle)
+            using (portForwarder)
+            {
+                doSomeActionService.Action();
+            }
+
+            calls.Should().HaveCount(1);
+            calls.ElementAt(0).Should().BeOnOrAfter(started).And.BeCloseTo(started, TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        public void PollingClientShouldReConnectQuickly()
+        {
+            var started = DateTime.UtcNow;
+            var calls = new List<DateTime>();
+
+            var (server, tentacle, portForwarder, _, doSomeActionService) = SetupPollingServerAndTentacle(() =>
+            {
+                calls.Add(DateTime.UtcNow);
+            });
+
+            using (server)
+            using (tentacle)
+            using (portForwarder)
+            {
+                doSomeActionService.Action();
+
+                portForwarder.CloseExistingConnections();
+
+                // First Reconnect
+                try
+                {
+                    doSomeActionService.Action();
+                }
+                catch (HalibutClientException ex)
+                {
+                    // Work around the known dequeue to a broken tcp connection issue
+                    doSomeActionService.Action();
+                }
+
+                portForwarder.CloseExistingConnections();
+
+                // Second Reconnect
+                try
+                {
+                    doSomeActionService.Action();
+                }
+                catch (HalibutClientException ex)
+                {
+                    // Work around the known dequeue to a broken tcp connection issue
+                    doSomeActionService.Action();
+                }
+            }
+
+            calls.Should().HaveCount(3);
+
+            var firstCall = calls.ElementAt(0);
+            var firstReconnect = calls.ElementAt(1);
+            var secondReconnect = calls.ElementAt(2);
+
+            firstCall.Should().BeOnOrAfter(started).And.BeCloseTo(started, TimeSpan.FromSeconds(5));
+            firstReconnect.Should().BeOnOrAfter(firstCall).And.BeCloseTo(firstCall, TimeSpan.FromSeconds(8));
+            secondReconnect.Should().BeOnOrAfter(firstReconnect).And.BeCloseTo(firstReconnect, TimeSpan.FromSeconds(8));
+        }
+
+        (HalibutRuntime server,
+            IHalibutRuntime tentacle,
+            PortForwarder portForwarder,
+            IEchoService echoService,
+            IDoSomeActionService doSomeActionService)
+            SetupPollingServerAndTentacle(Action doSomeActionServiceAction)
+        {
+            var server = SetupServer();
+            var portForwarder = SetupPortForwarder(server);
+            var serverUri = new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port);
+            var tentacle = SetupPollingTentacle(serverUri, "poll://SQ-TENTAPOLL", doSomeActionServiceAction);
+            var (echoService, doSomeActionService) = SetupServices(server, "poll://SQ-TENTAPOLL");
+            EnsureTentacleIsConnected(echoService);
+
+            return (server, tentacle, portForwarder, echoService, doSomeActionService);
+        }
+
+        static HalibutRuntime SetupPollingTentacle(Uri url, string pollingEndpoint, Action doSomeServiceAction)
+        {
+            var services = new DelegateServiceFactory();
+            var doSomeActionService = new DoSomeActionService(doSomeServiceAction);
+
+            services.Register<IDoSomeActionService>(() => doSomeActionService);
+            services.Register<IEchoService>(() => new EchoService());
+
+            var pollingTentacle = new HalibutRuntimeBuilder()
+                .WithServiceFactory(services)
+                .WithServerCertificate(Certificates.TentaclePolling)
+                .Build();
+
+            pollingTentacle.Poll(new Uri(pollingEndpoint), new ServiceEndPoint(url, Certificates.OctopusPublicThumbprint));
+
+            return pollingTentacle;
+        }
+
+        static PortForwarder SetupPortForwarder(IHalibutRuntime halibut)
+        {
+            var octopusPort = halibut.Listen();
+            var portForwarder = new PortForwarder(new Uri("https://localhost:" + (octopusPort)), TimeSpan.Zero);
+
+            return portForwarder;
+        }
+
+        static HalibutRuntime SetupServer()
+        {
+            var octopus = new HalibutRuntimeBuilder()
+                .WithServerCertificate(Certificates.Octopus)
+                .Build();
+
+            octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+            return octopus;
+        }
+
+        static (IEchoService scriptService, IDoSomeActionService doSomeActionService) SetupServices(HalibutRuntime octopus, string endpoint)
+        {
+            var doSomeActionService = octopus.CreateClient<IDoSomeActionService>(endpoint, Certificates.TentaclePollingPublicThumbprint);
+            var scriptService = octopus.CreateClient<IEchoService>(endpoint, Certificates.TentaclePollingPublicThumbprint);
+            return (scriptService, doSomeActionService);
+        }
+
+        static void EnsureTentacleIsConnected(IEchoService echoService)
+        {
+            // Ensure the tentacle is connected
+            echoService.SayHello("Hello");
+            // Ensure the tentacle is waiting for the next request
+            Thread.Sleep(2);
+        }
+    }
+}

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -62,7 +62,14 @@ namespace Halibut.Transport
                     try
                     {
                         retry.Try();
-                        secureClient.ExecuteTransaction(protocol => { protocol.ExchangeAsSubscriber(subscription, handleIncomingRequest); }, cancellationToken);
+                        secureClient.ExecuteTransaction(protocol =>
+                        {
+                            // We have successfully connected at this point so reset the retry policy
+                            // Subsequent connection issues will try and reconnect quickly and then back-off
+                            retry.Success();
+
+                            protocol.ExchangeAsSubscriber(subscription, handleIncomingRequest);
+                        }, cancellationToken);
                         retry.Success();
                     }
                     finally


### PR DESCRIPTION
# Background

When a Polling Client connects to a Service, it uses a backoff strategy to determine if it should wait between connection attempts.

The intent was to slow re-connection attempts to the Service when the Polling Client was having trouble connecting rather than trying to connect very frequently and possibly making the issue worse.

The backoff is based on the duration that the client has been trying to connect and ranges from 5 seconds to a maximum of 2 minutes.

A side effect of this logic means that if a polling client has been connected to the Service successfully for 2 minutes or over and then experiences a connection issue the client will wait for 2 minutes before trying to reconnect. Given the connection has been stable, possibly for a long duration, the 2-minute backoff does not seem necessary and causes unexpected delays in the polling tentacle reconnecting and picking up queued requests.

## Backoff strategy 

```
Elapsed 00:00:00 - Delay 00:00:05
Elapsed 00:00:01 - Delay 00:00:05
Elapsed 00:00:05 - Delay 00:00:08.7314902
Elapsed 00:00:10 - Delay 00:00:17.4629805
Elapsed 00:00:20 - Delay 00:00:34.9259611
Elapsed 00:00:30 - Delay 00:00:52.3889417
Elapsed 00:01:00 - Delay 00:01:44.7778834
Elapsed 00:02:00 - Delay 00:02:00
Elapsed 00:03:00 - Delay 00:02:00
```

# Results

This PR resets the backoff strategy once a connection has been successfully established. If the connection is dropped and the client needs to reconnect, the backoff strategy will start again, e.g. it will wait 5 seconds initially rather than 2 minutes.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
