### PR TITLE
Luke/throw specific method not found exceptions

### DIFF
--- a/source/Halibut.Tests/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/HalibutProxyFixture.cs
@@ -94,7 +94,7 @@ String, <null>
         
             Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
         
-            errorThrower.Should().Throw<NoMatchingServiceOrMethodHalibutClientException>();
+            errorThrower.Should().Throw<AmbiguousMethodMatchHalibutClientException>();
         }
     }
 }

--- a/source/Halibut.Tests/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/HalibutProxyFixture.cs
@@ -14,7 +14,7 @@ namespace Halibut.Tests
         {
             ServerError serverError = ResponseMessage.ServerErrorFromException(new MethodNotFoundHalibutClientException("not found", "not even mum could find it"));
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
         
             errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
         }
@@ -24,23 +24,23 @@ namespace Halibut.Tests
         {
             ServerError serverError = new ServerError{ Message = "bob", Details = "details", HalibutErrorType = "Foo.BarException" };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
         
             errorThrower.Should().Throw<HalibutClientException>();
         }
     
         [Test]
-        public void ThrowsGenericErrorWhenErrorTypeIsNull_EGWhenTalkingToAnOlderHalibutVersion()
+        public void ThrowsGenericErrorWhenErrorTypeIsNull_ForExampleWhenTalkingToAnOlderHalibutVersion()
         {
             ServerError serverError = new ServerError{ Message = "bob", Details = "details", HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
         
             errorThrower.Should().Throw<HalibutClientException>();
         }
         
         [Test]
-        public void BackwardCompatibility_ServiceNotFound_IsThrownAsServiceNotFoundHalibutClientException()
+        public void BackwardCompatibility_ServiceNotFound_IsThrownAsA_ServiceNotFoundHalibutClientException()
         {
             ServerError serverError = new ServerError{ 
                 Message = "Service not found: IEchoService", 
@@ -52,26 +52,26 @@ namespace Halibut.Tests
    at Halibut.Transport.Protocol.MessageExchangeProtocol.InvokeAndWrapAnyExceptions(RequestMessage request, Func`2 incomingRequestProcessor) in /home/auser/Documents/octopus/Halibut4/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 266",
                 HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
         
             errorThrower.Should().Throw<ServiceNotFoundHalibutClientException>();
         }
         
         [Test]
-        public void BackwardCompatibility_MethodNotFound_IsThrownAsMethodNotFoundHalibutClientException()
+        public void BackwardsCompatibility_MethodNotFound_IsThrownAsA_MethodNotFoundHalibutClientException()
         {
             ServerError serverError = new ServerError{ 
                 Message = "Service System.Object::SayHello not found", 
                 Details = null,
                 HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
         
             errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
         }
         
         [Test]
-        public void BackwardCompatibility_AmbiguousMethodMatch_IsThrownAsNoMatchingServiceOrMethodHalibutClientException()
+        public void BackwardCompatibility_AmbiguousMethodMatch_IsThrownAsA_NoMatchingServiceOrMethodHalibutClientException()
         {
             ServerError serverError = new ServerError{ 
                 Message = @"More than one possible match for the requested service method was found given the argument types. The matches were:
@@ -92,7 +92,7 @@ String, <null>
    at Halibut.Transport.Protocol.MessageExchangeProtocol.InvokeAndWrapAnyExceptions(RequestMessage request, Func`2 incomingRequestProcessor) in /home/auser/Documents/octopus/Halibut4/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 266",
                 HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
         
             errorThrower.Should().Throw<AmbiguousMethodMatchHalibutClientException>();
         }

--- a/source/Halibut.Tests/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/HalibutProxyFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using FluentAssertions;
+using Halibut.Diagnostics;
 using Halibut.Exceptions;
 using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
@@ -14,7 +15,7 @@ namespace Halibut.Tests
         {
             ServerError serverError = ResponseMessage.ServerErrorFromException(new MethodNotFoundHalibutClientException("not found", "not even mum could find it"));
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
         
             errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
         }
@@ -24,7 +25,7 @@ namespace Halibut.Tests
         {
             ServerError serverError = new ServerError{ Message = "bob", Details = "details", HalibutErrorType = "Foo.BarException" };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
         
             errorThrower.Should().Throw<HalibutClientException>();
         }
@@ -34,7 +35,7 @@ namespace Halibut.Tests
         {
             ServerError serverError = new ServerError{ Message = "bob", Details = "details", HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
         
             errorThrower.Should().Throw<HalibutClientException>();
         }
@@ -52,7 +53,7 @@ namespace Halibut.Tests
    at Halibut.Transport.Protocol.MessageExchangeProtocol.InvokeAndWrapAnyExceptions(RequestMessage request, Func`2 incomingRequestProcessor) in /home/auser/Documents/octopus/Halibut4/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 266",
                 HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
         
             errorThrower.Should().Throw<ServiceNotFoundHalibutClientException>();
         }
@@ -65,7 +66,7 @@ namespace Halibut.Tests
                 Details = null,
                 HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
         
             errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
         }
@@ -92,7 +93,7 @@ String, <null>
    at Halibut.Transport.Protocol.MessageExchangeProtocol.InvokeAndWrapAnyExceptions(RequestMessage request, Func`2 incomingRequestProcessor) in /home/auser/Documents/octopus/Halibut4/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 266",
                 HalibutErrorType = null };
         
-            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
         
             errorThrower.Should().Throw<AmbiguousMethodMatchHalibutClientException>();
         }

--- a/source/Halibut.Tests/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/HalibutProxyFixture.cs
@@ -1,40 +1,42 @@
+using System;
 using FluentAssertions;
 using Halibut.Exceptions;
 using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
-namespace Halibut.Tests;
-
-public class HalibutProxyFixture
+namespace Halibut.Tests
 {
-    [Test]
-    public void ThrowsSpecificErrorWhenErrorTypeIsSet()
+    public class HalibutProxyFixture
     {
-        ServerError serverError = ResponseMessage.ServerErrorFromException(new MethodNotFoundHalibutClientException("not found", "not even mum could find it"));
+        [Test]
+        public void ThrowsSpecificErrorWhenErrorTypeIsSet()
+        {
+            ServerError serverError = ResponseMessage.ServerErrorFromException(new MethodNotFoundHalibutClientException("not found", "not even mum could find it"));
         
-        var errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
         
-        errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
-    }
+            errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
+        }
     
-    [Test]
-    public void ThrowsGenericErrorWhenErrorTypeIsUnknown()
-    {
-        ServerError serverError = new ServerError{ Message = "bob", Details = "details", ErrorType = "Foo.BarException" };
+        [Test]
+        public void ThrowsGenericErrorWhenErrorTypeIsUnknown()
+        {
+            ServerError serverError = new ServerError{ Message = "bob", Details = "details", ErrorType = "Foo.BarException" };
         
-        var errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
         
-        errorThrower.Should().Throw<HalibutClientException>();
-    }
+            errorThrower.Should().Throw<HalibutClientException>();
+        }
     
-    [Test]
-    public void ThrowsGenericErrorWhenErrorTypeIsNull_EGWhenTalkingToAnOlderHalibutVersion()
-    {
-        ServerError serverError = new ServerError{ Message = "bob", Details = "details", ErrorType = null };
+        [Test]
+        public void ThrowsGenericErrorWhenErrorTypeIsNull_EGWhenTalkingToAnOlderHalibutVersion()
+        {
+            ServerError serverError = new ServerError{ Message = "bob", Details = "details", ErrorType = null };
         
-        var errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
         
-        errorThrower.Should().Throw<HalibutClientException>();
+            errorThrower.Should().Throw<HalibutClientException>();
+        }
     }
 }

--- a/source/Halibut.Tests/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/HalibutProxyFixture.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using Halibut.Exceptions;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+using NUnit.Framework;
+
+namespace Halibut.Tests;
+
+public class HalibutProxyFixture
+{
+    [Test]
+    public void ThrowsSpecificErrorWhenErrorTypeIsSet()
+    {
+        ServerError serverError = ResponseMessage.ServerErrorFromException(new MethodNotFoundHalibutClientException("not found", "not even mum could find it"));
+        
+        var errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+        
+        errorThrower.Should().Throw<MethodNotFoundHalibutClientException>();
+    }
+    
+    [Test]
+    public void ThrowsGenericErrorWhenErrorTypeIsUnknown()
+    {
+        ServerError serverError = new ServerError{ Message = "bob", Details = "details", ErrorType = "Foo.BarException" };
+        
+        var errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+        
+        errorThrower.Should().Throw<HalibutClientException>();
+    }
+    
+    [Test]
+    public void ThrowsGenericErrorWhenErrorTypeIsNull_EGWhenTalkingToAnOlderHalibutVersion()
+    {
+        ServerError serverError = new ServerError{ Message = "bob", Details = "details", ErrorType = null };
+        
+        var errorThrower = () => HalibutProxy.ThrowExceptionFromError(serverError);
+        
+        errorThrower.Should().Throw<HalibutClientException>();
+    }
+}

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -308,8 +308,8 @@ namespace Halibut.ServiceModel
     {
         public HalibutProxy() { }
         protected Object Invoke(MethodInfo targetMethod, Object[] args) { }
-        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint) { }
-        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, System.Threading.CancellationToken, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, System.Threading.CancellationToken cancellationToken) { }
+        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger) { }
+        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, System.Threading.CancellationToken, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger, System.Threading.CancellationToken cancellationToken) { }
     }
     public interface IPendingRequestQueue
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -229,6 +229,12 @@ namespace Halibut.Diagnostics
 }
 namespace Halibut.Exceptions
 {
+    public class AmbiguousMethodMatchHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable
+    {
+        public AmbiguousMethodMatchHalibutClientException(string message) { }
+        public AmbiguousMethodMatchHalibutClientException(string message, Exception inner) { }
+        public AmbiguousMethodMatchHalibutClientException(string message, string serverException) { }
+    }
     public class MethodNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable
     {
         public MethodNotFoundHalibutClientException(string message) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETCore.approved.cs
@@ -227,6 +227,27 @@ namespace Halibut.Diagnostics
         public Uri[] GetEndpoints() { }
     }
 }
+namespace Halibut.Exceptions
+{
+    public class MethodNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable
+    {
+        public MethodNotFoundHalibutClientException(string message) { }
+        public MethodNotFoundHalibutClientException(string message, Exception inner) { }
+        public MethodNotFoundHalibutClientException(string message, string serverException) { }
+    }
+    public class NoMatchingServiceOrMethodHalibutClientException : Halibut.HalibutClientException, ISerializable
+    {
+        public NoMatchingServiceOrMethodHalibutClientException(string message) { }
+        public NoMatchingServiceOrMethodHalibutClientException(string message, Exception inner) { }
+        public NoMatchingServiceOrMethodHalibutClientException(string message, string serverException) { }
+    }
+    public class ServiceNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable
+    {
+        public ServiceNotFoundHalibutClientException(string message) { }
+        public ServiceNotFoundHalibutClientException(string message, Exception inner) { }
+        public ServiceNotFoundHalibutClientException(string message, string serverException) { }
+    }
+}
 namespace Halibut.Logging
 {
     public interface ILogProvider
@@ -613,6 +634,7 @@ namespace Halibut.Transport.Protocol
     {
         public ServerError() { }
         public string Details { get; set; }
+        public string HalibutErrorType { get; set; }
         public string Message { get; set; }
     }
     public class StreamCapture : IDisposable

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -229,13 +229,19 @@ namespace Halibut.Diagnostics
 }
 namespace Halibut.Exceptions
 {
-    public class MethodNotFoundHalibutClientException : Halibut.HalibutClientException, ISerializable, _Exception
+    public class MethodNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable, _Exception
     {
         public MethodNotFoundHalibutClientException(string message) { }
         public MethodNotFoundHalibutClientException(string message, Exception inner) { }
         public MethodNotFoundHalibutClientException(string message, string serverException) { }
     }
-    public class ServiceNotFoundHalibutClientException : Halibut.HalibutClientException, ISerializable, _Exception
+    public class NoMatchingServiceOrMethodHalibutClientException : Halibut.HalibutClientException, ISerializable, _Exception
+    {
+        public NoMatchingServiceOrMethodHalibutClientException(string message) { }
+        public NoMatchingServiceOrMethodHalibutClientException(string message, Exception inner) { }
+        public NoMatchingServiceOrMethodHalibutClientException(string message, string serverException) { }
+    }
+    public class ServiceNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable, _Exception
     {
         public ServiceNotFoundHalibutClientException(string message) { }
         public ServiceNotFoundHalibutClientException(string message, Exception inner) { }
@@ -635,7 +641,7 @@ namespace Halibut.Transport.Protocol
     {
         public ServerError() { }
         public string Details { get; set; }
-        public string ErrorType { get; set; }
+        public string HalibutErrorType { get; set; }
         public string Message { get; set; }
     }
     public class StreamCapture : IDisposable

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -229,6 +229,12 @@ namespace Halibut.Diagnostics
 }
 namespace Halibut.Exceptions
 {
+    public class AmbiguousMethodMatchHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable, _Exception
+    {
+        public AmbiguousMethodMatchHalibutClientException(string message) { }
+        public AmbiguousMethodMatchHalibutClientException(string message, Exception inner) { }
+        public AmbiguousMethodMatchHalibutClientException(string message, string serverException) { }
+    }
     public class MethodNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable, _Exception
     {
         public MethodNotFoundHalibutClientException(string message) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -227,6 +227,21 @@ namespace Halibut.Diagnostics
         public Uri[] GetEndpoints() { }
     }
 }
+namespace Halibut.Exceptions
+{
+    public class MethodNotFoundHalibutClientException : Halibut.HalibutClientException, ISerializable, _Exception
+    {
+        public MethodNotFoundHalibutClientException(string message) { }
+        public MethodNotFoundHalibutClientException(string message, Exception inner) { }
+        public MethodNotFoundHalibutClientException(string message, string serverException) { }
+    }
+    public class ServiceNotFoundHalibutClientException : Halibut.HalibutClientException, ISerializable, _Exception
+    {
+        public ServiceNotFoundHalibutClientException(string message) { }
+        public ServiceNotFoundHalibutClientException(string message, Exception inner) { }
+        public ServiceNotFoundHalibutClientException(string message, string serverException) { }
+    }
+}
 namespace Halibut.Logging
 {
     public interface ILogProvider
@@ -620,6 +635,7 @@ namespace Halibut.Transport.Protocol
     {
         public ServerError() { }
         public string Details { get; set; }
+        public string ErrorType { get; set; }
         public string Message { get; set; }
     }
     public class StreamCapture : IDisposable

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
             "System.Threading.Tasks"
         };
 
-        [Test]
+        // [Test] Why do we even have this test.
         public void ThePublicSurfaceAreaShouldNotRegress()
         {
             var usings = commonNamespaces.Select(ns => $"using {ns};").Concat("".InArray());

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
             "System.Threading.Tasks"
         };
 
-        // [Test] Why do we even have this test.
+        [Test]
         public void ThePublicSurfaceAreaShouldNotRegress()
         {
             var usings = commonNamespaces.Select(ns => $"using {ns};").Concat("".InArray());

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
             "System.Threading.Tasks"
         };
 
-        //[Test] TODO
+        [Test]
         public void ThePublicSurfaceAreaShouldNotRegress()
         {
             var usings = commonNamespaces.Select(ns => $"using {ns};").Concat("".InArray());

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
             "System.Threading.Tasks"
         };
 
-        [Test]
+        //[Test] TODO
         public void ThePublicSurfaceAreaShouldNotRegress()
         {
             var usings = commonNamespaces.Select(ns => $"using {ns};").Concat("".InArray());

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -296,7 +296,7 @@ namespace Halibut.Tests
                 echo.Ambiguous("a", "b").Should().Be("Hello string");
                 echo.Ambiguous("a", new Tuple<string, string>("a", "b")).Should().Be("Hello tuple");
 
-                var ex = Assert.Throws<MethodNotFoundHalibutClientException>(() => echo.Ambiguous("a", (string)null));
+                var ex = Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>(() => echo.Ambiguous("a", (string)null));
                 ex.Message.Should().Contain("Ambiguous");
 
                 echo.GetLocation(new MapLocation { Latitude = -27, Longitude = 153 }).Should().Match<MapLocation>(x => x.Latitude == 153 && x.Longitude == -27);

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -296,7 +296,7 @@ namespace Halibut.Tests
                 echo.Ambiguous("a", "b").Should().Be("Hello string");
                 echo.Ambiguous("a", new Tuple<string, string>("a", "b")).Should().Be("Hello tuple");
 
-                var ex = Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>(() => echo.Ambiguous("a", (string)null));
+                var ex = Assert.Throws<AmbiguousMethodMatchHalibutClientException>(() => echo.Ambiguous("a", (string)null));
                 ex.Message.Should().Contain("Ambiguous");
 
                 echo.GetLocation(new MapLocation { Latitude = -27, Longitude = 153 }).Should().Match<MapLocation>(x => x.Latitude == 153 && x.Longitude == -27);

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Exceptions;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
@@ -295,7 +296,7 @@ namespace Halibut.Tests
                 echo.Ambiguous("a", "b").Should().Be("Hello string");
                 echo.Ambiguous("a", new Tuple<string, string>("a", "b")).Should().Be("Hello tuple");
 
-                var ex = Assert.Throws<HalibutClientException>(() => echo.Ambiguous("a", (string)null));
+                var ex = Assert.Throws<MethodNotFoundHalibutClientException>(() => echo.Ambiguous("a", (string)null));
                 ex.Message.Should().Contain("Ambiguous");
 
                 echo.GetLocation(new MapLocation { Latitude = -27, Longitude = 153 }).Should().Match<MapLocation>(x => x.Latitude == 153 && x.Longitude == -27);

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests
 
                         var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
 
-                        var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+                        Func<string> readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
 
                         readAsyncCall.Should().Throw<MethodNotFoundHalibutClientException>();
                     }
@@ -50,7 +50,7 @@ namespace Halibut.Tests
                     tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
 
                     var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
-                    var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+                    Func<string> readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
 
                     readAsyncCall.Should().Throw<MethodNotFoundHalibutClientException>();
                 }

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Exceptions;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public static class WhenCallingAMethodThatDoesNotExist
+    {
+        public class OnAPollingService
+        {
+            [Test]
+            public async Task AMethodNotFoundHalibutClientExceptionShouldBeRaisedByTheClient()
+            {
+                var services = new SingleServiceFactory(new object(), typeof(EchoService));
+                
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                {
+                    var octopusPort = octopus.Listen();
+                    using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+                    {
+                        octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + octopusPort), Certificates.OctopusPublicThumbprint));
+
+                        var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+                        var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+
+                        readAsyncCall.Should().Throw<MethodNotFoundHalibutClientException>();
+                    }
+                }
+            }
+        }
+
+        public class OnAListeningTentacle
+        {
+            [Test]
+            public async Task AMethodNotFoundHalibutClientExceptionShouldBeRaisedByTheClient()
+            {
+                var services = new SingleServiceFactory(new object(), typeof(EchoService));
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+                {
+                    var tentaclePort = tentacleListening.Listen();
+                    tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+
+                    var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+                    var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+
+                    readAsyncCall.Should().Throw<MethodNotFoundHalibutClientException>();
+                }
+            }
+        }
+
+        public class SingleServiceFactory : IServiceFactory
+        {
+            readonly object Service;
+            readonly Type serviceType;
+
+            public SingleServiceFactory(object service, Type serviceType)
+            {
+                Service = service;
+                this.serviceType = serviceType;
+            }
+
+            public IServiceLease CreateService(string serviceName)
+            {
+                return new SharedNeverExpiringLease(Service);
+            }
+
+            public IReadOnlyList<Type> RegisteredServiceTypes
+            {
+                get => new[] { serviceType };
+            }
+        }
+
+        public class SharedNeverExpiringLease : IServiceLease
+        {
+            public SharedNeverExpiringLease(object service)
+            {
+                Service = service;
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public object Service { get; }
+        }
+    }
+}

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
 
                         var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
 
-                        var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+                        Func<string> readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
 
                         readAsyncCall.Should().Throw<ServiceNotFoundHalibutClientException>();
                     }
@@ -48,7 +48,7 @@ namespace Halibut.Tests
                     tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
 
                     var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
-                    var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+                    Func<string> readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
 
                     readAsyncCall.Should().Throw<ServiceNotFoundHalibutClientException>();
                 }

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Exceptions;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public static class WhenCallingAServiceThatDoesNotExist
+    {
+        public class OnAPollingService
+        {
+            [Test]
+            public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient()
+            {
+                var services = new DelegateServiceFactory();
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                {
+                    var octopusPort = octopus.Listen();
+                    using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+                    {
+                        octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + octopusPort), Certificates.OctopusPublicThumbprint));
+
+                        var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+                        var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+
+                        readAsyncCall.Should().Throw<ServiceNotFoundHalibutClientException>();
+                    }
+                }
+            }
+        }
+
+        public class OnAListeningTentacle
+        {
+            [Test]
+            public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient()
+            {
+                var services = new DelegateServiceFactory();
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+                {
+                    var tentaclePort = tentacleListening.Listen();
+                    tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+
+                    var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+                    var readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+
+                    readAsyncCall.Should().Throw<ServiceNotFoundHalibutClientException>();
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut/Exceptions/AmbiguousMethodMatchHalibutClientException.cs
+++ b/source/Halibut/Exceptions/AmbiguousMethodMatchHalibutClientException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Halibut.Exceptions
+{
+    public class AmbiguousMethodMatchHalibutClientException : NoMatchingServiceOrMethodHalibutClientException
+    {
+        public AmbiguousMethodMatchHalibutClientException(string message) : base(message)
+        {
+        }
+
+        public AmbiguousMethodMatchHalibutClientException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public AmbiguousMethodMatchHalibutClientException(string message, string serverException) : base(message, serverException)
+        {
+        }
+    }
+}

--- a/source/Halibut/Exceptions/MethodNotFoundHalibutClientException.cs
+++ b/source/Halibut/Exceptions/MethodNotFoundHalibutClientException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Halibut.Exceptions
 {
-    public class MethodNotFoundHalibutClientException : HalibutClientException
+    public class MethodNotFoundHalibutClientException : NoMatchingServiceOrMethodHalibutClientException
     {
         public MethodNotFoundHalibutClientException(string message) : base(message)
         {

--- a/source/Halibut/Exceptions/MethodNotFoundHalibutClientException.cs
+++ b/source/Halibut/Exceptions/MethodNotFoundHalibutClientException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Halibut.Exceptions
+{
+    public class MethodNotFoundHalibutClientException : HalibutClientException
+    {
+        public MethodNotFoundHalibutClientException(string message) : base(message)
+        {
+        }
+
+        public MethodNotFoundHalibutClientException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public MethodNotFoundHalibutClientException(string message, string serverException) : base(message, serverException)
+        {
+        }
+    }
+}

--- a/source/Halibut/Exceptions/NoMatchingServiceOrMethodHalibutClientException.cs
+++ b/source/Halibut/Exceptions/NoMatchingServiceOrMethodHalibutClientException.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Halibut.Exceptions
+{
+    /// <summary>
+    /// Parent exception any time the service (Tentacle) is unable to find the requested
+    /// Service or Method. Including when the request from the client is ambiguous.
+    /// </summary>
+    public class NoMatchingServiceOrMethodHalibutClientException : HalibutClientException
+    {
+        public NoMatchingServiceOrMethodHalibutClientException(string message) : base(message)
+        {
+        }
+
+        public NoMatchingServiceOrMethodHalibutClientException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public NoMatchingServiceOrMethodHalibutClientException(string message, string serverException) : base(message, serverException)
+        {
+        }
+    }
+}

--- a/source/Halibut/Exceptions/ServiceNotFoundHalibutClientException.cs
+++ b/source/Halibut/Exceptions/ServiceNotFoundHalibutClientException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Halibut.Exceptions
 {
-    public class ServiceNotFoundHalibutClientException : HalibutClientException
+    public class ServiceNotFoundHalibutClientException : NoMatchingServiceOrMethodHalibutClientException
     {
         public ServiceNotFoundHalibutClientException(string message) : base(message)
         {

--- a/source/Halibut/Exceptions/ServiceNotFoundHalibutClientException.cs
+++ b/source/Halibut/Exceptions/ServiceNotFoundHalibutClientException.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Halibut.Exceptions
+{
+    public class ServiceNotFoundHalibutClientException : HalibutClientException
+    {
+        public ServiceNotFoundHalibutClientException(string message) : base(message)
+        {
+        }
+
+        public ServiceNotFoundHalibutClientException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public ServiceNotFoundHalibutClientException(string message, string serverException) : base(message, serverException)
+        {
+        }
+    }
+}

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -198,15 +198,15 @@ namespace Halibut
         public TService CreateClient<TService>(ServiceEndPoint endpoint, CancellationToken cancellationToken)
         {
             typeRegistry.AddToMessageContract(typeof(TService));
-
+            var logger = logs.ForEndpoint(endpoint.BaseUri);
 #if HAS_REAL_PROXY
 #pragma warning disable 618
-            return (TService)new HalibutProxy(SendOutgoingRequest, typeof(TService), endpoint, cancellationToken).GetTransparentProxy();
+            return (TService)new HalibutProxy(SendOutgoingRequest, typeof(TService), endpoint, logger, cancellationToken).GetTransparentProxy();
 #pragma warning restore 618
 #else
             var proxy = DispatchProxy.Create<TService, HalibutProxy>();
 #pragma warning disable 618
-            (proxy as HalibutProxy).Configure(SendOutgoingRequest, typeof(TService), endpoint, cancellationToken);
+            (proxy as HalibutProxy).Configure(SendOutgoingRequest, typeof(TService), endpoint, logger, cancellationToken);
 #pragma warning restore 618
             return proxy;
 #endif

--- a/source/Halibut/ServiceModel/DelegateServiceFactory.cs
+++ b/source/Halibut/ServiceModel/DelegateServiceFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Halibut.Exceptions;
 
 namespace Halibut.ServiceModel
 {
@@ -29,7 +30,7 @@ namespace Halibut.ServiceModel
         {
             if (!services.TryGetValue(name, out var result))
             {
-                throw new Exception("Service not found: " + name);
+                throw new ServiceNotFoundHalibutClientException("Service not found: " + name);
             }
 
             return result;

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -166,6 +166,17 @@ namespace Halibut.ServiceModel
                 return;
 
             var realException = responseMessage.Error.Details as string;
+            if (!string.IsNullOrEmpty(responseMessage.Error.ErrorType))
+            {
+                var theType = Type.GetType(responseMessage.Error.ErrorType);
+                if (theType != null)
+                {
+                    var ctor = theType.GetConstructor(new[] { typeof(string), typeof(string) });
+                    Exception e = (Exception)ctor.Invoke(new object[] { responseMessage.Error.Message, realException });
+                    throw e;
+                }
+            }
+            
             throw new HalibutClientException(responseMessage.Error.Message, realException);
         }
     }

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -77,19 +77,6 @@ namespace Halibut.ServiceModel
         {
             return messageRouter(requestMessage, cancellationToken);
         }
-
-        static void EnsureNotError(ResponseMessage responseMessage)
-        {
-            if (responseMessage == null)
-                throw new HalibutClientException("No response was received from the endpoint within the allowed time.");
-
-            if (responseMessage.Error == null)
-                return;
-
-            var realException = responseMessage.Error.Details as string;
-            throw new HalibutClientException(responseMessage.Error.Message, realException);
-        }
-    }
 #else
     public class HalibutProxy : DispatchProxy
     {
@@ -156,7 +143,7 @@ namespace Halibut.ServiceModel
         {
             return messageRouter(requestMessage, cancellationToken);
         }
-
+#endif
         static void EnsureNotError(ResponseMessage responseMessage)
         {
             if (responseMessage == null)
@@ -186,5 +173,4 @@ namespace Halibut.ServiceModel
             throw new HalibutClientException(error.Message, realException);
         }
     }
-#endif
 }

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -196,7 +196,8 @@ namespace Halibut.ServiceModel
             }
             catch (Exception exception) when (!(exception is HalibutClientException))
             {
-                // Something when wrong trying to understand the ServerError revert back to throwing a standard halibut client exception.
+                // Something went wrong trying to understand the ServerError revert back to the old behaviour of just
+                // throwing a standard halibut client exception.
                 logger.Write(EventType.Error, "Error {0} when processing ServerError", exception);
             }
 

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -168,7 +168,8 @@ namespace Halibut.ServiceModel
             ThrowExceptionFromError(responseMessage.Error);
         }
 
-        internal static void ThrowExceptionFromError(ServerError error)
+        // TODO does this need to be public for testing?
+        public static void ThrowExceptionFromError(ServerError error)
         {
             var realException = error.Details as string;
             if (!string.IsNullOrEmpty(error.ErrorType))

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -165,19 +165,24 @@ namespace Halibut.ServiceModel
             if (responseMessage.Error == null)
                 return;
 
-            var realException = responseMessage.Error.Details as string;
-            if (!string.IsNullOrEmpty(responseMessage.Error.ErrorType))
+            ThrowExceptionFromError(responseMessage.Error);
+        }
+
+        internal static void ThrowExceptionFromError(ServerError error)
+        {
+            var realException = error.Details as string;
+            if (!string.IsNullOrEmpty(error.ErrorType))
             {
-                var theType = Type.GetType(responseMessage.Error.ErrorType);
+                var theType = Type.GetType(error.ErrorType);
                 if (theType != null)
                 {
                     var ctor = theType.GetConstructor(new[] { typeof(string), typeof(string) });
-                    Exception e = (Exception)ctor.Invoke(new object[] { responseMessage.Error.Message, realException });
+                    Exception e = (Exception) ctor.Invoke(new object[] { error.Message, realException });
                     throw e;
                 }
             }
-            
-            throw new HalibutClientException(responseMessage.Error.Message, realException);
+
+            throw new HalibutClientException(error.Message, realException);
         }
     }
 #endif

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -153,10 +153,10 @@ namespace Halibut.ServiceModel
             if (responseMessage.Error == null)
                 return;
 
-            ThrowExceptionFromError(responseMessage.Error);
+            ThrowExceptionFromReceivedError(responseMessage.Error);
         }
         
-        internal static void ThrowExceptionFromError(ServerError error)
+        internal static void ThrowExceptionFromReceivedError(ServerError error)
         {
             var realException = error.Details as string;
             if (!string.IsNullOrEmpty(error.HalibutErrorType))

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -182,7 +182,7 @@ namespace Halibut.ServiceModel
             
             if (error.Details.StartsWith("System.Reflection.AmbiguousMatchException: "))
             {
-                throw new NoMatchingServiceOrMethodHalibutClientException(error.Message, realException);
+                throw new AmbiguousMethodMatchHalibutClientException(error.Message, realException);
             }
 
             throw new HalibutClientException(error.Message, realException);

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -154,9 +154,8 @@ namespace Halibut.ServiceModel
 
             ThrowExceptionFromError(responseMessage.Error);
         }
-
-        // TODO does this need to be public for testing?
-        public static void ThrowExceptionFromError(ServerError error)
+        
+        internal static void ThrowExceptionFromError(ServerError error)
         {
             var realException = error.Details as string;
             if (!string.IsNullOrEmpty(error.ErrorType))

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -100,7 +100,7 @@ namespace Halibut.ServiceModel
             message.AppendLine("The request arguments were:");
             message.AppendLine(string.Join(", ", argumentTypes.Select(t => t == null ? "<null>" : t.Name)));
 
-            throw new NoMatchingServiceOrMethodHalibutClientException("", new AmbiguousMatchException(message.ToString()));
+            throw new AmbiguousMethodMatchHalibutClientException("", new AmbiguousMatchException(message.ToString()));
         }
 
         static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -100,7 +100,7 @@ namespace Halibut.ServiceModel
             message.AppendLine("The request arguments were:");
             message.AppendLine(string.Join(", ", argumentTypes.Select(t => t == null ? "<null>" : t.Name)));
 
-            throw new AmbiguousMethodMatchHalibutClientException("", new AmbiguousMatchException(message.ToString()));
+            throw new AmbiguousMethodMatchHalibutClientException(message.ToString(), new AmbiguousMatchException(message.ToString()));
         }
 
         static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Halibut.Exceptions;
 using Halibut.Portability;
 using Halibut.Transport.Protocol;
 using Halibut.Util;
@@ -25,7 +26,7 @@ namespace Halibut.ServiceModel
                 var methods = lease.Service.GetType().GetHalibutServiceMethods().Where(m => string.Equals(m.Name, requestMessage.MethodName, StringComparison.OrdinalIgnoreCase)).ToList();
                 if (methods.Count == 0)
                 {
-                    return ResponseMessage.FromError(requestMessage, string.Format("Service {0}::{1} not found", lease.Service.GetType().FullName, requestMessage.MethodName));
+                    throw new MethodNotFoundHalibutClientException(string.Format("Method {0}::{1} not found", lease.Service.GetType().FullName, requestMessage.MethodName));
                 }
 
                 var method = SelectMethod(methods, requestMessage);
@@ -99,6 +100,7 @@ namespace Halibut.ServiceModel
             message.AppendLine("The request arguments were:");
             message.AppendLine(string.Join(", ", argumentTypes.Select(t => t == null ? "<null>" : t.Name)));
 
+            throw new MethodNotFoundHalibutClientException("", new AmbiguousMatchException(message.ToString()));
             throw new AmbiguousMatchException(message.ToString());
         }
 

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -100,8 +100,7 @@ namespace Halibut.ServiceModel
             message.AppendLine("The request arguments were:");
             message.AppendLine(string.Join(", ", argumentTypes.Select(t => t == null ? "<null>" : t.Name)));
 
-            throw new MethodNotFoundHalibutClientException("", new AmbiguousMatchException(message.ToString()));
-            throw new AmbiguousMatchException(message.ToString());
+            throw new NoMatchingServiceOrMethodHalibutClientException("", new AmbiguousMatchException(message.ToString()));
         }
 
         static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -32,7 +32,12 @@ namespace Halibut.Transport.Protocol
 
         internal static ServerError ServerErrorFromException(Exception ex)
         {
-            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), ErrorType = ex.GetType().FullName };
+            string ErrorType = null;
+            if (ex is HalibutClientException)
+            {
+                ErrorType = ex.GetType().FullName;
+            }
+            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), ErrorType = ErrorType };
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -27,7 +27,12 @@ namespace Halibut.Transport.Protocol
 
         public static ResponseMessage FromException(RequestMessage request, Exception ex)
         {
-            return new ResponseMessage {Id = request.Id, Error = new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), ErrorType = ex.GetType().FullName}};
+            return new ResponseMessage {Id = request.Id, Error = ServerErrorFromException(ex)};
+        }
+
+        internal static ServerError ServerErrorFromException(Exception ex)
+        {
+            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), ErrorType = ex.GetType().FullName };
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -37,7 +37,7 @@ namespace Halibut.Transport.Protocol
             {
                 ErrorType = ex.GetType().FullName;
             }
-            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), ErrorType = ErrorType };
+            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), HalibutErrorType = ErrorType };
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -27,7 +27,7 @@ namespace Halibut.Transport.Protocol
 
         public static ResponseMessage FromException(RequestMessage request, Exception ex)
         {
-            return new ResponseMessage {Id = request.Id, Error = new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString() }};
+            return new ResponseMessage {Id = request.Id, Error = new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), ErrorType = ex.GetType().FullName}};
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ServerError.cs
+++ b/source/Halibut/Transport/Protocol/ServerError.cs
@@ -11,6 +11,6 @@ namespace Halibut.Transport.Protocol
         [JsonProperty("details")]
         public string Details { get; set; }
         
-        public string ErrorType { get; set; }
+        public string HalibutErrorType { get; set; }
     }
 }

--- a/source/Halibut/Transport/Protocol/ServerError.cs
+++ b/source/Halibut/Transport/Protocol/ServerError.cs
@@ -10,5 +10,7 @@ namespace Halibut.Transport.Protocol
 
         [JsonProperty("details")]
         public string Details { get; set; }
+        
+        public string ErrorType { get; set; }
     }
 }


### PR DESCRIPTION
# Background

This PR makes it easier for a client to determine if the service does not implement the called service or method. This is useful when newer clients are talking to older services which don't have the latest methods.

[SC-46268]
# Results

Clients can now catch a `NoMatchingServiceOrMethodHalibutClientException` to discover that the service (Tentacle):
- Doesn't know about the Service.
- Doesn't know about the method within that Service.
- Can't find an unambiguously matching method.

Also it is possible for a client to distinguish between those with:
- `ServiceNotFoundHalibutClientException`
- `MethodNotFoundHalibutClientException`
- `AmbiguousMethodMatchHalibutClientException`

The solution is also backwards compatible, this means an upgraded client can catch those exceptions and `Halibut` (client side) will do the heavy lifting of converting the old responses into the correct exception.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
