### PR TITLE
Enable TCP Keep Alives

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -52,6 +52,10 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT;DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
   </PropertyGroup>
 
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net60' ">
+        <DefineConstants>$(DefineConstants);HAS_TCP_KEEP_ALIVE_SOCKET_OPTIONS</DefineConstants>
+    </PropertyGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/source/Halibut/Diagnostics/HalibutLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutLimits.cs
@@ -107,6 +107,24 @@ namespace Halibut.Diagnostics
                 }
             }
         }
+
+        // TODO - Add to non static options
+        public static bool TcpKeepAliveEnabled = true;
+
+        /// <summary>
+        /// The number of TCP keep alive probes that will be sent before the connection is terminated.
+        /// </summary>
+        public static int TcpKeepAliveRetryCount = 10;
+
+        /// <summary>
+        /// The duration a TCP connection will remain alive/idle before keepalive probes are sent to the remote.
+        /// </summary>
+        public static TimeSpan TcpKeepAliveTime = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// The duration a TCP connection will wait for a keepalive response before sending another keepalive probe.
+        /// </summary>
+        public static TimeSpan TcpKeepAliveInterval = TimeSpan.FromSeconds(5);
     }
 #pragma warning disable CS0612
     public class HalibutTimeoutsAndLimits

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -53,6 +53,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <DefineConstants>$(DefineConstants);LIBLOG_PORTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_ASYNC_LOCAL;LIBLOG_PORTABLE;HAS_TCP_KEEP_ALIVE_SOCKET_OPTIONS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -208,10 +208,13 @@ namespace Halibut.Transport
             var clientName = client.Client.RemoteEndPoint;
             
             Stream stream = client.GetStream();
+            client.EnableTcpKeepAlive();
+
             if (asyncHalibutFeature.IsEnabled())
             {
                 stream = stream.AsNetworkTimeoutStream();
             }
+
 #if !NETFRAMEWORK
             await
 #endif            

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -40,7 +40,8 @@ namespace Halibut.Transport
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
 
             var stream = client.GetStream();
-
+            client.EnableTcpKeepAlive();
+            
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
             var ssl = new SslStream(stream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
             ssl.AuthenticateAsClient(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(clientCertificate), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
@@ -61,6 +62,8 @@ namespace Halibut.Transport
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
             
             var networkTimeoutStream = client.GetNetworkTimeoutStream();
+            client.EnableTcpKeepAlive();
+
             var ssl = new SslStream(networkTimeoutStream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");


### PR DESCRIPTION
# Background

https://learn.microsoft.com/en-us/windows/win32/winsock/so-keepalive

**Stalled TCP connection**: A TCP connection where data has stopped flowing. This typically occurs when the connection has been terminated, but one or more sides have not received a [FIN](https://en.wikipedia.org/wiki/Transmission_Control_Protocol#Connection_termination) packet and do not know the connection was terminated.

When a stalled connection occurs between a Halibut client and service it can take up to 10 minutes for either the client or server to detect the tcp connection has stalled.

# Results

This enables keep alive for TCP Clients and TCP Listeners.
For a TCP Client, keep alive are turned off when the client is returned to the pool.

## Before

Physically pulling out a network cable to simulate a real stalled connection
Takes 5 mins to fail - time multiplier was 0.5 - real world would be 10 mins

![image](https://user-images.githubusercontent.com/86938706/234468176-740b9c67-f88c-41e8-9015-bd8a176807d6.png)

 Duration: 5 min

```
  Standard Output: 
2023-03-29T09:18:25.6749413Z           Server: Info: listen://[::]:12346/  24 Listener started
2023-03-29T09:18:25.7338525Z  PollingTentacle: Debug: https://192.168.1.160:12345/  32 Opening a new connection to https://192.168.1.160:12345/
2023-03-29T09:18:25.7377167Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Connection established to [::ffff:192.168.1.160]:12345 for https://192.168.1.160:12345/
2023-03-29T09:18:25.7377260Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Performing TLS handshake
2023-03-29T09:18:25.7392271Z           Server: Trace: poll://sq-tentapoll/  24 Request IEchoService::PingPong[1] / c757a10f-487a-4b04-a8e5-85e64e231a21 was queued
2023-03-29T09:18:25.7557720Z           Server: Info: listen://[::]:12346/  11 Accepted TCP client: [::ffff:192.168.1.160]:5063
2023-03-29T09:18:25.7568894Z           Server: Trace: listen://[::]:12346/  11 Performing TLS server handshake
2023-03-29T09:18:25.9839759Z           Server: Trace: listen://[::]:12346/  6 Secure connection established, client is not yet authenticated, client connected with Tls12
2023-03-29T09:18:25.9868544Z  PollingTentacle: Info: https://192.168.1.160:12345/  32 Secure connection established. Server at [::ffff:192.168.1.160]:12345 identified by thumbprint: 76225C0717A16C1D0BA4A7FFA76519D286D8A248, using protocol Tls12
2023-03-29T09:18:25.9905050Z           Server: Trace: listen://[::]:12346/  6 Begin authorization
2023-03-29T09:18:25.9906968Z           Server: Info: listen://[::]:12346/  6 Client at [::ffff:192.168.1.160]:5063 authenticated as 4098EC3A2FC2B92B97339D3831BA230CC1DD590F
2023-03-29T09:18:25.9911839Z           Server: Trace: listen://[::]:12346/  6 Begin message exchange
2023-03-29T09:18:26.0595885Z           Server: Trace: listen://[::]:12346/  6 Sent: IEchoService::PingPong[1] / c757a10f-487a-4b04-a8e5-85e64e231a21
2023-03-29T09:18:26.0934770Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Received: IEchoService::PingPong[1] / c757a10f-487a-4b04-a8e5-85e64e231a21
2023-03-29T09:18:26.0964674Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Sent: Halibut.Transport.Protocol.ResponseMessage
2023-03-29T09:18:26.0996248Z           Server: Trace: listen://[::]:12346/  6 Received: Halibut.Transport.Protocol.ResponseMessage
2023-03-29T09:18:26.0999495Z           Server: Trace: poll://sq-tentapoll/  24 Request IEchoService::PingPong[1] / c757a10f-487a-4b04-a8e5-85e64e231a21 was collected by the polling endpoint
2023-03-29T09:18:26.1166423Z           Server: Trace: poll://sq-tentapoll/  24 Request IDoSomeActionService::Action[1] / 508b2501-a5e5-4c2c-9054-e1d1819c91ba was queued
2023-03-29T09:18:26.1524623Z           Server: Trace: listen://[::]:12346/  9 Sent: IDoSomeActionService::Action[1] / 508b2501-a5e5-4c2c-9054-e1d1819c91ba
2023-03-29T09:18:26.1966191Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Received: IDoSomeActionService::Action[1] / 508b2501-a5e5-4c2c-9054-e1d1819c91ba
2023-03-29T09:23:26.1744754Z           Server: Trace: poll://sq-tentapoll/  24 Request IDoSomeActionService::Action[1] / 508b2501-a5e5-4c2c-9054-e1d1819c91ba was eventually collected by the polling endpoint
300.0606324
Real Time:600.1212648
Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond..

Server exception: 
System.IO.IOException: Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond..
 ---> System.Net.Sockets.SocketException (10060): A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)
   --- End of inner exception stack trace ---
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)
   at System.Net.Security.SslStream.FillBufferAsync[TReadAdapter](TReadAdapter adapter, Int32 minSize)
   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.RewindableBufferStream.Read(Byte[] buffer, Int32 offset, Int32 count) in D:\Code\Halibut\source\Halibut\Transport\RewindableBufferStream.cs:line 92
   at System.IO.Compression.DeflateStream.ReadCore(Span`1 buffer)
   at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
   at System.IO.BinaryReader.InternalRead(Int32 numBytes)
   at System.IO.BinaryReader.ReadInt32()
   at Newtonsoft.Json.Bson.BsonDataReader.ReadNormal()
   at Newtonsoft.Json.Bson.BsonDataReader.Read()
   at Newtonsoft.Json.JsonReader.ReadAndMoveToContent()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Halibut.Transport.Protocol.MessageSerializer.DeserializeMessage[T](JsonReader reader) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 103
   at Halibut.Transport.Protocol.MessageSerializer.ReadCompressedMessageRewindable[T](Stream stream, IRewindableBuffer rewindable) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 80
   at Halibut.Transport.Protocol.MessageSerializer.ReadMessage[T](Stream stream) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 56
   at Halibut.Transport.Protocol.MessageExchangeStream.Receive[T]() in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageExchangeStream.cs:line 207
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageExchangeProtocol.cs:line 231
2023-03-29T09:23:26.1888383Z           Server: Info: listen://[::]:12346/  24 Listener stopped
```

## After

Physically pulling out a network cable to simulate a real stalled connection

Takes 1 minute to fail!! 

![image](https://user-images.githubusercontent.com/86938706/234468257-122d8717-e883-4b24-9548-e7f0285a49ea.png)

 Duration: 1.2 min

```
  Standard Output: 
2023-03-29T09:15:36.9220708Z           Server: Info: listen://[::]:12346/  25 Listener started
2023-03-29T09:15:36.9780199Z  PollingTentacle: Debug: https://192.168.1.160:12345/  32 Opening a new connection to https://192.168.1.160:12345/
2023-03-29T09:15:36.9813683Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Connection established to [::ffff:192.168.1.160]:12345 for https://192.168.1.160:12345/
2023-03-29T09:15:36.9813771Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Performing TLS handshake
2023-03-29T09:15:36.9827685Z           Server: Trace: poll://sq-tentapoll/  25 Request IEchoService::PingPong[1] / 56f7b474-98f2-42e5-b799-28ec316633f8 was queued
2023-03-29T09:15:36.9874089Z           Server: Info: listen://[::]:12346/  11 Accepted TCP client: [::ffff:192.168.1.160]:31050
2023-03-29T09:15:36.9883769Z           Server: Trace: listen://[::]:12346/  11 Performing TLS server handshake
2023-03-29T09:15:37.1788390Z           Server: Trace: listen://[::]:12346/  6 Secure connection established, client is not yet authenticated, client connected with Tls12
2023-03-29T09:15:37.1818511Z  PollingTentacle: Info: https://192.168.1.160:12345/  32 Secure connection established. Server at [::ffff:192.168.1.160]:12345 identified by thumbprint: 76225C0717A16C1D0BA4A7FFA76519D286D8A248, using protocol Tls12
2023-03-29T09:15:37.1851102Z           Server: Trace: listen://[::]:12346/  6 Begin authorization
2023-03-29T09:15:37.1852363Z           Server: Info: listen://[::]:12346/  6 Client at [::ffff:192.168.1.160]:31050 authenticated as 4098EC3A2FC2B92B97339D3831BA230CC1DD590F
2023-03-29T09:15:37.1855790Z           Server: Trace: listen://[::]:12346/  6 Begin message exchange
2023-03-29T09:15:37.4218584Z           Server: Trace: listen://[::]:12346/  6 Sent: IEchoService::PingPong[1] / 56f7b474-98f2-42e5-b799-28ec316633f8
2023-03-29T09:15:37.4511681Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Received: IEchoService::PingPong[1] / 56f7b474-98f2-42e5-b799-28ec316633f8
2023-03-29T09:15:37.4547479Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Sent: Halibut.Transport.Protocol.ResponseMessage
2023-03-29T09:15:37.4632916Z           Server: Trace: listen://[::]:12346/  6 Received: Halibut.Transport.Protocol.ResponseMessage
2023-03-29T09:15:37.4635193Z           Server: Trace: poll://sq-tentapoll/  25 Request IEchoService::PingPong[1] / 56f7b474-98f2-42e5-b799-28ec316633f8 was collected by the polling endpoint
2023-03-29T09:15:37.4750270Z           Server: Trace: poll://sq-tentapoll/  25 Request IDoSomeActionService::Action[1] / eab072ea-e222-4e22-982e-75e288f55e44 was queued
2023-03-29T09:15:37.6838413Z           Server: Trace: listen://[::]:12346/  9 Sent: IDoSomeActionService::Action[1] / eab072ea-e222-4e22-982e-75e288f55e44
2023-03-29T09:15:37.7352486Z  PollingTentacle: Trace: https://192.168.1.160:12345/  32 Received: IDoSomeActionService::Action[1] / eab072ea-e222-4e22-982e-75e288f55e44
2023-03-29T09:16:47.8843323Z           Server: Trace: poll://sq-tentapoll/  25 Request IDoSomeActionService::Action[1] / eab072ea-e222-4e22-982e-75e288f55e44 was eventually collected by the polling endpoint
70.4116642
Real Time:140.8233284
Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond..

Server exception: 
System.IO.IOException: Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond..
 ---> System.Net.Sockets.SocketException (10060): A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)
   --- End of inner exception stack trace ---
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)
   at System.Net.Security.SslStream.FillBufferAsync[TReadAdapter](TReadAdapter adapter, Int32 minSize)
   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.RewindableBufferStream.Read(Byte[] buffer, Int32 offset, Int32 count) in D:\Code\Halibut\source\Halibut\Transport\RewindableBufferStream.cs:line 92
   at System.IO.Compression.DeflateStream.ReadCore(Span`1 buffer)
   at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
   at System.IO.BinaryReader.InternalRead(Int32 numBytes)
   at System.IO.BinaryReader.ReadInt32()
   at Newtonsoft.Json.Bson.BsonDataReader.ReadNormal()
   at Newtonsoft.Json.Bson.BsonDataReader.Read()
   at Newtonsoft.Json.JsonReader.ReadAndMoveToContent()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Halibut.Transport.Protocol.MessageSerializer.DeserializeMessage[T](JsonReader reader) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 103
   at Halibut.Transport.Protocol.MessageSerializer.ReadCompressedMessageRewindable[T](Stream stream, IRewindableBuffer rewindable) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 80
   at Halibut.Transport.Protocol.MessageSerializer.ReadMessage[T](Stream stream) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 56
   at Halibut.Transport.Protocol.MessageExchangeStream.Receive[T]() in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageExchangeStream.cs:line 207
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest) in D:\Code\Halibut\source\Halibut\Transport\Protocol\MessageExchangeProtocol.cs:line 231
2023-03-29T09:16:47.8955818Z           Server: Info: listen://[::]:12346/  25 Listener stopped
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
