### PR TITLE
Improves the envelope was null error and invalid compression format error to instead report the actual underlying network error.

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -48,10 +48,11 @@ namespace Halibut.Tests.Diagnostics
 
         public class WhenTheHalibutProxyThrowsAnException : BaseTest
         {
-            [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
-            public async Task WhenTheConnectionTerminatesWaitingForAResponse(ServiceConnectionType serviceConnectionType)
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions:false)]
+            public async Task WhenTheConnectionTerminatesWaitingForAResponse(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await ClientServiceBuilder.ForServiceConnectionType(serviceConnectionType)
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
                            .WithPortForwarding(out var portForwarder)
                            .WithDoSomeActionService(() => portForwarder.Value.EnterKillNewAndExistingConnectionsMode())
                            .Build(CancellationToken))
@@ -67,13 +68,14 @@ namespace Halibut.Tests.Diagnostics
                 }
             }
             
-            [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
-            public async Task WhenTheConnectionPausesWaitingForAResponse(ServiceConnectionType serviceConnectionType)
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions:false)]
+            public async Task WhenTheConnectionPausesWaitingForAResponse(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await ClientServiceBuilder.ForServiceConnectionType(serviceConnectionType)
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
                            .WithPortForwarding(out var portForwarder)
                            .WithDoSomeActionService(() => portForwarder.Value.PauseExistingConnections())
-                           .Build())
+                           .Build(CancellationToken))
                 {
                     var svc = clientAndService.CreateClient<IDoSomeActionService>();
 

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -66,12 +66,19 @@ namespace Halibut.Tests.Diagnostics
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
                     
-                        exception.Message.Should().Contain("Attempted to read past the end of the stream.",
+                        exception.Message.Should().ContainAny(new String[]
+                            {
+                                "Attempted to read past the end of the stream.",
+                                "Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.",
+                                "The I/O operation has been aborted because of either a thread exit or an application request"
+                            },
                             because: "This isn't the best message, really the connection was closed before we got the data we were expecting resulting in us reading past the end of the stream");
                     }
             }
             
-            [LatestClientAndLatestServiceTestCases(testNetworkConditions:false)]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions:false, 
+                testWebSocket:false // Since websockets do not timeout
+                )]
             public async Task WhenTheConnectionPausesWaitingForAResponse(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
@@ -89,7 +96,12 @@ namespace Halibut.Tests.Diagnostics
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
                     
-                    exception.Message.Should().Contain("Unable to read data from the transport connection: Connection timed out.");
+                    exception.Message.Should().ContainAny(new[]
+                    {
+                        "Unable to read data from the transport connection: Connection timed out.",
+                        "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."
+                        
+                    });
                 }
             }
 

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -65,7 +65,10 @@ namespace Halibut.Tests.Diagnostics
                     exception.IsNetworkError()
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
-                }
+                    
+                        exception.Message.Should().Contain("Attempted to read past the end of the stream.",
+                            because: "This isn't the best message, really the connection was closed before we got the data we were expecting resulting in us reading past the end of the stream");
+                    }
             }
             
             [LatestClientAndLatestServiceTestCases(testNetworkConditions:false)]
@@ -85,6 +88,8 @@ namespace Halibut.Tests.Diagnostics
                     exception.IsNetworkError()
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
+                    
+                    exception.Message.Should().Contain("Unable to read data from the transport connection: Connection timed out.");
                 }
             }
 

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Text;
 using FluentAssertions;
 using Halibut.Tests.Support;

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -86,7 +86,7 @@ namespace Halibut.Tests.Transport.Protocol
         }
 
         [Test]
-        public void WhenTheStreamEndsBeforeBeforeAnyBytesAreRead_AEndOfStreamExceptionIsThrown()
+        public void WhenTheStreamEndsBeforeAnyBytesAreRead_AnEndOfStreamExceptionIsThrown()
         {
             var sut = new MessageSerializerBuilder().Build();
             using (var stream = new MemoryStream(new byte[0]))

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -151,7 +151,7 @@ namespace Halibut.Tests.Transport.Protocol
             {
                 using (var zip = new DeflateStream(memoryStream, CompressionMode.Compress, true))
                 {
-                    zip.Write(s.GetBytesUtf8());
+                    zip.Write(s.GetBytesUtf8(), 0, s.GetBytesUtf8().Length);
                     zip.Flush();
                 }
                 memoryStream.Position = 0;

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using FluentAssertions;
 using Halibut.Tests.Support;
+using Halibut.Tests.Util;
 using Halibut.Transport;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
@@ -83,7 +86,81 @@ namespace Halibut.Tests.Transport.Protocol
             }
         }
 
-        #if !NETFRAMEWORK
+        [Test]
+        public void WhenTheStreamEndsBeforeBeforeAnyBytesAreRead_AEndOfStreamExceptionIsThrown()
+        {
+            var sut = new MessageSerializerBuilder().Build();
+            using (var stream = new MemoryStream(new byte[0]))
+            {
+                Assert.Throws<EndOfStreamException>(() => sut.ReadMessage<ResponseMessage>(stream));
+            }
+        }
+        
+        [Test]
+        public void WhenTheStreamEndsMidWayThroughReadingAMessage_AEndOfStreamExceptionIsThrown()
+        {
+            var sut = new MessageSerializerBuilder().Build();
+            var completeBytes = CreateBytesFromMessage("Hello this is the message");
+            var someOfTheBytes = completeBytes.SubArray(0, completeBytes.Length - 5);
+            using (var stream = new MemoryStream(someOfTheBytes))
+            {
+                Assert.Throws<EndOfStreamException>(() => sut.ReadMessage<ResponseMessage>(stream));
+            }
+        }
+        
+        [Test]
+        public void WhenTheStreamContainsAnIncompleteZipStream_SomeSortOfZipErrorIsThrown()
+        {
+            var sut = new MessageSerializerBuilder().Build();
+            var completeBytes = CreateBytesFromMessage(Some.RandomAsciiStringOfLength(22000));
+            var badZipStream = new byte[64000];
+            Array.Copy(completeBytes, 0, badZipStream, 0, 30);
+            
+            using (var stream = new MemoryStream(badZipStream))
+            {
+                Assert.Throws<InvalidDataException>(() => sut.ReadMessage<ResponseMessage>(stream));
+            }
+        }
+        
+        [Test]
+        public void WhenTheStreamContainsAnInvalidObject_SomeSortOfJsonErrorsThrown()
+        {
+            var sut = new MessageSerializerBuilder().Build();
+            
+            var deflatedString = DeflateString("Some invalid json/bson");
+            using (var stream = new MemoryStream(deflatedString))
+            {
+                Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => sut.ReadMessage<ResponseMessage>(stream));
+            }
+        }
+
+        private static byte[] CreateBytesFromMessage(object message)
+        {
+            var writingSerializer = new MessageSerializerBuilder().Build();
+
+            using (var stream = new MemoryStream())
+            {
+                writingSerializer.WriteMessage(stream, message);
+                stream.Position = 0;
+                return stream.ToArray();
+            }
+        }
+
+        private static byte[] DeflateString(string s)
+        {
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var zip = new DeflateStream(memoryStream, CompressionMode.Compress, true))
+                {
+                    zip.Write(s.GetBytesUtf8());
+                    zip.Flush();
+                }
+                memoryStream.Position = 0;
+                return memoryStream.ToArray();
+            }
+        }
+
+#if !NETFRAMEWORK
         [Test]
         public void SendReceiveMessageRewindableShouldRoundTrip()
         {

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -151,7 +151,7 @@ namespace Halibut.Tests.Transport.Protocol
             {
                 using (var zip = new DeflateStream(memoryStream, CompressionMode.Compress, true))
                 {
-                    zip.Write(s.GetBytesUtf8(), 0, s.GetBytesUtf8().Length);
+                    zip.WriteString(s);
                     zip.Flush();
                 }
                 memoryStream.Position = 0;

--- a/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Util;
+using Halibut.Transport.Streams;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Transport.Streams
+{
+    public class ErrorRecordingStreamFixture
+    {
+        [Test]
+        public void WhenAskedToCloseTheInnerStreamItIsClosed()
+        {
+            using var tmpDir = new TemporaryDirectory();
+            var path = tmpDir.RandomFileName();
+            using (FileStream fs = File.OpenWrite(path))
+            {
+                using (var errorRecordingStream = new ErrorRecordingStream(fs, closeInner: true))
+                {
+                    errorRecordingStream.Write("Hello".GetBytesUtf8());
+                }
+
+                Assert.Throws<ObjectDisposedException>(() => fs.Write("not this".GetBytesUtf8()));
+            }
+
+            File.ReadAllText(path).Should().Be("Hello");
+        }
+        
+        [Test]
+        public void WhenAskedToLeaveTheStreamOpenItIsLeftOpen()
+        {
+            using var tmpDir = new TemporaryDirectory();
+            var path = tmpDir.RandomFileName();
+            using (FileStream fs = File.OpenWrite(path))
+            {
+                using (var errorRecordingStream = new ErrorRecordingStream(fs, closeInner: false))
+                {
+                    errorRecordingStream.Write("Hello".GetBytesUtf8());
+                }
+
+                fs.Write(" and this".GetBytesUtf8());
+            }
+
+            File.ReadAllText(path).Should().Be("Hello and this");
+        }
+        
+        [Test]
+        public void ReadErrorsFromUnderlyingStreamAreRecorded()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(
+                new CallBackStream(new MemoryStream("hello".GetBytesUtf8()))
+                    .WithBeforeRead((_) => throw new Exception($"Exception number {counter++}"))
+                , true
+                );
+
+            Assert.Throws<Exception>(() => errorRecordingStream.Read(new byte[100], 0, 100));
+            Assert.Throws<Exception>(() => errorRecordingStream.Read(new byte[100], 0, 100));
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(false);
+            errorRecordingStream.ReadExceptions.Count.Should().Be(2);
+            errorRecordingStream.ReadExceptions[0].Message.Should().Be("Exception number 0");
+            errorRecordingStream.ReadExceptions[1].Message.Should().Be("Exception number 1");
+        }
+        
+        [Test]
+        public void ReadErrorsFromUnderlyingStreamAreRecordedAsync()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(
+                new CallBackStream(new MemoryStream("hello".GetBytesUtf8()))
+                    .WithBeforeRead((_) => throw new Exception($"Exception number {counter++}"))
+                , true
+            );
+
+            Assert.ThrowsAsync<Exception>(async () => await errorRecordingStream.ReadAsync(new byte[100], 0, 100));
+            Assert.ThrowsAsync<Exception>(async () => await errorRecordingStream.ReadAsync(new byte[100], 0, 100));
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(false);
+            errorRecordingStream.ReadExceptions.Count.Should().Be(2);
+            errorRecordingStream.ReadExceptions[0].Message.Should().Be("Exception number 0");
+            errorRecordingStream.ReadExceptions[1].Message.Should().Be("Exception number 1");
+        }
+        
+        [Test]
+        public void EndOfStreamEncounteredIsRecorded()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(new MemoryStream("hello".GetBytesUtf8()), true);
+
+            while (errorRecordingStream.Read(new byte[100], 0, 100) != 0)
+            {
+            }
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(true);
+            errorRecordingStream.ReadExceptions.Count.Should().Be(0);
+        }
+        
+        [Test]
+        public async Task EndOfStreamEncounteredIsRecordedAsync()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(new MemoryStream("hello".GetBytesUtf8()), true);
+
+            while ((await errorRecordingStream.ReadAsync(new byte[100], 0, 100)) != 0)
+            {
+            }
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(true);
+            errorRecordingStream.ReadExceptions.Count.Should().Be(0);
+        }
+        
+        [Test]
+        public void WriteErrorsFromUnderlyingStreamAreRecorded()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(
+                new CallBackStream(new MemoryStream("hello".GetBytesUtf8()))
+                    .WithBeforeWrite((_) => throw new Exception($"Exception number {counter++}"))
+                , true
+            );
+
+            Assert.Throws<Exception>(() => errorRecordingStream.Write(new byte[100], 0, 100));
+            Assert.Throws<Exception>(() => errorRecordingStream.Write(new byte[100], 0, 100));
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(false);
+            errorRecordingStream.WriteExceptions.Count.Should().Be(2);
+            errorRecordingStream.WriteExceptions[0].Message.Should().Be("Exception number 0");
+            errorRecordingStream.WriteExceptions[1].Message.Should().Be("Exception number 1");
+        }
+        
+        [Test]
+        public void WriteErrorsFromUnderlyingStreamAreRecordedAsync()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(
+                new CallBackStream(new MemoryStream("hello".GetBytesUtf8()))
+                    .WithBeforeWrite((_) => throw new Exception($"Exception number {counter++}"))
+                , true
+            );
+
+            Assert.ThrowsAsync<Exception>(async () => await errorRecordingStream.WriteAsync(new byte[100], 0, 100));
+            Assert.ThrowsAsync<Exception>(async () => await errorRecordingStream.WriteAsync(new byte[100], 0, 100));
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(false);
+            errorRecordingStream.WriteExceptions.Count.Should().Be(2);
+            errorRecordingStream.WriteExceptions[0].Message.Should().Be("Exception number 0");
+            errorRecordingStream.WriteExceptions[1].Message.Should().Be("Exception number 1");
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
@@ -20,10 +20,10 @@ namespace Halibut.Tests.Transport.Streams
             {
                 using (var errorRecordingStream = new ErrorRecordingStream(fs, closeInner: true))
                 {
-                    errorRecordingStream.Write("Hello".GetBytesUtf8());
+                    errorRecordingStream.WriteString("Hello");
                 }
 
-                Assert.Throws<ObjectDisposedException>(() => fs.Write("not this".GetBytesUtf8()));
+                Assert.Throws<ObjectDisposedException>(() => fs.WriteString("not this"));
             }
 
             File.ReadAllText(path).Should().Be("Hello");
@@ -38,10 +38,10 @@ namespace Halibut.Tests.Transport.Streams
             {
                 using (var errorRecordingStream = new ErrorRecordingStream(fs, closeInner: false))
                 {
-                    errorRecordingStream.Write("Hello".GetBytesUtf8());
+                    errorRecordingStream.WriteString("Hello");
                 }
 
-                fs.Write(" and this".GetBytesUtf8());
+                fs.WriteString(" and this");
             }
 
             File.ReadAllText(path).Should().Be("Hello and this");

--- a/source/Halibut.Tests/Util/ArrayExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/ArrayExtensionMethods.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Halibut.Tests.Util
+{
+    public static class ArrayExtensionMethods
+    {
+        public static T[] SubArray<T>(this T[] array, int offset, int length)
+        {
+            T[] result = new T[length];
+            Array.Copy(array, offset, result, 0, length);
+            return result;
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/CallBackStream.cs
+++ b/source/Halibut.Tests/Util/CallBackStream.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Tests.Util
+{
+    public class CallBackStream : Stream
+    {
+        readonly Stream inner;
+        Action<Stream> beforeReadAction = (innerStream) => { };
+        Action<Stream> beforeWriteAction = (innerStream) => { };
+
+        public CallBackStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public CallBackStream WithBeforeRead(Action<Stream> beforeRead)
+        {
+            this.beforeReadAction += beforeRead;
+            return this;
+        }
+        
+        public CallBackStream WithBeforeWrite(Action<Stream> beforeRead)
+        {
+            this.beforeWriteAction += beforeRead;
+            return this;
+        }
+
+        public override void Flush()
+        {
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            beforeReadAction(inner);
+            return inner.Read(buffer, offset, count);
+        }
+        
+        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            beforeReadAction(inner);
+            return await inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+        
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            beforeWriteAction(inner);
+            inner.Write(buffer, offset, count);
+        }
+        
+        public async override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            beforeWriteAction(inner);
+            await inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            inner.SetLength(value);
+        }
+
+        
+
+        public override bool CanRead => inner.CanRead;
+
+        public override bool CanSeek => inner.CanSeek;
+
+        public override bool CanWrite => inner.CanWrite;
+
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/StreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/StreamExtensionMethods.cs
@@ -1,0 +1,13 @@
+using System.IO;
+
+namespace Halibut.Tests.Util
+{
+    public static class StreamExtensionMethods
+    {
+        public static void WriteString(this Stream stream, string s)
+        {
+            var bytes = s.GetBytesUtf8();
+            stream.Write(bytes, 0, bytes.Length);
+        }
+    }
+}

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -61,6 +61,7 @@ namespace Halibut.Diagnostics
             if (exception is HalibutClientException)
             {
                 if (exception.Message.Contains("System.IO.EndOfStreamException")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("System.Net.Sockets.SocketException (110): Connection timed out")) return HalibutNetworkExceptionType.IsNetworkError;
             }
 
             return HalibutNetworkExceptionType.UnknownError;

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -58,6 +58,11 @@ namespace Halibut.Diagnostics
                 return IsNetworkError(exception.InnerException);
             }
 
+            if (exception is HalibutClientException)
+            {
+                if (exception.Message.Contains("System.IO.EndOfStreamException")) return HalibutNetworkExceptionType.IsNetworkError;
+            }
+
             return HalibutNetworkExceptionType.UnknownError;
         }
     }

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -62,6 +62,9 @@ namespace Halibut.Diagnostics
             {
                 if (exception.Message.Contains("System.IO.EndOfStreamException")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("System.Net.Sockets.SocketException (110): Connection timed out")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("The I/O operation has been aborted because of either a thread exit or an application request")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.")) return HalibutNetworkExceptionType.IsNetworkError;
             }
 
             return HalibutNetworkExceptionType.UnknownError;

--- a/source/Halibut/Transport/ErrorRecordingStream/ErrorRecordingStream.cs
+++ b/source/Halibut/Transport/ErrorRecordingStream/ErrorRecordingStream.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Transport.ErrorRecordingStream
+{
+    public class ErrorRecordingStream : Stream
+    {
+        Stream innerStream;
+
+        public ErrorRecordingStream(Stream innerStream)
+        {
+            this.innerStream = innerStream;
+        }
+
+        public List<Exception> ReadExceptions { get; } = new List<Exception>();
+        public List<Exception> WriteExceptions { get; } = new List<Exception>();
+
+        public bool WasTheEndOfStreamEncountered { get; private set; } = false;
+
+        public override void Flush()
+        {
+            innerStream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            try
+            {
+                int read = innerStream.Read(buffer, offset, count);
+                if (read == 0) WasTheEndOfStreamEncountered = true;
+                return read;
+            }
+            catch (Exception e)
+            {
+                ReadExceptions.Add(e);
+                throw;
+            }
+            
+        }
+
+        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                int read = await ReadAsync(buffer, offset, count, cancellationToken);
+                if (read == 0) WasTheEndOfStreamEncountered = true;
+                return read;
+            }
+            catch (Exception e)
+            {
+                ReadExceptions.Add(e);
+                throw;
+            }
+            
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return innerStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            innerStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            try
+            {
+                innerStream.Write(buffer, offset, count);
+            }
+            catch (Exception e)
+            {
+                WriteExceptions.Add(e);
+                throw;
+            }
+        }
+        
+        public async override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                WriteExceptions.Add(e);
+                throw;
+            }
+        }
+
+        public override bool CanRead => innerStream.CanRead;
+
+        public override bool CanSeek => innerStream.CanSeek;
+
+        public override bool CanWrite => innerStream.CanWrite;
+
+        public override long Length => innerStream.Length;
+
+        public override long Position
+        {
+            get => innerStream.Position;
+            set => innerStream.Position = value;
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using Halibut.Transport.Observability;
 using System.Linq;
 using Halibut.Diagnostics;
+using Halibut.Transport.Streams;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
 
@@ -65,7 +66,7 @@ namespace Halibut.Transport.Protocol
         public T ReadMessage<T>(Stream stream)
         {
             var messageReader = MessageReaderStrategyFromStream<T>(stream);
-            using (var errorRecorder = new ErrorRecordingStream.ErrorRecordingStream(stream))
+            using (var errorRecorder = new ErrorRecordingStream(stream))
             {
                 Exception exceptionFromDeserialisation = null;
                 try

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -170,7 +170,7 @@ namespace Halibut.Transport.Protocol
         
         // By making this a generic type, each message specifies the exact type it sends/expects
         // And it is impossible to deserialize the wrong type - any mismatched type will refuse to deserialize
-        public class MessageEnvelope<T>
+        class MessageEnvelope<T>
         {
             public T Message { get; set; }
         }

--- a/source/Halibut/Transport/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/RewindableBufferStream.cs
@@ -136,7 +136,7 @@ namespace Halibut.Transport
             baseStream.Write(buffer, offset, count);
         }
 
-        public async override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             await baseStream.WriteAsync(buffer, offset, count, cancellationToken);
         }

--- a/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
+++ b/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
@@ -9,10 +9,12 @@ namespace Halibut.Transport.Streams
     public class ErrorRecordingStream : Stream
     {
         Stream innerStream;
+        bool closeInner;
 
-        public ErrorRecordingStream(Stream innerStream)
+        public ErrorRecordingStream(Stream innerStream, bool closeInner) : base()
         {
             this.innerStream = innerStream;
+            this.closeInner = closeInner;
         }
 
         public List<Exception> ReadExceptions { get; } = new List<Exception>();
@@ -105,6 +107,14 @@ namespace Halibut.Transport.Streams
         {
             get => innerStream.Position;
             set => innerStream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (closeInner && disposing)
+            {
+                innerStream.Dispose();
+            }
         }
     }
 }

--- a/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
+++ b/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Halibut.Transport.ErrorRecordingStream
+namespace Halibut.Transport.Streams
 {
     public class ErrorRecordingStream : Stream
     {
@@ -47,7 +45,7 @@ namespace Halibut.Transport.ErrorRecordingStream
         {
             try
             {
-                int read = await ReadAsync(buffer, offset, count, cancellationToken);
+                int read = await innerStream.ReadAsync(buffer, offset, count, cancellationToken);
                 if (read == 0) WasTheEndOfStreamEncountered = true;
                 return read;
             }


### PR DESCRIPTION
# Background

Previously network errors would result in a message envelope was null error or the compression format was invalid. Both of which is wrong. This was happening because end of stream within reading messages was not considered an error in either zip or JSON stream reading.

The change here is to treat timeouts and end of streams when reading messages as an error and throw that type of error.

It works by wrapping the stream before passing that stream to the json serializer. The wrapper `ErrorRecordingStream` records if a error has occured or if the end of the stream was reached. If either of those have occured then we just need to throw some sort of IOException.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
