### PR TITLE
Adds the ability to detect if an error is a network error

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -233,6 +233,28 @@ namespace Halibut.Tests.Diagnostics
                         .Be(HalibutNetworkExceptionType.NotANetworkError);
                 }
             }
+            
+            [Test]
+            public void BecauseTheServiceThrowAnException_ItIsNotANetworkError()
+            {
+                var services = new DelegateServiceFactory();
+                services.Register<IEchoService>(() => new EchoService());
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+                {
+                    var octopusPort = octopus.Listen();
+                    octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                    tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + octopusPort), Certificates.OctopusPublicThumbprint));
+
+                    var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+                    
+                    var exception = Assert.Throws<HalibutClientException>(() => echo.Crash());
+                    exception.IsErrorInService().Should().BeTrue();
+                    exception.IsNetworkError().Should().Be(HalibutNetworkExceptionType.NotANetworkError);
+                }
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Diagnostics;
+
+public static class ExceptionReturnedByHalibutProxyExtensionMethodFixture
+{
+
+    public class WhenTheHalibutProxyThrowsAnException
+    {
+
+
+        [Test]
+        public async Task WhenTheConnectionTerminatesWaitingForAResponseFromAPollingTentacle()
+        {
+            var services = new DelegateServiceFactory();
+            DoSomeActionService doSomeActionService = new DoSomeActionService();
+            services.Register<IDoSomeActionService>(() => doSomeActionService);
+            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            {
+                var octopusPort = octopus.Listen();
+                using (var portForwarder = new PortForwarder(new Uri("https://localhost:" + octopusPort), TimeSpan.Zero))
+                using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+                {
+
+                    octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                    tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port), Certificates.OctopusPublicThumbprint));
+
+                    var svc = octopus.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+                    doSomeActionService.ActionDelegate = () => portForwarder.Dispose();
+
+                    try
+                    {
+                        // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
+                        svc.Action();
+                    }
+                    catch (Exception exception)
+                    {
+                        exception.IsNetworkError()
+                            .Should()
+                            .Be(HalibutNetworkExceptionType.UnknownError, "Since currently we get a message envelope is null message");
+                    }
+                }
+            }
+        }
+
+
+        [Test]
+        public async Task BecauseThePollingRequestWasNotCollected()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            using (var octopus = new HalibutRuntimeBuilder()
+                       .WithServerCertificate(Certificates.Octopus)
+                       .Build())
+            {
+                octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                var serviceEndpoint = new ServiceEndPoint("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+                serviceEndpoint.PollingRequestQueueTimeout = TimeSpan.FromSeconds(1);
+
+                var echo = octopus.CreateClient<IEchoService>(serviceEndpoint);
+
+                try
+                {
+                    echo.SayHello("Hello");
+                }
+                catch (Exception exception)
+                {
+                    exception.IsNetworkError()
+                        .Should()
+                        .Be(HalibutNetworkExceptionType.UnknownError, "We don't know why it wasn't collected.");
+                }
+            }
+        }
+        
+        [Test]
+        public void BecauseTheTentacleIsNotListening_TheError()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+
+            int tentaclePort = 0;
+            using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+            {
+                tentaclePort = tentacleListening.Listen();
+                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
+            }
+            
+            using (var octopus = new HalibutRuntime(Certificates.Octopus)) {
+                var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+                try
+                {
+                    echo.SayHello("Hello");
+                }
+                catch (Exception exception)
+                {
+                    exception.IsNetworkError()
+                        .Should()
+                        .Be(HalibutNetworkExceptionType.IsNetworkError);
+                }
+
+            }
+        }
+        
+    }
+}

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -5,112 +5,114 @@ using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
-using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 
-namespace Halibut.Tests.Diagnostics;
-
-public static class ExceptionReturnedByHalibutProxyExtensionMethodFixture
+namespace Halibut.Tests.Diagnostics
 {
 
-    public class WhenTheHalibutProxyThrowsAnException
+    public static class ExceptionReturnedByHalibutProxyExtensionMethodFixture
     {
 
-
-        [Test]
-        public async Task WhenTheConnectionTerminatesWaitingForAResponseFromAPollingTentacle()
+        public class WhenTheHalibutProxyThrowsAnException
         {
-            var services = new DelegateServiceFactory();
-            DoSomeActionService doSomeActionService = new DoSomeActionService();
-            services.Register<IDoSomeActionService>(() => doSomeActionService);
-            using (var octopus = new HalibutRuntime(Certificates.Octopus))
-            {
-                var octopusPort = octopus.Listen();
-                using (var portForwarder = new PortForwarder(new Uri("https://localhost:" + octopusPort), TimeSpan.Zero))
-                using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
-                {
 
+
+            [Test]
+            public async Task WhenTheConnectionTerminatesWaitingForAResponseFromAPollingTentacle()
+            {
+                var services = new DelegateServiceFactory();
+                DoSomeActionService doSomeActionService = new DoSomeActionService();
+                services.Register<IDoSomeActionService>(() => doSomeActionService);
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                {
+                    var octopusPort = octopus.Listen();
+                    using (var portForwarder = new PortForwarder(new Uri("https://localhost:" + octopusPort), TimeSpan.Zero))
+                    using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
+                    {
+
+                        octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port), Certificates.OctopusPublicThumbprint));
+
+                        var svc = octopus.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+                        doSomeActionService.ActionDelegate = () => portForwarder.Dispose();
+
+                        try
+                        {
+                            // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
+                            svc.Action();
+                        }
+                        catch (Exception exception)
+                        {
+                            exception.IsNetworkError()
+                                .Should()
+                                .Be(HalibutNetworkExceptionType.UnknownError, "Since currently we get a message envelope is null message");
+                        }
+                    }
+                }
+            }
+
+
+            [Test]
+            public async Task BecauseThePollingRequestWasNotCollected()
+            {
+                var services = new DelegateServiceFactory();
+                services.Register<IEchoService>(() => new EchoService());
+                using (var octopus = new HalibutRuntimeBuilder()
+                           .WithServerCertificate(Certificates.Octopus)
+                           .Build())
+                {
                     octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
 
-                    tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port), Certificates.OctopusPublicThumbprint));
+                    var serviceEndpoint = new ServiceEndPoint("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+                    serviceEndpoint.PollingRequestQueueTimeout = TimeSpan.FromSeconds(1);
 
-                    var svc = octopus.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
-
-                    doSomeActionService.ActionDelegate = () => portForwarder.Dispose();
+                    var echo = octopus.CreateClient<IEchoService>(serviceEndpoint);
 
                     try
                     {
-                        // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
-                        svc.Action();
+                        echo.SayHello("Hello");
                     }
                     catch (Exception exception)
                     {
                         exception.IsNetworkError()
                             .Should()
-                            .Be(HalibutNetworkExceptionType.UnknownError, "Since currently we get a message envelope is null message");
+                            .Be(HalibutNetworkExceptionType.UnknownError, "We don't know why it wasn't collected.");
                     }
                 }
             }
-        }
 
-
-        [Test]
-        public async Task BecauseThePollingRequestWasNotCollected()
-        {
-            var services = new DelegateServiceFactory();
-            services.Register<IEchoService>(() => new EchoService());
-            using (var octopus = new HalibutRuntimeBuilder()
-                       .WithServerCertificate(Certificates.Octopus)
-                       .Build())
+            [Test]
+            public void BecauseTheTentacleIsNotListening_TheError()
             {
-                octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+                var services = new DelegateServiceFactory();
+                services.Register<IEchoService>(() => new EchoService());
 
-                var serviceEndpoint = new ServiceEndPoint("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
-                serviceEndpoint.PollingRequestQueueTimeout = TimeSpan.FromSeconds(1);
-
-                var echo = octopus.CreateClient<IEchoService>(serviceEndpoint);
-
-                try
+                int tentaclePort = 0;
+                using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
                 {
-                    echo.SayHello("Hello");
+                    tentaclePort = tentacleListening.Listen();
+                    tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
                 }
-                catch (Exception exception)
+
+                using (var octopus = new HalibutRuntime(Certificates.Octopus))
                 {
-                    exception.IsNetworkError()
-                        .Should()
-                        .Be(HalibutNetworkExceptionType.UnknownError, "We don't know why it wasn't collected.");
+                    var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+                    try
+                    {
+                        echo.SayHello("Hello");
+                    }
+                    catch (Exception exception)
+                    {
+                        exception.IsNetworkError()
+                            .Should()
+                            .Be(HalibutNetworkExceptionType.IsNetworkError);
+                    }
+
                 }
             }
+
         }
-        
-        [Test]
-        public void BecauseTheTentacleIsNotListening_TheError()
-        {
-            var services = new DelegateServiceFactory();
-            services.Register<IEchoService>(() => new EchoService());
-
-            int tentaclePort = 0;
-            using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
-            {
-                tentaclePort = tentacleListening.Listen();
-                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
-            }
-            
-            using (var octopus = new HalibutRuntime(Certificates.Octopus)) {
-                var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
-                try
-                {
-                    echo.SayHello("Hello");
-                }
-                catch (Exception exception)
-                {
-                    exception.IsNetworkError()
-                        .Should()
-                        .Be(HalibutNetworkExceptionType.IsNetworkError);
-                }
-
-            }
-        }
-        
     }
 }

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Diagnostics;
+using Halibut.Exceptions;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
@@ -13,6 +14,32 @@ namespace Halibut.Tests.Diagnostics
 {
     public static class ExceptionReturnedByHalibutProxyExtensionMethodFixture
     {
+        public class WhenGivenA
+        {
+            [Test]
+            public void MethodNotFoundHalibutClientException_ItIsNotANetworkError()
+            {
+                new MethodNotFoundHalibutClientException("").IsNetworkError()
+                    .Should()
+                    .Be(HalibutNetworkExceptionType.NotANetworkError);
+            }
+            
+            [Test]
+            public void ServiceNotFoundHalibutClientException_ItIsNotANetworkError()
+            {
+                new ServiceNotFoundHalibutClientException("").IsNetworkError()
+                    .Should()
+                    .Be(HalibutNetworkExceptionType.NotANetworkError);
+            }
+            
+            [Test]
+            public void AmbiguousMethodMatchHalibutClientException_ItIsNotANetworkError()
+            {
+                new AmbiguousMethodMatchHalibutClientException("").IsNetworkError()
+                    .Should()
+                    .Be(HalibutNetworkExceptionType.NotANetworkError);
+            }
+        }
         public class WhenTheHalibutProxyThrowsAnException
         {
             [Test]

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -251,7 +251,6 @@ namespace Halibut.Tests.Diagnostics
 
                     
                     var exception = Assert.Throws<ServiceInvocationHalibutClientException>(() => echo.Crash());
-                    exception.IsErrorInService().Should().BeTrue();
                     exception.IsNetworkError().Should().Be(HalibutNetworkExceptionType.NotANetworkError);
                 }
             }

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -250,7 +250,7 @@ namespace Halibut.Tests.Diagnostics
                     var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
 
                     
-                    var exception = Assert.Throws<HalibutClientException>(() => echo.Crash());
+                    var exception = Assert.Throws<ServiceInvocationHalibutClientException>(() => echo.Crash());
                     exception.IsErrorInService().Should().BeTrue();
                     exception.IsNetworkError().Should().Be(HalibutNetworkExceptionType.NotANetworkError);
                 }

--- a/source/Halibut.Tests/Diagnostics/UnpackFromContainersFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/UnpackFromContainersFixture.cs
@@ -4,45 +4,46 @@ using FluentAssertions;
 using Halibut.Diagnostics;
 using NUnit.Framework;
 
-namespace Halibut.Tests.Diagnostics;
-
-public class UnpackFromContainersFixture
+namespace Halibut.Tests.Diagnostics
 {
-    [Test]
-    public void JustAnException()
+    public class UnpackFromContainersFixture
     {
-        var e = new Exception();
+        [Test]
+        public void JustAnException()
+        {
+            var e = new Exception();
 
-        e.UnpackFromContainers().Should().Be(e);
-    }
-    
-    
-    [Test]
-    public void HasInner()
-    {
-        var inner = new Exception("inner");
-        var e = new Exception("outer", inner);
+            e.UnpackFromContainers().Should().Be(e);
+        }
 
-        e.UnpackFromContainers().Should().Be(e);
-    }
-    
-    
-    [Test]
-    public void IsInvocationException()
-    {
-        var inner = new Exception("inner");
-        var e = new TargetInvocationException("invocation", inner);
 
-        e.UnpackFromContainers().Should().Be(inner);
-    }
-    
-    [Test]
-    public void IsAggregateException()
-    {
-        var inner = new Exception("inner");
-        var inner2 = new Exception("inner2");
-        var e = new AggregateException("invocation", inner, inner2);
+        [Test]
+        public void HasInner()
+        {
+            var inner = new Exception("inner");
+            var e = new Exception("outer", inner);
 
-        e.UnpackFromContainers().Should().Be(e);
+            e.UnpackFromContainers().Should().Be(e);
+        }
+
+
+        [Test]
+        public void IsInvocationException()
+        {
+            var inner = new Exception("inner");
+            var e = new TargetInvocationException("invocation", inner);
+
+            e.UnpackFromContainers().Should().Be(inner);
+        }
+
+        [Test]
+        public void IsAggregateException()
+        {
+            var inner = new Exception("inner");
+            var inner2 = new Exception("inner2");
+            var e = new AggregateException("invocation", inner, inner2);
+
+            e.UnpackFromContainers().Should().Be(e);
+        }
     }
 }

--- a/source/Halibut.Tests/Diagnostics/UnpackFromContainersFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/UnpackFromContainersFixture.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Reflection;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Diagnostics;
+
+public class UnpackFromContainersFixture
+{
+    [Test]
+    public void JustAnException()
+    {
+        var e = new Exception();
+
+        e.UnpackFromContainers().Should().Be(e);
+    }
+    
+    
+    [Test]
+    public void HasInner()
+    {
+        var inner = new Exception("inner");
+        var e = new Exception("outer", inner);
+
+        e.UnpackFromContainers().Should().Be(e);
+    }
+    
+    
+    [Test]
+    public void IsInvocationException()
+    {
+        var inner = new Exception("inner");
+        var e = new TargetInvocationException("invocation", inner);
+
+        e.UnpackFromContainers().Should().Be(inner);
+    }
+    
+    [Test]
+    public void IsAggregateException()
+    {
+        var inner = new Exception("inner");
+        var inner2 = new Exception("inner2");
+        var e = new AggregateException("invocation", inner, inner2);
+
+        e.UnpackFromContainers().Should().Be(e);
+    }
+}

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using FluentAssertions;
+using Halibut.Exceptions;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using NUnit.Framework;
@@ -47,7 +48,7 @@ namespace Halibut.Tests
                 tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
 
                 var echo = octopus.CreateClient<IEchoService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
-                var ex = Assert.Throws<HalibutClientException>(() => echo.Crash());
+                var ex = Assert.Throws<ServiceInvocationHalibutClientException>(() => echo.Crash());
                 ex.Message.Should().Contain("at Halibut.Tests.TestServices.EchoService.Crash()").And.Contain("divide by zero");
             }
         }
@@ -65,7 +66,7 @@ namespace Halibut.Tests
                 tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + octopusPort), Certificates.OctopusPublicThumbprint));
 
                 var echo = octopus.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
-                var ex = Assert.Throws<HalibutClientException>(() => echo.Crash());
+                var ex = Assert.Throws<ServiceInvocationHalibutClientException>(() => echo.Crash());
                 ex.Message.Should().Contain("at Halibut.Tests.TestServices.EchoService.Crash()").And.Contain("divide by zero");
             }
         }

--- a/source/Halibut.Tests/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/HalibutProxyFixture.cs
@@ -97,5 +97,30 @@ String, <null>
         
             errorThrower.Should().Throw<AmbiguousMethodMatchHalibutClientException>();
         }
+        
+        
+        [Test]
+        public void BackwardsCompatibility_ServiceThrewAnException_IsThrownAsA_ServiceInvocationHalibutClientException()
+        {
+            ServerError serverError = new ServerError{ 
+                Message = "Attempted to divide by zero.", 
+                Details = @"System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
+ ---> System.DivideByZeroException: Attempted to divide by zero.
+   at Halibut.Tests.TestServices.EchoService.Crash() in /home/auser/Documents/octopus/Halibut4/source/Halibut.Tests/TestServices/EchoService.cs:line 16
+   --- End of inner exception stack trace ---
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Span`1& arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
+   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
+   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
+   at Halibut.ServiceModel.ServiceInvoker.Invoke(RequestMessage requestMessage) in /home/auser/Documents/octopus/Halibut4/source/Halibut/ServiceModel/ServiceInvoker.cs:line 34
+   at Halibut.HalibutRuntime.HandleIncomingRequest(RequestMessage request) in /home/auser/Documents/octopus/Halibut4/source/Halibut/HalibutRuntime.cs:line 256
+   at Halibut.Transport.Protocol.MessageExchangeProtocol.InvokeAndWrapAnyExceptions(RequestMessage request, Func`2 incomingRequestProcessor) in /home/auser/Documents/octopus/Halibut4/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 266",
+                HalibutErrorType = null };
+        
+            Action errorThrower = () => HalibutProxy.ThrowExceptionFromReceivedError(serverError, new InMemoryConnectionLog("endpoint"));
+        
+            errorThrower.Should().Throw<ServiceInvocationHalibutClientException>();
+        }
+        
+        
     }
 }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -179,7 +179,7 @@ namespace Halibut.Diagnostics
     }
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
-        public static bool IsErrorInService(Exception e) { }
+        public static bool IsErrorInService(Exception exception) { }
         public static Halibut.Diagnostics.HalibutNetworkExceptionType IsNetworkError(Exception exception) { }
     }
     public class HalibutLimits

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -745,9 +745,10 @@ namespace Halibut.Transport.Proxy.Exceptions
     public class ProxyException : Exception, ISerializable
     {
         public ProxyException() { }
-        public ProxyException(string message) { }
-        public ProxyException(string message, Exception innerException) { }
+        public ProxyException(string message, bool causedByNetworkError) { }
+        public ProxyException(string message, Exception innerException, bool causedByNetworkError) { }
         protected ProxyException(SerializationInfo info, StreamingContext context) { }
+        public bool CausedByNetworkError { get; protected set; }
     }
 }
 namespace Halibut.Util

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -179,7 +179,6 @@ namespace Halibut.Diagnostics
     }
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
-        public static bool IsErrorInService(Exception exception) { }
         public static Halibut.Diagnostics.HalibutNetworkExceptionType IsNetworkError(Exception exception) { }
     }
     public class HalibutLimits
@@ -257,6 +256,12 @@ namespace Halibut.Exceptions
         public NoMatchingServiceOrMethodHalibutClientException(string message) { }
         public NoMatchingServiceOrMethodHalibutClientException(string message, Exception inner) { }
         public NoMatchingServiceOrMethodHalibutClientException(string message, string serverException) { }
+    }
+    public class ServiceInvocationHalibutClientException : Halibut.HalibutClientException, ISerializable
+    {
+        public ServiceInvocationHalibutClientException(string message) { }
+        public ServiceInvocationHalibutClientException(string message, Exception inner) { }
+        public ServiceInvocationHalibutClientException(string message, string serverException) { }
     }
     public class ServiceNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -177,6 +177,11 @@ namespace Halibut.Diagnostics
         public static bool IsSocketTimeout(Exception exception) { }
         public static Exception UnpackFromContainers(Exception error) { }
     }
+    public static class ExceptionReturnedByHalibutProxyExtensionMethod
+    {
+        public static bool IsErrorInService(Exception e) { }
+        public static Halibut.Diagnostics.HalibutNetworkExceptionType IsNetworkError(Exception exception) { }
+    }
     public class HalibutLimits
     {
         public static TimeSpan ConnectionErrorRetryTimeout;
@@ -194,6 +199,12 @@ namespace Halibut.Diagnostics
         public static TimeSpan TcpClientSendTimeout;
         public HalibutLimits() { }
         public static TimeSpan SafeTcpClientPooledConnectionTimeout { get; }
+    }
+    public enum HalibutNetworkExceptionType
+    {
+        IsNetworkError = 0,
+        UnknownError = 1,
+        NotANetworkError = 2
     }
     public interface ILog
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -752,9 +752,10 @@ namespace Halibut.Transport.Proxy.Exceptions
     public class ProxyException : Exception, ISerializable, _Exception
     {
         public ProxyException() { }
-        public ProxyException(string message) { }
-        public ProxyException(string message, Exception innerException) { }
+        public ProxyException(string message, bool causedByNetworkError) { }
+        public ProxyException(string message, Exception innerException, bool causedByNetworkError) { }
         protected ProxyException(SerializationInfo info, StreamingContext context) { }
+        public bool CausedByNetworkError { get; protected set; }
     }
 }
 namespace Halibut.Util

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -179,7 +179,7 @@ namespace Halibut.Diagnostics
     }
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
-        public static bool IsErrorInService(Exception e) { }
+        public static bool IsErrorInService(Exception exception) { }
         public static Halibut.Diagnostics.HalibutNetworkExceptionType IsNetworkError(Exception exception) { }
     }
     public class HalibutLimits

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -177,6 +177,11 @@ namespace Halibut.Diagnostics
         public static bool IsSocketTimeout(Exception exception) { }
         public static Exception UnpackFromContainers(Exception error) { }
     }
+    public static class ExceptionReturnedByHalibutProxyExtensionMethod
+    {
+        public static bool IsErrorInService(Exception e) { }
+        public static Halibut.Diagnostics.HalibutNetworkExceptionType IsNetworkError(Exception exception) { }
+    }
     public class HalibutLimits
     {
         public static TimeSpan ConnectionErrorRetryTimeout;
@@ -194,6 +199,12 @@ namespace Halibut.Diagnostics
         public static TimeSpan TcpClientSendTimeout;
         public HalibutLimits() { }
         public static TimeSpan SafeTcpClientPooledConnectionTimeout { get; }
+    }
+    public enum HalibutNetworkExceptionType
+    {
+        IsNetworkError = 0,
+        UnknownError = 1,
+        NotANetworkError = 2
     }
     public interface ILog
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -179,7 +179,6 @@ namespace Halibut.Diagnostics
     }
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
-        public static bool IsErrorInService(Exception exception) { }
         public static Halibut.Diagnostics.HalibutNetworkExceptionType IsNetworkError(Exception exception) { }
     }
     public class HalibutLimits
@@ -257,6 +256,12 @@ namespace Halibut.Exceptions
         public NoMatchingServiceOrMethodHalibutClientException(string message) { }
         public NoMatchingServiceOrMethodHalibutClientException(string message, Exception inner) { }
         public NoMatchingServiceOrMethodHalibutClientException(string message, string serverException) { }
+    }
+    public class ServiceInvocationHalibutClientException : Halibut.HalibutClientException, ISerializable, _Exception
+    {
+        public ServiceInvocationHalibutClientException(string message) { }
+        public ServiceInvocationHalibutClientException(string message, Exception inner) { }
+        public ServiceInvocationHalibutClientException(string message, string serverException) { }
     }
     public class ServiceNotFoundHalibutClientException : Halibut.Exceptions.NoMatchingServiceOrMethodHalibutClientException, ISerializable, _Exception
     {

--- a/source/Halibut.Tests/Util/TCPListenerWhichKillsNewConnections.cs
+++ b/source/Halibut.Tests/Util/TCPListenerWhichKillsNewConnections.cs
@@ -37,7 +37,7 @@ namespace Halibut.Tests.Util
 
                 try
                 {
-                    var clientSocket = await listeningSocket.AcceptAsync(cancellationToken);
+                    var clientSocket = await listeningSocket.AcceptAsync();
                     clientSocket.Close();
                 }
                 catch (SocketException ex)

--- a/source/Halibut.Tests/Util/TCPListenerWhichKillsNewConnections.cs
+++ b/source/Halibut.Tests/Util/TCPListenerWhichKillsNewConnections.cs
@@ -7,6 +7,11 @@ using Serilog;
 
 namespace Halibut.Tests.Util
 {
+    
+    /// <summary>
+    /// A TCP listener which when a client connects (and so a new TCP connection is created) this
+    /// immediately kills that new connection.
+    /// </summary>
     public class TCPListenerWhichKillsNewConnections : IDisposable
     {
         readonly Socket listeningSocket;

--- a/source/Halibut.Tests/Util/TCPListenerWhichKillsNewConnections.cs
+++ b/source/Halibut.Tests/Util/TCPListenerWhichKillsNewConnections.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Halibut.Tests.Util
+{
+    public class TCPListenerWhichKillsNewConnections : IDisposable
+    {
+        readonly Socket listeningSocket;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        readonly ILogger logger = Log.ForContext<PortForwarder>();
+        
+        public int Port { get; private set; }
+        
+        public TCPListenerWhichKillsNewConnections()
+        {
+            listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listeningSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listeningSocket.Listen(0);
+            Port = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
+            Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
+        }
+        
+        async Task WorkerTask(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Yield();
+
+                try
+                {
+                    var clientSocket = await listeningSocket.AcceptAsync(cancellationToken);
+                    clientSocket.Close();
+                }
+                catch (SocketException ex)
+                {
+                    // This will occur normally on teardown.
+                    logger.Verbose(ex, "Socket Error accepting new connection {Message}", ex.Message);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Error accepting new connection {Message}", ex.Message);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            cancellationTokenSource.Cancel();
+            listeningSocket?.Dispose();
+        }
+    }
+}

--- a/source/Halibut/Diagnostics/ExceptionExtensions.cs
+++ b/source/Halibut/Diagnostics/ExceptionExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Threading.Tasks;
+using Halibut.Exceptions;
 
 namespace Halibut.Diagnostics
 {

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -70,7 +70,7 @@ namespace Halibut.Diagnostics
         /// throwing an exception?
         /// </summary>
         /// <param name="exception">The exception thrown from a Halibut proxy object/param>
-        /// <returns></returns>
+        /// <returns>true the exception indicates an exception was raised within the execution of the remote method</returns>
         public static bool IsErrorInService(this Exception exception)
         {
             if (exception is HalibutClientException)

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net.Sockets;
 using Halibut.Exceptions;
+using Halibut.Transport;
 using Halibut.Transport.Protocol;
 using Halibut.Transport.Proxy.Exceptions;
 
@@ -22,6 +23,11 @@ namespace Halibut.Diagnostics
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
 
+            if (exception is UnexpectedCertificateException)
+            {
+                return HalibutNetworkExceptionType.NotANetworkError;
+            }
+
             if (exception is ProtocolException
                 || exception is SocketException
                 || exception is IOException)
@@ -34,11 +40,18 @@ namespace Halibut.Diagnostics
                 if ((exception as ProxyException).CausedByNetworkError) return HalibutNetworkExceptionType.IsNetworkError;
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
-
+            
+            if (exception is HalibutClientException && exception.Message.Contains("Could not find file"))
+            {
+                return HalibutNetworkExceptionType.NotANetworkError;
+            }
+            
             if (exception is HalibutClientException && exception.InnerException != null)
             {
                 return IsNetworkError(exception.InnerException);
             }
+
+            
 
             return HalibutNetworkExceptionType.UnknownError;
         }

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -22,12 +22,17 @@ namespace Halibut.Diagnostics
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
 
-            if (exception is ProtocolException 
-                || exception is ProxyException 
+            if (exception is ProtocolException
                 || exception is SocketException
                 || exception is IOException)
             {
                 return HalibutNetworkExceptionType.IsNetworkError;
+            }
+
+            if (exception is ProxyException)
+            {
+                if ((exception as ProxyException).CausedByNetworkError) return HalibutNetworkExceptionType.IsNetworkError;
+                return HalibutNetworkExceptionType.NotANetworkError;
             }
 
             if (exception is HalibutClientException && exception.InnerException != null)
@@ -36,7 +41,6 @@ namespace Halibut.Diagnostics
             }
 
             return HalibutNetworkExceptionType.UnknownError;
-
         }
 
         /// <summary>

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -66,11 +66,11 @@ namespace Halibut.Diagnostics
         }
 
         /// <summary>
-        /// Did the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
+        /// Is the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
         /// throwing an exception?
         /// </summary>
         /// <param name="exception">The exception thrown from a Halibut proxy object/param>
-        /// <returns>true the exception indicates an exception was raised within the execution of the remote method</returns>
+        /// <returns>true if the exception indicates an exception was raised within the execution of the remote method</returns>
         public static bool IsErrorInService(this Exception exception)
         {
             if (exception is HalibutClientException)

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -23,10 +23,13 @@ namespace Halibut.Diagnostics
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
 
-            if (exception is UnexpectedCertificateException)
+            if (exception is UnexpectedCertificateException
+                || exception is FileNotFoundException)
             {
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
+            
+            
 
             if (exception is ProtocolException
                 || exception is SocketException
@@ -41,7 +44,7 @@ namespace Halibut.Diagnostics
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
             
-            if (exception is HalibutClientException && exception.Message.Contains("Could not find file"))
+            if (exception is HalibutClientException && exception.Message.Contains("System.IO.FileNotFoundException"))
             {
                 return HalibutNetworkExceptionType.NotANetworkError;
             }

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -8,15 +8,15 @@ using Halibut.Transport.Proxy.Exceptions;
 
 namespace Halibut.Diagnostics
 {
-
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
         /// <summary>
-        /// Classifies the exception thrown from a halibut proxy as a network error or not.
-        /// In some cases it is not possible to tell if the exception is a network error. 
+        ///     Classifies the exception thrown from a halibut proxy as a network error or not.
+        ///     In some cases it is not possible to tell if the exception is a network error.
         /// </summary>
-        /// <param name="exception">The exception thrown from a Halibut proxy object/param>
-        /// <returns></returns>
+        /// <param name="exception">
+        ///     The exception thrown from a Halibut proxy object/param>
+        ///     <returns></returns>
         public static HalibutNetworkExceptionType IsNetworkError(this Exception exception)
         {
             if (exception is NoMatchingServiceOrMethodHalibutClientException)
@@ -24,7 +24,7 @@ namespace Halibut.Diagnostics
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
 
-            if (IsErrorInService(exception))
+            if (exception is ServiceInvocationHalibutClientException)
             {
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
@@ -34,8 +34,6 @@ namespace Halibut.Diagnostics
             {
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
-            
-            
 
             if (exception is ProtocolException
                 || exception is SocketException
@@ -49,37 +47,18 @@ namespace Halibut.Diagnostics
                 if ((exception as ProxyException).CausedByNetworkError) return HalibutNetworkExceptionType.IsNetworkError;
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
-            
+
             if (exception is HalibutClientException && exception.Message.Contains("System.IO.FileNotFoundException"))
             {
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
-            
+
             if (exception is HalibutClientException && exception.InnerException != null)
             {
                 return IsNetworkError(exception.InnerException);
             }
 
-            
-
             return HalibutNetworkExceptionType.UnknownError;
-        }
-
-        /// <summary>
-        /// Is the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
-        /// throwing an exception?
-        /// </summary>
-        /// <param name="exception">The exception thrown from a Halibut proxy object/param>
-        /// <returns>true if the exception indicates an exception was raised within the execution of the remote method</returns>
-        public static bool IsErrorInService(this Exception exception)
-        {
-            if (exception is HalibutClientException)
-            {
-                // This message is returned when the service e.g. tentacle itself throws an error
-                return exception.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
-            }
-
-            return false;
         }
     }
 }

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -11,6 +11,12 @@ namespace Halibut.Diagnostics
 
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
+        /// <summary>
+        /// Classifies the exception thrown from a halibut proxy as a network error or not.
+        /// In some cases it is not possible to tell if the exception is a network error. 
+        /// </summary>
+        /// <param name="exception">The exception thrown from a Halibut proxy object/param>
+        /// <returns></returns>
         public static HalibutNetworkExceptionType IsNetworkError(this Exception exception)
         {
             if (exception is NoMatchingServiceOrMethodHalibutClientException)
@@ -63,14 +69,14 @@ namespace Halibut.Diagnostics
         /// Did the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
         /// throwing an exception?
         /// </summary>
-        /// <param name="e"></param>
+        /// <param name="exception">The exception thrown from a Halibut proxy object/param>
         /// <returns></returns>
-        public static bool IsErrorInService(this Exception e)
+        public static bool IsErrorInService(this Exception exception)
         {
-            if (e is HalibutClientException)
+            if (exception is HalibutClientException)
             {
                 // This message is returned when the service e.g. tentacle itself throws an error
-                return e.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
+                return exception.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
             }
 
             return false;

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -16,7 +16,7 @@ public static class ExceptionReturnedByHalibutProxyExtensionMethod
             return HalibutNetworkExceptionType.NotANetworkError;
         }
 
-        if (IsErrorInTentacle(exception))
+        if (IsErrorInService(exception))
         {
             return HalibutNetworkExceptionType.NotANetworkError;
         }
@@ -35,11 +35,17 @@ public static class ExceptionReturnedByHalibutProxyExtensionMethod
             
     }
     
-    public static bool IsErrorInTentacle(this Exception e) 
+    /// <summary>
+    /// Did the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
+    /// throwing an exception?
+    /// </summary>
+    /// <param name="e"></param>
+    /// <returns></returns>
+    public static bool IsErrorInService(this Exception e) 
     {
         if (e is HalibutClientException)
         {
-            // This message is returned when tentacle itself throws an error
+            // This message is returned when the service e.g. tentacle itself throws an error
             return e.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
         }
 

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Net.Sockets;
+using Halibut.Exceptions;
+using Halibut.Transport.Protocol;
+using Halibut.Transport.Proxy.Exceptions;
+
+namespace Halibut.Diagnostics;
+
+public static class ExceptionReturnedByHalibutProxyExtensionMethod
+{
+    public static HalibutNetworkExceptionType IsNetworkError(this Exception exception)
+    {
+        if (exception is NoMatchingServiceOrMethodHalibutClientException)
+        {
+            return HalibutNetworkExceptionType.NotANetworkError;
+        }
+
+        if (IsErrorInTentacle(exception))
+        {
+            return HalibutNetworkExceptionType.NotANetworkError;
+        }
+
+        if (exception is ProtocolException or ProxyException or SocketException or IOException)
+        {
+            return HalibutNetworkExceptionType.IsNetworkError;
+        }
+
+        if (exception is HalibutClientException && exception.InnerException != null)
+        {
+            return IsNetworkError(exception.InnerException);
+        }
+
+        return HalibutNetworkExceptionType.UnknownError;
+            
+    }
+    
+    public static bool IsErrorInTentacle(this Exception e) 
+    {
+        if (e is HalibutClientException)
+        {
+            // This message is returned when tentacle itself throws an error
+            return e.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
+        }
+
+        return false;
+    }
+}

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -5,50 +5,55 @@ using Halibut.Exceptions;
 using Halibut.Transport.Protocol;
 using Halibut.Transport.Proxy.Exceptions;
 
-namespace Halibut.Diagnostics;
-
-public static class ExceptionReturnedByHalibutProxyExtensionMethod
+namespace Halibut.Diagnostics
 {
-    public static HalibutNetworkExceptionType IsNetworkError(this Exception exception)
+
+    public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
-        if (exception is NoMatchingServiceOrMethodHalibutClientException)
+        public static HalibutNetworkExceptionType IsNetworkError(this Exception exception)
         {
-            return HalibutNetworkExceptionType.NotANetworkError;
+            if (exception is NoMatchingServiceOrMethodHalibutClientException)
+            {
+                return HalibutNetworkExceptionType.NotANetworkError;
+            }
+
+            if (IsErrorInService(exception))
+            {
+                return HalibutNetworkExceptionType.NotANetworkError;
+            }
+
+            if (exception is ProtocolException 
+                || exception is ProxyException 
+                || exception is SocketException
+                || exception is IOException)
+            {
+                return HalibutNetworkExceptionType.IsNetworkError;
+            }
+
+            if (exception is HalibutClientException && exception.InnerException != null)
+            {
+                return IsNetworkError(exception.InnerException);
+            }
+
+            return HalibutNetworkExceptionType.UnknownError;
+
         }
 
-        if (IsErrorInService(exception))
+        /// <summary>
+        /// Did the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
+        /// throwing an exception?
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
+        public static bool IsErrorInService(this Exception e)
         {
-            return HalibutNetworkExceptionType.NotANetworkError;
-        }
+            if (e is HalibutClientException)
+            {
+                // This message is returned when the service e.g. tentacle itself throws an error
+                return e.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
+            }
 
-        if (exception is ProtocolException or ProxyException or SocketException or IOException)
-        {
-            return HalibutNetworkExceptionType.IsNetworkError;
+            return false;
         }
-
-        if (exception is HalibutClientException && exception.InnerException != null)
-        {
-            return IsNetworkError(exception.InnerException);
-        }
-
-        return HalibutNetworkExceptionType.UnknownError;
-            
-    }
-    
-    /// <summary>
-    /// Did the exception thrown from a HalibutProxy object one which was caused by the service e.g. Tentacle
-    /// throwing an exception?
-    /// </summary>
-    /// <param name="e"></param>
-    /// <returns></returns>
-    public static bool IsErrorInService(this Exception e) 
-    {
-        if (e is HalibutClientException)
-        {
-            // This message is returned when the service e.g. tentacle itself throws an error
-            return e.Message.Contains("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.");
-        }
-
-        return false;
     }
 }

--- a/source/Halibut/Diagnostics/HalibutNetworkExceptionType.cs
+++ b/source/Halibut/Diagnostics/HalibutNetworkExceptionType.cs
@@ -1,8 +1,9 @@
-namespace Halibut.Diagnostics;
-
-public enum HalibutNetworkExceptionType
+namespace Halibut.Diagnostics
 {
-    IsNetworkError,
-    UnknownError,
-    NotANetworkError
+    public enum HalibutNetworkExceptionType
+    {
+        IsNetworkError,
+        UnknownError,
+        NotANetworkError
+    }   
 }

--- a/source/Halibut/Diagnostics/HalibutNetworkExceptionType.cs
+++ b/source/Halibut/Diagnostics/HalibutNetworkExceptionType.cs
@@ -1,0 +1,8 @@
+namespace Halibut.Diagnostics;
+
+public enum HalibutNetworkExceptionType
+{
+    IsNetworkError,
+    UnknownError,
+    NotANetworkError
+}

--- a/source/Halibut/Exceptions/ServiceInvocationHalibutClientException.cs
+++ b/source/Halibut/Exceptions/ServiceInvocationHalibutClientException.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Halibut.Exceptions
+{
+    /// <summary>
+    /// Throw when the service itself threw an exception
+    /// </summary>
+    public class ServiceInvocationHalibutClientException : HalibutClientException
+    {
+        public ServiceInvocationHalibutClientException(string message) : base(message)
+        {
+        }
+
+        public ServiceInvocationHalibutClientException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public ServiceInvocationHalibutClientException(string message, string serverException) : base(message, serverException)
+        {
+        }
+    }
+}

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -192,6 +192,11 @@ namespace Halibut.ServiceModel
                 {
                     throw new AmbiguousMethodMatchHalibutClientException(error.Message, realException);
                 }
+                
+                if (error.Details.StartsWith("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation."))
+                {
+                    throw new ServiceInvocationHalibutClientException(error.Message, realException);
+                }
 
             }
             catch (Exception exception) when (!(exception is HalibutClientException))

--- a/source/Halibut/Transport/Proxy/Exceptions/ProxyException.cs
+++ b/source/Halibut/Transport/Proxy/Exceptions/ProxyException.cs
@@ -35,6 +35,9 @@ namespace Halibut.Transport.Proxy.Exceptions
     [Serializable()]
     public class ProxyException : Exception
     {
+
+        public bool CausedByNetworkError { get; protected set; }
+        
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -46,9 +49,10 @@ namespace Halibut.Transport.Proxy.Exceptions
         /// Constructor.
         /// </summary>
         /// <param name="message">Exception message text.</param>
-        public ProxyException(string message)
+        public ProxyException(string message, bool causedByNetworkError)
             : base(message)
         {
+            this.CausedByNetworkError = causedByNetworkError;
         }
 
         /// <summary>
@@ -56,10 +60,11 @@ namespace Halibut.Transport.Proxy.Exceptions
         /// </summary>
         /// <param name="message">Exception message text.</param>
         /// <param name="innerException">The inner exception object.</param>
-        public ProxyException(string message, Exception innerException)
+        public ProxyException(string message, Exception innerException, bool causedByNetworkError)
             :
            base(message, innerException)
         {
+            CausedByNetworkError = causedByNetworkError;
         }
 
         /// <summary>

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -214,13 +214,13 @@ namespace Halibut.Transport.Proxy
                 if (TcpClient == null)
                 {
                     if (string.IsNullOrEmpty(ProxyHost))
-                        throw new ProxyException("ProxyHost property must contain a value");
+                        throw new ProxyException("ProxyHost property must contain a value", false);
 
                     if (ProxyPort <= 0 || ProxyPort > 65535)
-                        throw new ProxyException("ProxyPort value must be greater than zero and less than 65535");
+                        throw new ProxyException("ProxyPort value must be greater than zero and less than 65535", false);
 
                     if(ProxyHost.Contains("://"))
-                        throw new ProxyException("The proxy's hostname cannot contain a protocol prefix (eg http://)");
+                        throw new ProxyException("The proxy's hostname cannot contain a protocol prefix (eg http://)", false);
 
 
                     //  create new tcp client object to the proxy server
@@ -241,13 +241,13 @@ namespace Halibut.Transport.Proxy
             {
                 var se = ae.InnerExceptions.OfType<SocketException>().FirstOrDefault();
                 if (se != null)
-                    throw new ProxyException($"Connection to proxy host {ProxyHost} on port {ProxyPort} failed: {se.Message}", se);
+                    throw new ProxyException($"Connection to proxy host {ProxyHost} on port {ProxyPort} failed: {se.Message}", se, true);
 
                 throw;
             }
             catch (SocketException ex)
             {
-                throw new ProxyException($"Connection to proxy host {ProxyHost} on port {ProxyPort} failed: {ex.Message}", ex);
+                throw new ProxyException($"Connection to proxy host {ProxyHost} on port {ProxyPort} failed: {ex.Message}", ex, true);
             }
         }
 
@@ -330,7 +330,7 @@ namespace Halibut.Transport.Proxy
             }
 
             //  throw a new application exception 
-            throw new ProxyException(msg);
+            throw new ProxyException(msg, false);
         }
 
         void WaitForData(NetworkStream stream)
@@ -341,7 +341,7 @@ namespace Halibut.Transport.Proxy
                 Thread.Sleep(WAIT_FOR_DATA_INTERVAL);
                 sleepTime += WAIT_FOR_DATA_INTERVAL;
                 if (sleepTime > WAIT_FOR_DATA_TIMEOUT)
-                    throw new ProxyException(string.Format("A timeout while waiting for the proxy server at {0} on port {1} to respond.", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient)));
+                    throw new ProxyException(string.Format("A timeout while waiting for the proxy server at {0} on port {1} to respond.", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient)), true);
             }
         }
 
@@ -356,7 +356,7 @@ namespace Halibut.Transport.Proxy
         void ParseCodeAndText(string line)
         {
             if (line.IndexOf("HTTP") == -1)
-                throw new ProxyException(string.Format("No HTTP response received from proxy destination.  Server response: {0}.", line));
+                throw new ProxyException(string.Format("No HTTP response received from proxy destination.  Server response: {0}.", line), false);
 
             var begin = line.IndexOf(" ") + 1;
             var end = line.IndexOf(" ", begin);
@@ -365,7 +365,7 @@ namespace Halibut.Transport.Proxy
 
             int code;
             if (!int.TryParse(val, out code))
-                throw new ProxyException(string.Format("An invalid response code was received from proxy destination.  Server response: {0}.", line));
+                throw new ProxyException(string.Format("An invalid response code was received from proxy destination.  Server response: {0}.", line), false);
 
             _respCode = (HttpResponseCodes)code;
             _respText = line.Substring(end + 1).Trim();

--- a/source/Halibut/Transport/Proxy/ProxyClientFactory.cs
+++ b/source/Halibut/Transport/Proxy/ProxyClientFactory.cs
@@ -95,7 +95,7 @@ namespace Halibut.Transport.Proxy
                 case ProxyType.HTTP:
                     return new HttpProxyClient(logger, proxyHost, proxyPort, proxyUsername, proxyPassword);
                 default:
-                    throw new ProxyException(string.Format("Unknown proxy type {0}.", type.ToString()));
+                    throw new ProxyException(string.Format("Unknown proxy type {0}.", type.ToString()), false);
             }
         }
 

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -95,7 +95,7 @@ namespace Halibut.Transport
         public WebSocketProxy(ProxyDetails proxy)
         {
             if (proxy.Type != ProxyType.HTTP)
-                throw new ProxyException(string.Format("Unknown proxy type {0}.", proxy.Type.ToString()));
+                throw new ProxyException(string.Format("Unknown proxy type {0}.", proxy.Type.ToString()), false);
 
             uri = new Uri($"http://{proxy.Host}:{proxy.Port}");
 


### PR DESCRIPTION
# Background

It can be useful for clients to be able to know if the error returned by the Halibut client is a network error or not. This can be useful to know when to try again.

[SC-46263]

[SC-46263](https://app.shortcut.com/octopusdeploy/story/46263/halibut-ability-to-identify-halibut-network-related-errors)

# Results

An extension method which can tell you if an exception thrown by the halibut client is or is not a network error. Since it is currently it also has to return the `Unknown` type for many errors since it is not easy or possible to determine what is or is not a network error. This isn't great but at least clients can just depend on the halibut implementation, which can be improved as needed.


This adds specific cases around:
* proxies
* FileNotFound exceptions.


This adds a new halibut client exception type of `ServiceInvocationHalibutClientException` thrown when the service e.g. tentacle throws an exception.

This also adds a new TCP Listening helper which just listens on a port and each time a client connects it immediately closes that new tcp connection.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
