### PR TITLE
Fix a bug where a request for a polling service could be cancelled after transmission has started

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -6,6 +6,7 @@
     <PackageId>Halibut.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
@@ -53,7 +54,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT;DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+using NUnit.Framework;
+
+namespace Halibut.Tests.ServiceModel
+{
+    public class PendingRequestQueueFixture
+    {
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CanCancelAPendingRequestBeforeItIsDequeued(bool async)
+        {
+            // Arrange
+            const string endpoint = "poll://endpoint001";
+            var request = new RequestMessage
+            {
+                Id = Guid.NewGuid().ToString(),
+                Destination = new ServiceEndPoint(new Uri(endpoint), "thumbprint")
+            };
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            // Act
+            var (pendingRequestQueue, task) = async ? await StartQueueAndWaitAsATask(endpoint, request, cancellationTokenSource)
+                    : await StartQueueAndWaitAsyncAsATask(endpoint, request, cancellationTokenSource);
+
+            cancellationTokenSource.Cancel();
+
+            Exception actualException = null;
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                actualException = ex;
+            }
+
+            // Assert
+            actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
+            var next = await pendingRequestQueue.DequeueAsync();
+            next.Should().BeNull();
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task CannotCancelAPendingRequestAfterItIsDequeued(bool async)
+        {
+            // Arrange
+            const string endpoint = "poll://endpoint001";
+            var request = new RequestMessage
+            {
+                Id = Guid.NewGuid().ToString(),
+                Destination = new ServiceEndPoint(new Uri(endpoint), "thumbprint")
+            };
+            var expectedResponse = new ResponseMessage
+            {
+                Id = request.Id,
+                Result = new object()
+            };
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            // Act
+            var (pendingRequestQueue, task) = async ? await StartQueueAndWaitAsATask(endpoint, request, cancellationTokenSource)
+                : await StartQueueAndWaitAsyncAsATask(endpoint, request, cancellationTokenSource);
+
+            var dequeued = async ? await pendingRequestQueue.DequeueAsync() : pendingRequestQueue.Dequeue();
+            dequeued.Should().NotBeNull().And.Be(request);
+
+            pendingRequestQueue.ApplyResponse(expectedResponse, request.Destination);
+
+            cancellationTokenSource.Cancel();
+
+            var response = await task;
+
+            // Assert
+            response.Should().Be(expectedResponse);
+            var next = await pendingRequestQueue.DequeueAsync();
+            next.Should().BeNull();
+        }
+
+        static async Task<(PendingRequestQueue, Task<ResponseMessage> task)> StartQueueAndWaitAsyncAsATask(
+            string endpoint,
+            RequestMessage request,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            var log = new InMemoryConnectionLog(endpoint);
+            var pendingRequestQueue = new PendingRequestQueue(log);
+
+            var task = Task.Run(
+                async () => await pendingRequestQueue.QueueAndWaitAsync(request, cancellationTokenSource.Token),
+                CancellationToken.None);
+
+            while (pendingRequestQueue.IsEmpty)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+            }
+
+            return (pendingRequestQueue, task);
+        }
+
+        static async Task<(PendingRequestQueue, Task<ResponseMessage> task)> StartQueueAndWaitAsATask(
+            string endpoint,
+            RequestMessage request,
+            CancellationTokenSource cancellationTokenSource)
+        {
+            var log = new InMemoryConnectionLog(endpoint);
+            var pendingRequestQueue = new PendingRequestQueue(log);
+
+            var task = Task.Run(
+                () => pendingRequestQueue.QueueAndWait(request, cancellationTokenSource.Token),
+                CancellationToken.None);
+
+            while (pendingRequestQueue.IsEmpty)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+            }
+
+            return (pendingRequestQueue, task);
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests/Util/TestContextConnectionLog.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Halibut.Diagnostics;
+using Halibut.Logging;
+using NUnit.Framework;
+using ILog = Halibut.Diagnostics.ILog;
+
+namespace Halibut.Tests.Util
+{
+    internal class TestContextConnectionLog : ILog
+    {
+        readonly string endpoint;
+        readonly string name;
+
+        public TestContextConnectionLog(string endpoint, string name)
+        {
+            this.endpoint = endpoint;
+            this.name = name;
+        }
+
+        public void Write(EventType type, string message, params object[] args)
+        {
+            WriteInternal(new LogEvent(type, message, null, args));
+        }
+
+        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        {
+            WriteInternal(new LogEvent(type, message, ex, args));
+        }
+
+        public IList<LogEvent> GetLogs()
+        {
+            throw new NotImplementedException();
+        }
+
+        void WriteInternal(LogEvent logEvent)
+        {
+            var logLevel = GetLogLevel(logEvent);
+
+            TestContext.WriteLine(string.Format("{6} {5, 16}: {0}:{1} {2}  {3} {4}", logLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name, DateTime.UtcNow.ToString("o")));
+        }
+
+        static LogLevel GetLogLevel(LogEvent logEvent)
+        {
+            switch (logEvent.Type)
+            {
+                case EventType.Error:
+                    return LogLevel.Error;
+                case EventType.Diagnostic:
+                case EventType.SecurityNegotiation:
+                case EventType.MessageExchange:
+                    return LogLevel.Trace;
+                case EventType.OpeningNewConnection:
+                    return LogLevel.Debug;
+                default:
+                    return LogLevel.Info;
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/TestContextLogFactory.cs
+++ b/source/Halibut.Tests/Util/TestContextLogFactory.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Halibut.Diagnostics;
+
+namespace Halibut.Tests.Util
+{
+    public class TestContextLogFactory : ILogFactory
+    {
+        readonly string name;
+        readonly ConcurrentDictionary<string, TestContextConnectionLog> events = new ConcurrentDictionary<string, TestContextConnectionLog>();
+        readonly HashSet<Uri> endpoints = new HashSet<Uri>();
+        readonly HashSet<string> prefixes = new HashSet<string>();
+
+        public TestContextLogFactory(string name)
+        {
+            this.name = name;
+        }
+
+        public Uri[] GetEndpoints()
+        {
+            lock (endpoints)
+                return endpoints.ToArray();
+        }
+
+        public string[] GetPrefixes()
+        {
+            lock (prefixes)
+                return prefixes.ToArray();
+        }
+
+        public ILog ForEndpoint(Uri endpoint)
+        {
+            endpoint = NormalizeEndpoint(endpoint);
+            lock (endpoints)
+                endpoints.Add(endpoint);
+            return events.GetOrAdd(endpoint.ToString(), e => new TestContextConnectionLog(endpoint.ToString(), name));
+        }
+
+        public ILog ForPrefix(string prefix)
+        {
+            lock (prefixes)
+                prefixes.Add(prefix);
+            return events.GetOrAdd(prefix, e => new TestContextConnectionLog(prefix, name));
+        }
+
+        static Uri NormalizeEndpoint(Uri endpoint)
+        {
+            return ServiceEndPoint.IsWebSocketAddress(endpoint)
+                ? new Uri(endpoint.AbsoluteUri.ToLowerInvariant())
+                : new Uri(endpoint.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped).TrimEnd('/').ToLowerInvariant());
+        }
+    }
+}

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class WhenCancellingARequestForAPollingTentacle
+    {
+        public class AndTheRequestIsStillQueued
+        {
+            [Test]
+            public async Task TheRequestShouldBeCancelled()
+            {
+                var cancellationTokenSource = new CancellationTokenSource();
+
+                // No Tentacle
+                using (var server = SetupServer())
+                {
+                    server.Listen();
+                    var doSomeActionService = server.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint, cancellationTokenSource.Token);
+
+                    var waitForActionToBeCalled = new SemaphoreSlim(0, 1);
+                    var task = Task.Run(() =>
+                        {
+                            waitForActionToBeCalled.Release(1);
+                            doSomeActionService.Action();
+                        },
+                        CancellationToken.None);
+
+                    // Try and ensure the request has been queued in Halibut
+                    await waitForActionToBeCalled.WaitAsync(CancellationToken.None);
+                    await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken.None);
+
+                    cancellationTokenSource.Cancel();
+
+                    Exception actualException = null;
+
+                    try
+                    {
+                        await task;
+                    }
+                    catch (Exception ex)
+                    {
+                        actualException = ex;
+                    }
+
+                    actualException.Should().NotBeNull();
+                    actualException.Should().BeOfType<OperationCanceledException>();
+                }
+            }
+        }
+
+        public class AndTheRequestHasBeenDequeuedButNoResponseReceived
+        {
+            [Test]
+            public async Task TheRequestShouldNotBeCancelled()
+            {
+                var waitForActionToBeCalled = new SemaphoreSlim(0, 1);
+                var calls = new List<DateTime>();
+                var cancellationTokenSource = new CancellationTokenSource();
+
+                var (server, tentacle, doSomeActionService) = SetupPollingServerAndTentacle(() =>
+                {
+                    calls.Add(DateTime.UtcNow);
+                    waitForActionToBeCalled.Release(1);
+                }, cancellationTokenSource.Token);
+
+                using (server)
+                using (tentacle)
+                {
+                    var task = Task.Run(() =>
+                        {
+                            doSomeActionService.Action();
+                        },
+                        CancellationToken.None);
+
+                    await waitForActionToBeCalled.WaitAsync(CancellationToken.None);
+                    cancellationTokenSource.Cancel();
+                    await task;
+                }
+
+                calls.Should().HaveCount(1);
+            }
+        }
+
+        static (HalibutRuntime server,
+            IHalibutRuntime tentacle,
+            IDoSomeActionService doSomeActionService)
+            SetupPollingServerAndTentacle(Action doSomeActionServiceAction, CancellationToken cancellationToken)
+        {
+            var server = SetupServer();
+
+            var serverPort = server.Listen();
+
+            var serverUri = new Uri("https://localhost:" + serverPort);
+            var tentacle = SetupPollingTentacle(serverUri, "poll://SQ-TENTAPOLL", doSomeActionServiceAction);
+
+            var doSomeActionService = server.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint, cancellationToken);
+
+            return (server, tentacle, doSomeActionService);
+        }
+
+        static HalibutRuntime SetupPollingTentacle(Uri url, string pollingEndpoint, Action doSomeServiceAction)
+        {
+            var services = new DelegateServiceFactory();
+            var doSomeActionService = new DoSomeActionService(doSomeServiceAction);
+
+            services.Register<IDoSomeActionService>(() => doSomeActionService);
+            services.Register<IEchoService>(() => new EchoService());
+
+            var pollingTentacle = new HalibutRuntimeBuilder()
+                .WithServiceFactory(services)
+                .WithLogFactory(new TestContextLogFactory("Tentacle"))
+                .WithServerCertificate(Certificates.TentaclePolling)
+                .Build();
+
+            pollingTentacle.Poll(new Uri(pollingEndpoint), new ServiceEndPoint(url, Certificates.OctopusPublicThumbprint));
+
+            return pollingTentacle;
+        }
+
+        static HalibutRuntime SetupServer()
+        {
+            var octopus = new HalibutRuntimeBuilder()
+                .WithLogFactory(new TestContextLogFactory("Server"))
+                .WithServerCertificate(Certificates.Octopus)
+                .Build();
+
+            octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+
+            return octopus;
+        }
+    }
+}

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -15,6 +15,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net48;net6.0</TargetFrameworks>

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -183,7 +183,7 @@ namespace Halibut.ServiceModel
                 catch (Exception ex) when (ex is TaskCanceledException or OperationCanceledException)
                 {
                     // waiter.Set is only called when the request has been collected and the response received.
-                    // It is possible that the transfer has already stated once the cancellationToken is cancelled
+                    // It is possible that the transfer has already started once the cancellationToken is cancelled
                     // In this case we cannot walk away from the request as it is already in progress and no longer in the connecting phase
                     cancelled = true;
 

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -10,10 +10,10 @@ namespace Halibut.ServiceModel
 {
     public class PendingRequestQueue : IPendingRequestQueue
     {
-        readonly List<PendingRequest> queue = new List<PendingRequest>();
-        readonly Dictionary<string, PendingRequest> inProgress = new Dictionary<string, PendingRequest>();
-        readonly object sync = new object();
-        readonly AsyncManualResetEvent hasItems = new AsyncManualResetEvent();
+        readonly List<PendingRequest> queue = new();
+        readonly Dictionary<string, PendingRequest> inProgress = new();
+        readonly object sync = new();
+        readonly AsyncManualResetEvent hasItems = new();
         readonly ILog log;
 
         public PendingRequestQueue(ILog log)
@@ -26,7 +26,7 @@ namespace Halibut.ServiceModel
         {
             return QueueAndWait(request, CancellationToken.None);
         }
-        
+
         [Obsolete]
         public ResponseMessage QueueAndWait(RequestMessage request, CancellationToken cancellationToken)
         {
@@ -72,7 +72,11 @@ namespace Halibut.ServiceModel
         public RequestMessage Dequeue()
         {
             var pending = DequeueNext();
-            if (pending == null) return null;
+            if (pending == null)
+            {
+                return null;
+            }
+
             return pending.BeginTransfer() ? pending.Request : null;
         }
 
@@ -80,7 +84,9 @@ namespace Halibut.ServiceModel
         {
             var first = TakeFirst();
             if (first != null)
+            {
                 return first;
+            }
 
             using (var cts = new CancellationTokenSource(HalibutLimits.PollingQueueWaitTimeout))
                 hasItems.Wait(cts.Token);
@@ -100,7 +106,9 @@ namespace Halibut.ServiceModel
         {
             var first = TakeFirst();
             if (first != null)
+            {
                 return first;
+            }
 
             await Task.WhenAny(hasItems.WaitAsync(), Task.Delay(HalibutLimits.PollingQueueWaitTimeout));
             hasItems.Reset();
@@ -112,7 +120,9 @@ namespace Halibut.ServiceModel
             lock (sync)
             {
                 if (queue.Count == 0)
+                {
                     return null;
+                }
 
                 var first = queue[0];
                 queue.RemoveAt(0);
@@ -123,12 +133,13 @@ namespace Halibut.ServiceModel
         public void ApplyResponse(ResponseMessage response, ServiceEndPoint destination)
         {
             if (response == null)
+            {
                 return;
+            }
 
             lock (sync)
             {
-                PendingRequest pending;
-                if (inProgress.TryGetValue(response.Id, out pending))
+                if (inProgress.TryGetValue(response.Id, out var pending))
                 {
                     pending.SetResponse(response);
                 }
@@ -140,7 +151,7 @@ namespace Halibut.ServiceModel
             readonly RequestMessage request;
             readonly ILog log;
             readonly ManualResetEventSlim waiter;
-            readonly object sync = new object();
+            readonly object sync = new();
             bool transferBegun;
             bool completed;
 
@@ -151,20 +162,42 @@ namespace Halibut.ServiceModel
                 waiter = new ManualResetEventSlim(false);
             }
 
-            public RequestMessage Request
-            {
-                get { return request; }
-            }
+            public RequestMessage Request => request;
 
             public void WaitUntilComplete(CancellationToken cancellationToken)
             {
                 log.Write(EventType.MessageExchange, "Request {0} was queued", request);
 
-                var success = waiter.Wait(request.Destination.PollingRequestQueueTimeout, cancellationToken);
-                if (success)
+                bool success;
+                var cancelled = false;
+
+                try
                 {
-                    log.Write(EventType.MessageExchange, "Request {0} was collected by the polling endpoint", request);
-                    return;
+                    success = waiter.Wait(request.Destination.PollingRequestQueueTimeout, cancellationToken);
+                    if (success)
+                    {
+                        log.Write(EventType.MessageExchange, "Request {0} was collected by the polling endpoint", request);
+                        return;
+                    }
+                }
+                catch (Exception ex) when (ex is TaskCanceledException or OperationCanceledException)
+                {
+                    // waiter.Set is only called when the request has been collected and the response received.
+                    // It is possible that the transfer has already stated once the cancellationToken is cancelled
+                    // In this case we cannot walk away from the request as it is already in progress and no longer in the connecting phase
+                    cancelled = true;
+
+                    lock (sync)
+                    {
+                        if (!transferBegun)
+                        {
+                            completed = true;
+                            log.Write(EventType.MessageExchange, "Request {0} was cancelled before it could be collected by the polling endpoint", request);
+                            throw;
+                        }
+
+                        log.Write(EventType.MessageExchange, "Request {0} was cancelled after it had been collected by the polling endpoint and will not be cancelled", request);
+                    }
                 }
 
                 var waitForTransferToComplete = false;
@@ -182,20 +215,29 @@ namespace Halibut.ServiceModel
 
                 if (waitForTransferToComplete)
                 {
-                    success = waiter.Wait(request.Destination.PollingRequestMaximumMessageProcessingTimeout);
+                    success = waiter.Wait(request.Destination.PollingRequestMaximumMessageProcessingTimeout, CancellationToken.None);
                     if (success)
                     {
-                        log.Write(EventType.MessageExchange, "Request {0} was eventually collected by the polling endpoint", request);
+                        // We end up here when the request is cancelled but already being transferred so we need to adjust the log message accordingly
+                        if (cancelled)
+                        {
+                            log.Write(EventType.MessageExchange, "Request {0} was collected by the polling endpoint", request);
+                        }
+                        else
+                        {
+                            log.Write(EventType.MessageExchange, "Request {0} was eventually collected by the polling endpoint", request);
+                        }
+
                     }
                     else
                     {
-                        SetResponse(ResponseMessage.FromException(request, new TimeoutException(string.Format("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time ({0}), so the request timed out.", request.Destination.PollingRequestMaximumMessageProcessingTimeout))));
+                        SetResponse(ResponseMessage.FromException(request, new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time ({request.Destination.PollingRequestMaximumMessageProcessingTimeout}), so the request timed out.")));
                     }
                 }
                 else
                 {
                     log.Write(EventType.MessageExchange, "Request {0} timed out before it could be collected by the polling endpoint", request);
-                    SetResponse(ResponseMessage.FromException(request, new TimeoutException(string.Format("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time ({0}), so the request timed out.", request.Destination.PollingRequestQueueTimeout))));
+                    SetResponse(ResponseMessage.FromException(request, new TimeoutException($"A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time ({request.Destination.PollingRequestQueueTimeout}), so the request timed out.")));
                 }
             }
 
@@ -204,7 +246,9 @@ namespace Halibut.ServiceModel
                 lock (sync)
                 {
                     if (completed)
+                    {
                         return false;
+                    }
 
                     transferBegun = true;
                     return true;


### PR DESCRIPTION
# Background

Halibut allows the cancellation of requests during the connecting phase, i.e. if a request is queued for a polling service but has not yet been transmitted or halibut is trying to connect to a listening service.

After the connection phase, the request should not be cancelled.

Fixes https://github.com/OctopusDeploy/Issues/issues/8141

# Results

This PR fixes a bug that would allow a request to be cancelled after transmission had started to a polling service but before receiving the service's response. This allowed the client to walk away from a request that was actually being processed by the service.

## Before

The request to the polling service could be cancelled after transmission had started.

## After

The request to the polling service can not be cancelled after transmission has started. 

The Halibut Logs have also been adjusted slightly to show the cancellation scenarios.

### Request queued but not yet transmitted

`Request IDoSomeActionService::Action[1] / 08e2724f-a5cc-4121-9928-81bb237df8e9 was cancelled before it could be collected by the polling endpoint`

```
2023-05-09T01:05:51.1348024Z           Server: Info: listen://[::]:56416/  16 Listener started
2023-05-09T01:05:51.1358097Z           Server: Trace: poll://sq-tentapoll/  9 Request IDoSomeActionService::Action[1] / 08e2724f-a5cc-4121-9928-81bb237df8e9 was queued
2023-05-09T01:05:56.1414728Z           Server: Trace: poll://sq-tentapoll/  9 Request IDoSomeActionService::Action[1] / 08e2724f-a5cc-4121-9928-81bb237df8e9 was cancelled before it could be collected by the polling endpoint
2023-05-09T01:05:56.1674792Z           Server: Info: listen://[::]:56416/  9 Listener stopped
```

### Request queued and already being transmitted 

`Request IDoSomeActionService::Action[1] / 648bf70c-d0ae-4278-82f3-0c04d62ed29a was cancelled after it had been collected by the polling endpoint and will not be cancelled`

```
2023-05-09T01:05:50.6355710Z           Server: Info: listen://[::]:56414/  16 Listener started
2023-05-09T01:05:50.6835776Z         Tentacle: Debug: https://localhost:56414/  18 Opening a new connection to https://localhost:56414/
2023-05-09T01:05:50.6885653Z           Server: Trace: poll://sq-tentapoll/  9 Request IDoSomeActionService::Action[1] / 648bf70c-d0ae-4278-82f3-0c04d62ed29a was queued
2023-05-09T01:05:50.7095741Z           Server: Info: listen://[::]:56414/  10 Accepted TCP client: [::1]:56415
2023-05-09T01:05:50.7095741Z         Tentacle: Trace: https://localhost:56414/  18 Connection established to [::1]:56414 for https://localhost:56414/
2023-05-09T01:05:50.7105744Z         Tentacle: Trace: https://localhost:56414/  18 Performing TLS handshake
2023-05-09T01:05:50.7115736Z           Server: Trace: listen://[::]:56414/  10 Performing TLS server handshake
2023-05-09T01:05:50.9105784Z           Server: Trace: listen://[::]:56414/  5 Secure connection established, client is not yet authenticated, client connected with Tls12
2023-05-09T01:05:50.9195828Z         Tentacle: Info: https://localhost:56414/  18 Secure connection established. Server at [::1]:56414 identified by thumbprint: 76225C0717A16C1D0BA4A7FFA76519D286D8A248, using protocol Tls12
2023-05-09T01:05:50.9215834Z           Server: Trace: listen://[::]:56414/  5 Begin authorization
2023-05-09T01:05:50.9215834Z           Server: Info: listen://[::]:56414/  5 Client at [::1]:56415 authenticated as 4098EC3A2FC2B92B97339D3831BA230CC1DD590F
2023-05-09T01:05:50.9225837Z           Server: Trace: listen://[::]:56414/  5 Begin message exchange
2023-05-09T01:05:51.0542599Z           Server: Trace: listen://[::]:56414/  5 Sent: IDoSomeActionService::Action[1] / 648bf70c-d0ae-4278-82f3-0c04d62ed29a
2023-05-09T01:05:51.0973433Z         Tentacle: Trace: https://localhost:56414/  18 Received: IDoSomeActionService::Action[1] / 648bf70c-d0ae-4278-82f3-0c04d62ed29a
2023-05-09T01:05:51.0993252Z           Server: Trace: poll://sq-tentapoll/  9 Request IDoSomeActionService::Action[1] / 648bf70c-d0ae-4278-82f3-0c04d62ed29a was cancelled after it had been collected by the polling endpoint and will not be cancelled
2023-05-09T01:05:51.1003154Z         Tentacle: Trace: https://localhost:56414/  18 Sent: Halibut.Transport.Protocol.ResponseMessage
2023-05-09T01:05:51.1012563Z           Server: Trace: listen://[::]:56414/  5 Received: Halibut.Transport.Protocol.ResponseMessage
2023-05-09T01:05:51.1012563Z           Server: Trace: poll://sq-tentapoll/  9 Request IDoSomeActionService::Action[1] / 648bf70c-d0ae-4278-82f3-0c04d62ed29a was collected by the polling endpoint
2023-05-09T01:05:51.1073360Z           Server: Trace: listen://[::]:56414/  19 Sent: 
2023-05-09T01:05:51.1162639Z           Server: Info: listen://[::]:56414/  9 Listener stopped
```

# How to review this PR

🟢  Bump Halibut in Tentacle - https://github.com/OctopusDeploy/OctopusTentacle/pull/476
🟢  Bump Halibut and Tentacle in Server - Full Chain - https://github.com/OctopusDeploy/OctopusDeploy/pull/17996

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
