### PR TITLE
Simplify tests with builders

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -97,15 +97,10 @@ namespace Halibut.Tests.Diagnostics
             [Test]
             public void BecauseTheTentacleIsNotResponding()
             {
-                var services = new DelegateServiceFactory();
-                services.Register<IEchoService>(() => new EchoService());
-
-                using (var tcpKiller = new TCPListenerWhichKillsNewConnections())
-                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                using (var clientAndService = ClientServiceBuilder.Listening().NoService().Build())
                 {
-                    var serviceEndPoint = new ServiceEndPoint(new Uri("https://localhost:" + tcpKiller.Port), Certificates.TentacleListeningPublicThumbprint);
-                    serviceEndPoint.RetryCountLimit = 1;
-                    var echo = octopus.CreateClient<IEchoService>(serviceEndPoint);
+                    var echo = clientAndService.CreateClient<IEchoService>(serviceEndPoint => { serviceEndPoint.RetryCountLimit = 1; });
+
                     Assert.Throws<HalibutClientException>(() => echo.SayHello("Hello"))
                         .IsNetworkError()
                         .Should()

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -6,6 +6,7 @@
     <PackageId>Halibut.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net48;net6.0</TargetFrameworks>

--- a/source/Halibut.Tests/Util/CertAndThumbprint.cs
+++ b/source/Halibut.Tests/Util/CertAndThumbprint.cs
@@ -1,0 +1,21 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace Halibut.Tests.Util;
+
+public class CertAndThumbprint
+{
+
+    public static CertAndThumbprint TentacleListening = new CertAndThumbprint(Tests.Certificates.TentacleListening, Tests.Certificates.TentacleListeningPublicThumbprint);
+    public static CertAndThumbprint TentaclePolling = new CertAndThumbprint(Tests.Certificates.TentaclePolling, Tests.Certificates.TentaclePollingPublicThumbprint);
+    public static CertAndThumbprint Octopus = new CertAndThumbprint(Tests.Certificates.Octopus, Tests.Certificates.OctopusPublicThumbprint);
+    
+    public CertAndThumbprint(X509Certificate2 certificate2, string thumbprint)
+    {
+        Certificate2 = certificate2;
+        Thumbprint = thumbprint;
+    }
+
+    public X509Certificate2 Certificate2 { get; }
+    public string Thumbprint { get; }
+    
+}

--- a/source/Halibut.Tests/Util/CertAndThumbprint.cs
+++ b/source/Halibut.Tests/Util/CertAndThumbprint.cs
@@ -1,21 +1,21 @@
+using System;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Halibut.Tests.Util;
-
-public class CertAndThumbprint
+namespace Halibut.Tests.Util
 {
-
-    public static CertAndThumbprint TentacleListening = new CertAndThumbprint(Tests.Certificates.TentacleListening, Tests.Certificates.TentacleListeningPublicThumbprint);
-    public static CertAndThumbprint TentaclePolling = new CertAndThumbprint(Tests.Certificates.TentaclePolling, Tests.Certificates.TentaclePollingPublicThumbprint);
-    public static CertAndThumbprint Octopus = new CertAndThumbprint(Tests.Certificates.Octopus, Tests.Certificates.OctopusPublicThumbprint);
-    
-    public CertAndThumbprint(X509Certificate2 certificate2, string thumbprint)
+    public class CertAndThumbprint
     {
-        Certificate2 = certificate2;
-        Thumbprint = thumbprint;
-    }
+        public static CertAndThumbprint TentacleListening = new(Certificates.TentacleListening, Certificates.TentacleListeningPublicThumbprint);
+        public static CertAndThumbprint TentaclePolling = new(Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint);
+        public static CertAndThumbprint Octopus = new(Certificates.Octopus, Certificates.OctopusPublicThumbprint);
 
-    public X509Certificate2 Certificate2 { get; }
-    public string Thumbprint { get; }
-    
+        public CertAndThumbprint(X509Certificate2 certificate2, string thumbprint)
+        {
+            Certificate2 = certificate2;
+            Thumbprint = thumbprint;
+        }
+
+        public X509Certificate2 Certificate2 { get; }
+        public string Thumbprint { get; }
+    }
 }

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Threading;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.Util;
+
+public class ClientServiceBuilder
+{
+    IServiceFactory? serviceFactory;
+    readonly ServiceConnectionType serviceConnectionType;
+    readonly CertAndThumbprint serviceCertAndThumbprint;
+    readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
+    bool HasService = true;
+
+    Func<int, IPortForwarder> portForwarderFactory = port => new NullPortForwarder(port);
+
+    public ClientServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
+    {
+        this.serviceConnectionType = serviceConnectionType;
+        this.serviceCertAndThumbprint = serviceCertAndThumbprint;
+    }
+
+    public static ClientServiceBuilder Polling()
+    {
+        new ClientServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
+        return new ClientServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
+    }
+
+    public static ClientServiceBuilder Listening()
+    {
+        return new ClientServiceBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
+    }
+
+    /// <summary>
+    /// Ie no tentacle.
+    ///
+    /// In the case of listening, a TCPListenerWhichKillsNewConnections will be created. This will cause connections to that port to be killed immediately. 
+    /// </summary>
+    /// <returns></returns>
+    public ClientServiceBuilder NoService()
+    {
+        HasService = false;
+        return this;
+    }
+
+    public ClientServiceBuilder WithServiceFactory(IServiceFactory serviceFactory)
+    {
+        this.serviceFactory = serviceFactory;
+        return this;
+    }
+
+    public ClientServiceBuilder WithService<TContract>(TContract implementation)
+    {
+        return WithService(() => implementation);
+    }
+
+    public ClientServiceBuilder WithService<TContract>(Func<TContract> implementation)
+    {
+        if (serviceFactory == null) serviceFactory = new DelegateServiceFactory();
+        if (serviceFactory is not DelegateServiceFactory) throw new Exception("WithService can only be used with a delegate service factory");
+        (serviceFactory as DelegateServiceFactory)?.Register(implementation);
+
+        return this;
+    }
+
+    public ClientServiceBuilder WithPortForwarding(Func<int, IPortForwarder> portForwarderFactory)
+    {
+        this.portForwarderFactory = portForwarderFactory;
+        return this;
+    }
+
+    public ClientAndService Build()
+    {
+        serviceFactory = serviceFactory ?? new DelegateServiceFactory();
+        var octopus = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
+        octopus.Trust(serviceCertAndThumbprint.Thumbprint);
+        
+        
+        HalibutRuntime? tentacle = null;
+        if(HasService) tentacle = new HalibutRuntime(serviceFactory, serviceCertAndThumbprint.Certificate2);
+
+        DisposableCollection disposableCollection = new DisposableCollection();
+
+        IPortForwarder portForwarder;
+        Uri serviceUri;
+        CertAndThumbprint certForClientCreation;
+        if (serviceConnectionType == ServiceConnectionType.Polling)
+        {
+            var listenPort = octopus.Listen();
+            portForwarder = portForwarderFactory(listenPort);
+            serviceUri = new Uri("poll://SQ-TENTAPOLL");
+            if (tentacle != null)
+            {
+                tentacle.Poll(serviceUri, new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.ListeningPort), clientCertAndThumbprint.Thumbprint));
+            }
+        }
+        else
+        {
+            int listenPort;
+            if (tentacle != null)
+            {
+                tentacle.Trust(clientCertAndThumbprint.Thumbprint);
+                listenPort = tentacle.Listen();
+                
+            }
+            else
+            {
+                var dummyTentacle = new TCPListenerWhichKillsNewConnections();
+                disposableCollection.Add(dummyTentacle);
+                listenPort = dummyTentacle.Port;
+            }
+            portForwarder = portForwarderFactory(listenPort);
+            serviceUri = new Uri("https://localhost:" + portForwarder.ListeningPort);
+        }
+
+        return new ClientAndService(octopus, tentacle, serviceUri, serviceCertAndThumbprint, portForwarder, disposableCollection);
+    }
+
+    public enum ServiceConnectionType
+    {
+        Polling,
+        Listening
+    }
+
+    public class ClientAndService : IDisposable
+    {
+        readonly HalibutRuntime octopus;
+        readonly HalibutRuntime? tentacle;
+        public readonly IPortForwarder portForwarder;
+        readonly Uri serviceUri;
+        readonly CertAndThumbprint serviceCertAndThumbprint; // for creating a client
+        DisposableCollection disposableCollection;
+
+        public ClientAndService(HalibutRuntime octopus, 
+            HalibutRuntime tentacle, 
+            Uri serviceUri, 
+            CertAndThumbprint serviceCertAndThumbprint, 
+            IPortForwarder portForwarder, DisposableCollection disposableCollection)
+        {
+            this.octopus = octopus;
+            this.tentacle = tentacle;
+            this.serviceUri = serviceUri;
+            this.serviceCertAndThumbprint = serviceCertAndThumbprint;
+            this.portForwarder = portForwarder;
+            this.disposableCollection = disposableCollection;
+        }
+
+        public TService CreateClient<TService>()
+        {
+            return CreateClient<TService>(CancellationToken.None);
+        }
+
+        public TService CreateClient<TService>(CancellationToken cancellationToken)
+        {
+            return octopus.CreateClient<TService>(new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint), cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            octopus.Dispose();
+            tentacle?.Dispose();
+            portForwarder.Dispose();
+            disposableCollection.Dispose();
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -2,173 +2,169 @@ using System;
 using System.Threading;
 using Halibut.ServiceModel;
 
-namespace Halibut.Tests.Util;
-
-public class ClientServiceBuilder
+namespace Halibut.Tests.Util
 {
-    IServiceFactory? serviceFactory;
-    readonly ServiceConnectionType serviceConnectionType;
-    readonly CertAndThumbprint serviceCertAndThumbprint;
-    readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
-    bool HasService = true;
-
-    Func<int, IPortForwarder> portForwarderFactory = port => new NullPortForwarder(port);
-
-    public ClientServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
+    public class ClientServiceBuilder
     {
-        this.serviceConnectionType = serviceConnectionType;
-        this.serviceCertAndThumbprint = serviceCertAndThumbprint;
-    }
+        IServiceFactory? serviceFactory;
+        readonly ServiceConnectionType serviceConnectionType;
+        readonly CertAndThumbprint serviceCertAndThumbprint;
+        readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
+        bool HasService = true;
 
-    public static ClientServiceBuilder Polling()
-    {
-        new ClientServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
-        return new ClientServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
-    }
+        Func<int, IPortForwarder> portForwarderFactory = port => new NullPortForwarder(port);
 
-    public static ClientServiceBuilder Listening()
-    {
-        return new ClientServiceBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
-    }
-
-    /// <summary>
-    ///     Ie no tentacle.
-    ///     In the case of listening, a TCPListenerWhichKillsNewConnections will be created. This will cause connections to
-    ///     that port to be killed immediately.
-    /// </summary>
-    /// <returns></returns>
-    public ClientServiceBuilder NoService()
-    {
-        HasService = false;
-        return this;
-    }
-
-    public ClientServiceBuilder WithServiceFactory(IServiceFactory serviceFactory)
-    {
-        this.serviceFactory = serviceFactory;
-        return this;
-    }
-
-    public ClientServiceBuilder WithService<TContract>(TContract implementation)
-    {
-        return WithService(() => implementation);
-    }
-
-    public ClientServiceBuilder WithService<TContract>(Func<TContract> implementation)
-    {
-        if (serviceFactory == null) serviceFactory = new DelegateServiceFactory();
-        if (serviceFactory is not DelegateServiceFactory) throw new Exception("WithService can only be used with a delegate service factory");
-        (serviceFactory as DelegateServiceFactory)?.Register(implementation);
-
-        return this;
-    }
-
-    public ClientServiceBuilder WithPortForwarding(Func<int, IPortForwarder> portForwarderFactory)
-    {
-        this.portForwarderFactory = portForwarderFactory;
-        return this;
-    }
-
-    public ClientAndService Build()
-    {
-        serviceFactory = serviceFactory ?? new DelegateServiceFactory();
-        var octopus = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
-        octopus.Trust(serviceCertAndThumbprint.Thumbprint);
-
-        HalibutRuntime? tentacle = null;
-        if (HasService) tentacle = new HalibutRuntime(serviceFactory, serviceCertAndThumbprint.Certificate2);
-
-        DisposableCollection disposableCollection = new DisposableCollection();
-
-        IPortForwarder portForwarder;
-        Uri serviceUri;
-        CertAndThumbprint certForClientCreation;
-        if (serviceConnectionType == ServiceConnectionType.Polling)
+        public ClientServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
-            var listenPort = octopus.Listen();
-            portForwarder = portForwarderFactory(listenPort);
-            serviceUri = new Uri("poll://SQ-TENTAPOLL");
-            if (tentacle != null)
-            {
-                tentacle.Poll(serviceUri, new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.ListeningPort), clientCertAndThumbprint.Thumbprint));
-            }
+            this.serviceConnectionType = serviceConnectionType;
+            this.serviceCertAndThumbprint = serviceCertAndThumbprint;
         }
-        else
+
+        public static ClientServiceBuilder Polling()
         {
-            int listenPort;
-            if (tentacle != null)
+            new ClientServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
+            return new ClientServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
+        }
+
+        public static ClientServiceBuilder Listening()
+        {
+            return new ClientServiceBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
+        }
+
+        /// <summary>
+        ///     Ie no tentacle.
+        ///     In the case of listening, a TCPListenerWhichKillsNewConnections will be created. This will cause connections to
+        ///     that port to be killed immediately.
+        /// </summary>
+        /// <returns></returns>
+        public ClientServiceBuilder NoService()
+        {
+            HasService = false;
+            return this;
+        }
+
+        public ClientServiceBuilder WithServiceFactory(IServiceFactory serviceFactory)
+        {
+            this.serviceFactory = serviceFactory;
+            return this;
+        }
+
+        public ClientServiceBuilder WithService<TContract>(TContract implementation)
+        {
+            return WithService(() => implementation);
+        }
+
+        public ClientServiceBuilder WithService<TContract>(Func<TContract> implementation)
+        {
+            if (serviceFactory == null) serviceFactory = new DelegateServiceFactory();
+            if (serviceFactory is not DelegateServiceFactory) throw new Exception("WithService can only be used with a delegate service factory");
+            (serviceFactory as DelegateServiceFactory)?.Register(implementation);
+
+            return this;
+        }
+
+        public ClientServiceBuilder WithPortForwarding(Func<int, IPortForwarder> portForwarderFactory)
+        {
+            this.portForwarderFactory = portForwarderFactory;
+            return this;
+        }
+
+        public ClientAndService Build()
+        {
+            serviceFactory = serviceFactory ?? new DelegateServiceFactory();
+            var octopus = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
+            octopus.Trust(serviceCertAndThumbprint.Thumbprint);
+
+            HalibutRuntime? tentacle = null;
+            if (HasService) tentacle = new HalibutRuntime(serviceFactory, serviceCertAndThumbprint.Certificate2);
+
+            var disposableCollection = new DisposableCollection();
+
+            IPortForwarder portForwarder;
+            Uri serviceUri;
+            CertAndThumbprint certForClientCreation;
+            if (serviceConnectionType == ServiceConnectionType.Polling)
             {
-                tentacle.Trust(clientCertAndThumbprint.Thumbprint);
-                listenPort = tentacle.Listen();
+                var listenPort = octopus.Listen();
+                portForwarder = portForwarderFactory(listenPort);
+                serviceUri = new Uri("poll://SQ-TENTAPOLL");
+                if (tentacle != null) tentacle.Poll(serviceUri, new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.ListeningPort), clientCertAndThumbprint.Thumbprint));
             }
             else
             {
-                var dummyTentacle = new TCPListenerWhichKillsNewConnections();
-                disposableCollection.Add(dummyTentacle);
-                listenPort = dummyTentacle.Port;
+                int listenPort;
+                if (tentacle != null)
+                {
+                    tentacle.Trust(clientCertAndThumbprint.Thumbprint);
+                    listenPort = tentacle.Listen();
+                }
+                else
+                {
+                    var dummyTentacle = new TCPListenerWhichKillsNewConnections();
+                    disposableCollection.Add(dummyTentacle);
+                    listenPort = dummyTentacle.Port;
+                }
+
+                portForwarder = portForwarderFactory(listenPort);
+                serviceUri = new Uri("https://localhost:" + portForwarder.ListeningPort);
             }
 
-            portForwarder = portForwarderFactory(listenPort);
-            serviceUri = new Uri("https://localhost:" + portForwarder.ListeningPort);
+            return new ClientAndService(octopus, tentacle, serviceUri, serviceCertAndThumbprint, portForwarder, disposableCollection);
         }
 
-        return new ClientAndService(octopus, tentacle, serviceUri, serviceCertAndThumbprint, portForwarder, disposableCollection);
-    }
-
-    public enum ServiceConnectionType
-    {
-        Polling,
-        Listening
-    }
-
-    public class ClientAndService : IDisposable
-    {
-        readonly HalibutRuntime octopus;
-        readonly HalibutRuntime? tentacle;
-        public readonly IPortForwarder portForwarder;
-        readonly Uri serviceUri;
-        readonly CertAndThumbprint serviceCertAndThumbprint; // for creating a client
-        readonly DisposableCollection disposableCollection;
-
-        public ClientAndService(HalibutRuntime octopus,
-            HalibutRuntime tentacle,
-            Uri serviceUri,
-            CertAndThumbprint serviceCertAndThumbprint,
-            IPortForwarder portForwarder, DisposableCollection disposableCollection)
+        public enum ServiceConnectionType
         {
-            this.octopus = octopus;
-            this.tentacle = tentacle;
-            this.serviceUri = serviceUri;
-            this.serviceCertAndThumbprint = serviceCertAndThumbprint;
-            this.portForwarder = portForwarder;
-            this.disposableCollection = disposableCollection;
+            Polling,
+            Listening
         }
 
-        public TService CreateClient<TService>()
+        public class ClientAndService : IDisposable
         {
-            return CreateClient<TService>(s => { }, CancellationToken.None);
-        }
-        
-        public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint)
-        {
-            return CreateClient<TService>(modifyServiceEndpoint, CancellationToken.None);
-        }
+            readonly HalibutRuntime octopus;
+            readonly HalibutRuntime? tentacle;
+            public readonly IPortForwarder portForwarder;
+            readonly Uri serviceUri;
+            readonly CertAndThumbprint serviceCertAndThumbprint; // for creating a client
+            readonly DisposableCollection disposableCollection;
 
-        public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
-        {
-            var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
-            modifyServiceEndpoint(serviceEndpoint);
-            return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
-        }
-        
-        
+            public ClientAndService(HalibutRuntime octopus,
+                HalibutRuntime tentacle,
+                Uri serviceUri,
+                CertAndThumbprint serviceCertAndThumbprint,
+                IPortForwarder portForwarder, DisposableCollection disposableCollection)
+            {
+                this.octopus = octopus;
+                this.tentacle = tentacle;
+                this.serviceUri = serviceUri;
+                this.serviceCertAndThumbprint = serviceCertAndThumbprint;
+                this.portForwarder = portForwarder;
+                this.disposableCollection = disposableCollection;
+            }
 
-        public void Dispose()
-        {
-            octopus.Dispose();
-            tentacle?.Dispose();
-            portForwarder.Dispose();
-            disposableCollection.Dispose();
+            public TService CreateClient<TService>()
+            {
+                return CreateClient<TService>(s => { }, CancellationToken.None);
+            }
+
+            public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint)
+            {
+                return CreateClient<TService>(modifyServiceEndpoint, CancellationToken.None);
+            }
+
+            public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            {
+                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                modifyServiceEndpoint(serviceEndpoint);
+                return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
+            }
+
+            public void Dispose()
+            {
+                octopus.Dispose();
+                tentacle?.Dispose();
+                portForwarder.Dispose();
+                disposableCollection.Dispose();
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -32,9 +32,9 @@ public class ClientServiceBuilder
     }
 
     /// <summary>
-    /// Ie no tentacle.
-    ///
-    /// In the case of listening, a TCPListenerWhichKillsNewConnections will be created. This will cause connections to that port to be killed immediately. 
+    ///     Ie no tentacle.
+    ///     In the case of listening, a TCPListenerWhichKillsNewConnections will be created. This will cause connections to
+    ///     that port to be killed immediately.
     /// </summary>
     /// <returns></returns>
     public ClientServiceBuilder NoService()
@@ -74,10 +74,9 @@ public class ClientServiceBuilder
         serviceFactory = serviceFactory ?? new DelegateServiceFactory();
         var octopus = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
         octopus.Trust(serviceCertAndThumbprint.Thumbprint);
-        
-        
+
         HalibutRuntime? tentacle = null;
-        if(HasService) tentacle = new HalibutRuntime(serviceFactory, serviceCertAndThumbprint.Certificate2);
+        if (HasService) tentacle = new HalibutRuntime(serviceFactory, serviceCertAndThumbprint.Certificate2);
 
         DisposableCollection disposableCollection = new DisposableCollection();
 
@@ -101,7 +100,6 @@ public class ClientServiceBuilder
             {
                 tentacle.Trust(clientCertAndThumbprint.Thumbprint);
                 listenPort = tentacle.Listen();
-                
             }
             else
             {
@@ -109,6 +107,7 @@ public class ClientServiceBuilder
                 disposableCollection.Add(dummyTentacle);
                 listenPort = dummyTentacle.Port;
             }
+
             portForwarder = portForwarderFactory(listenPort);
             serviceUri = new Uri("https://localhost:" + portForwarder.ListeningPort);
         }
@@ -129,12 +128,12 @@ public class ClientServiceBuilder
         public readonly IPortForwarder portForwarder;
         readonly Uri serviceUri;
         readonly CertAndThumbprint serviceCertAndThumbprint; // for creating a client
-        DisposableCollection disposableCollection;
+        readonly DisposableCollection disposableCollection;
 
-        public ClientAndService(HalibutRuntime octopus, 
-            HalibutRuntime tentacle, 
-            Uri serviceUri, 
-            CertAndThumbprint serviceCertAndThumbprint, 
+        public ClientAndService(HalibutRuntime octopus,
+            HalibutRuntime tentacle,
+            Uri serviceUri,
+            CertAndThumbprint serviceCertAndThumbprint,
             IPortForwarder portForwarder, DisposableCollection disposableCollection)
         {
             this.octopus = octopus;

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -146,13 +146,22 @@ public class ClientServiceBuilder
 
         public TService CreateClient<TService>()
         {
-            return CreateClient<TService>(CancellationToken.None);
+            return CreateClient<TService>(s => { }, CancellationToken.None);
+        }
+        
+        public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint)
+        {
+            return CreateClient<TService>(modifyServiceEndpoint, CancellationToken.None);
         }
 
-        public TService CreateClient<TService>(CancellationToken cancellationToken)
+        public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
         {
-            return octopus.CreateClient<TService>(new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint), cancellationToken);
+            var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+            modifyServiceEndpoint(serviceEndpoint);
+            return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
         }
+        
+        
 
         public void Dispose()
         {

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -63,6 +63,10 @@ namespace Halibut.Tests.Util
             return this;
         }
 
+        public ClientServiceBuilder WithPortForwarding()
+        {
+            return WithPortForwarding(port => new PortForwarder(new Uri("https://localhost:" + port), TimeSpan.Zero));
+        }
         public ClientServiceBuilder WithPortForwarding(Func<int, IPortForwarder> portForwarderFactory)
         {
             this.portForwarderFactory = portForwarderFactory;

--- a/source/Halibut.Tests/Util/DisposableCollection.cs
+++ b/source/Halibut.Tests/Util/DisposableCollection.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Halibut.Tests.Util;
+
+public class DisposableCollection : IDisposable
+{
+ 
+    readonly ConcurrentStack<IDisposable> disposables = new();
+
+    public void Add(IDisposable disposable)
+    {
+        disposables.Push(disposable);
+    }
+
+    public void Dispose()
+    {
+        var exceptions = new List<Exception>();
+        while (!disposables.IsEmpty)
+            try
+            {
+                if (disposables.TryPop(out var disposable))
+                {
+                    disposable.Dispose();
+                }
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+
+        if (exceptions.Any()) throw new AggregateException(exceptions);
+    }
+}

--- a/source/Halibut.Tests/Util/DisposableCollection.cs
+++ b/source/Halibut.Tests/Util/DisposableCollection.cs
@@ -3,34 +3,31 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Halibut.Tests.Util;
-
-public class DisposableCollection : IDisposable
+namespace Halibut.Tests.Util
 {
- 
-    readonly ConcurrentStack<IDisposable> disposables = new();
-
-    public void Add(IDisposable disposable)
+    public class DisposableCollection : IDisposable
     {
-        disposables.Push(disposable);
-    }
+        readonly ConcurrentStack<IDisposable> disposables = new();
 
-    public void Dispose()
-    {
-        var exceptions = new List<Exception>();
-        while (!disposables.IsEmpty)
-            try
-            {
-                if (disposables.TryPop(out var disposable))
+        public void Add(IDisposable disposable)
+        {
+            disposables.Push(disposable);
+        }
+
+        public void Dispose()
+        {
+            var exceptions = new List<Exception>();
+            while (!disposables.IsEmpty)
+                try
                 {
-                    disposable.Dispose();
+                    if (disposables.TryPop(out var disposable)) disposable.Dispose();
                 }
-            }
-            catch (Exception e)
-            {
-                exceptions.Add(e);
-            }
+                catch (Exception e)
+                {
+                    exceptions.Add(e);
+                }
 
-        if (exceptions.Any()) throw new AggregateException(exceptions);
+            if (exceptions.Any()) throw new AggregateException(exceptions);
+        }
     }
 }

--- a/source/Halibut.Tests/Util/IPortForwarder.cs
+++ b/source/Halibut.Tests/Util/IPortForwarder.cs
@@ -1,8 +1,9 @@
 using System;
 
-namespace Halibut.Tests.Util;
-
-public interface IPortForwarder : IDisposable
+namespace Halibut.Tests.Util
 {
-    public int ListeningPort { get; }
+    public interface IPortForwarder : IDisposable
+    {
+        public int ListeningPort { get; }
+    }
 }

--- a/source/Halibut.Tests/Util/IPortForwarder.cs
+++ b/source/Halibut.Tests/Util/IPortForwarder.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Halibut.Tests.Util;
+
+public interface IPortForwarder : IDisposable
+{
+    public int ListeningPort { get; }
+}

--- a/source/Halibut.Tests/Util/NullPortForwarder.cs
+++ b/source/Halibut.Tests/Util/NullPortForwarder.cs
@@ -1,15 +1,17 @@
-namespace Halibut.Tests.Util;
-
-public class NullPortForwarder : IPortForwarder
+namespace Halibut.Tests.Util
 {
-    public NullPortForwarder(int listeningPort)
-    {
-        ListeningPort = listeningPort;
-    }
 
-    public void Dispose()
+    public class NullPortForwarder : IPortForwarder
     {
-    }
+        public NullPortForwarder(int listeningPort)
+        {
+            ListeningPort = listeningPort;
+        }
 
-    public int ListeningPort { get; }
+        public void Dispose()
+        {
+        }
+
+        public int ListeningPort { get; }
+    }
 }

--- a/source/Halibut.Tests/Util/NullPortForwarder.cs
+++ b/source/Halibut.Tests/Util/NullPortForwarder.cs
@@ -1,0 +1,15 @@
+namespace Halibut.Tests.Util;
+
+public class NullPortForwarder : IPortForwarder
+{
+    public NullPortForwarder(int listeningPort)
+    {
+        ListeningPort = listeningPort;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public int ListeningPort { get; }
+}

--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -8,7 +8,7 @@ using Serilog;
 
 namespace Halibut.Tests.Util
 {
-    sealed class PortForwarder : IDisposable
+    sealed class PortForwarder : IDisposable, IPortForwarder
     {
         readonly Uri originServer;
         readonly Socket listeningSocket;
@@ -16,6 +16,8 @@ namespace Halibut.Tests.Util
         readonly List<TcpPump> pumps = new List<TcpPump>();
         readonly ILogger logger = Log.ForContext<PortForwarder>();
         readonly TimeSpan sendDelay;
+        
+        public int ListeningPort { get; }
 
         public PortForwarder(Uri originServer, TimeSpan sendDelay)
         {
@@ -28,8 +30,8 @@ namespace Halibut.Tests.Util
             listeningSocket.Listen(0);
             logger.Information("Listening on {LoadBalancerEndpoint}", listeningSocket.LocalEndPoint?.ToString());
 
-            var port = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
-            PublicEndpoint = new UriBuilder(scheme, "localhost", port).Uri;
+            ListeningPort = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
+            PublicEndpoint = new UriBuilder(scheme, "localhost").Uri;
 
             Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
         }

--- a/source/Halibut.Tests/Util/PortForwarder.cs
+++ b/source/Halibut.Tests/Util/PortForwarder.cs
@@ -31,7 +31,7 @@ namespace Halibut.Tests.Util
             logger.Information("Listening on {LoadBalancerEndpoint}", listeningSocket.LocalEndPoint?.ToString());
 
             ListeningPort = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
-            PublicEndpoint = new UriBuilder(scheme, "localhost").Uri;
+            PublicEndpoint = new UriBuilder(scheme, "localhost", ListeningPort).Uri;
 
             Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
         }

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
@@ -12,33 +11,24 @@ namespace Halibut.Tests
     public class WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse
     {
         [Test]
-        public async Task ToPolling_AResponseShouldBeQuicklyReturned()
+        public async Task ToPolling_AResponseShouldBeQuicklyReturned2()
         {
-            var services = new DelegateServiceFactory();
             DoSomeActionService doSomeActionService = new DoSomeActionService();
-            services.Register<IDoSomeActionService>(() => doSomeActionService);
-            using (var octopus = new HalibutRuntime(Certificates.Octopus))
+            using (var clientAndService = ClientServiceBuilder.Polling()
+                       .WithService<IDoSomeActionService>(doSomeActionService)
+                       .WithPortForwarding(port => new PortForwarder(new Uri("https://localhost:" + port), TimeSpan.Zero))
+                       .Build())
             {
-                var octopusPort = octopus.Listen();
-                using (var portForwarder = new PortForwarder(new Uri("https://localhost:" + octopusPort), TimeSpan.Zero))
-                using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
-                {
-                        
-                    octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+                var svc = clientAndService.CreateClient<IDoSomeActionService>();
 
-                    tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port), Certificates.OctopusPublicThumbprint));
+                doSomeActionService.ActionDelegate = () => clientAndService.portForwarder.Dispose();
 
-                    var svc = octopus.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
-
-                    doSomeActionService.ActionDelegate = () => portForwarder.Dispose();
-                    
-                    // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
-                    var killPortForwarderTask = Task.Run(() => svc.Action());
-                    
-                    await Task.WhenAny(killPortForwarderTask, Task.Delay(TimeSpan.FromSeconds(10)));
-                    
-                    killPortForwarderTask.Status.Should().Be(TaskStatus.Faulted, "We should immediately get an error response.");
-                }
+                // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
+                var killPortForwarderTask = Task.Run(() => svc.Action());
+                
+                await Task.WhenAny(killPortForwarderTask, Task.Delay(TimeSpan.FromSeconds(10)));
+                
+                killPortForwarderTask.Status.Should().Be(TaskStatus.Faulted, "We should immediately get an error response.");
             }
         }
     }

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -11,12 +11,12 @@ namespace Halibut.Tests
     public class WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse
     {
         [Test]
-        public async Task ToPolling_AResponseShouldBeQuicklyReturned2()
+        public async Task ToPolling_AResponseShouldBeQuicklyReturned()
         {
             DoSomeActionService doSomeActionService = new DoSomeActionService();
             using (var clientAndService = ClientServiceBuilder.Polling()
                        .WithService<IDoSomeActionService>(doSomeActionService)
-                       .WithPortForwarding(port => new PortForwarder(new Uri("https://localhost:" + port), TimeSpan.Zero))
+                       .WithPortForwarding()
                        .Build())
             {
                 var svc = clientAndService.CreateClient<IDoSomeActionService>();


### PR DESCRIPTION
# Background

Simplify halibut tests by adding support for a `ClientServiceBuilder` which builds both a client (ie Octopus) and service (ie Tentacle) in listening or polling.

The builder also has support for:
- Configuring a port forwarder.
- Configuring no tentacle to be created.
- Makes it easy to just add a service to the tentacle.
- Makes it easy to get a client.
- The service endpoint can be configured when creating the client.

# Results

see the tests in the diff.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
