### PR TITLE
Luke/client proxy cancellation

### DIFF
--- a/source/Halibut.Tests/BackwardsCompatibility/Util/ClientAndPreviousVersionServiceBuilder.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/Util/ClientAndPreviousVersionServiceBuilder.cs
@@ -28,6 +28,19 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
             return new ClientAndPreviousVersionServiceBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
         }
 
+        public static ClientAndPreviousVersionServiceBuilder WithService(ServiceConnectionType connectionType)
+        {
+            switch (connectionType)
+            {
+                case ServiceConnectionType.Polling:
+                    return WithPollingService();
+                case ServiceConnectionType.Listening:
+                    return WithListeningService();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(connectionType), connectionType, null);
+            }
+        }
+
         public ClientAndPreviousVersionServiceBuilder WithServiceVersion(string version)
         {
             this.version = version;
@@ -90,6 +103,13 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
                 var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
                 modifyServiceEndpoint(serviceEndpoint);
                 return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
+            }
+            
+            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            {
+                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                modifyServiceEndpoint(serviceEndpoint);
+                return octopus.CreateClient<TService, TClientService>(serviceEndpoint, cancellationToken);
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/BackwardsCompatibility/Util/ClientAndPreviousVersionServiceBuilder.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/Util/ClientAndPreviousVersionServiceBuilder.cs
@@ -105,11 +105,11 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
                 return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
             }
             
-            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
                 modifyServiceEndpoint(serviceEndpoint);
-                return octopus.CreateClient<TService, TClientService>(serviceEndpoint, cancellationToken);
+                return octopus.CreateClient<TService, TClientService>(serviceEndpoint);
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Exceptions;
 using Halibut.ServiceModel;
+using Halibut.Tests.BackwardsCompatibility.Util;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
 using Halibut.Transport.Protocol;
@@ -47,6 +50,25 @@ namespace Halibut.Tests
             {
 
                 Assert.Throws<TypeNotAllowedException>(() => clientAndService.CreateClient<IAmNotAllowed>());
+            }
+        }
+
+        [Test]
+        [TestCase(ServiceConnectionType.Listening)]
+        [TestCase(ServiceConnectionType.Polling)]
+        public async Task CanTalkToOldServicesWhichDontKnowAboutHalibutProxyRequestOptions(ServiceConnectionType serviceConnectionType)
+        {
+            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithService(serviceConnectionType).WithServiceVersion("5.0.429").Build())
+            {
+                var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
+                {
+                    se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
+                    se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
+                },
+                    CancellationToken.None);
+
+                var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
+                res.Should().Be("Hello!!");
             }
         }
     }

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class CancellationViaClientProxyFixture
+    {
+        [Test]
+        public void CancellationCanBeDoneViaClientProxy()
+        {
+            using (var clientAndService = ClientServiceBuilder.Listening()
+                       .NoService()
+                       .WithService(new EchoService())
+                       .Build())
+            {
+                var data = new byte[1024 * 1024 + 15];
+                new Random().NextBytes(data);
+
+                var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(point =>
+                {
+                    point.RetryCountLimit = 1000000;
+                },
+                    CancellationToken.None);
+
+                CancellationTokenSource cts = new CancellationTokenSource();
+                cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+                var func = new Func<string>(() => echo.SayHello("hello", new HalibutProxyRequestOptions(cts.Token)));
+                var ex = Assert.Throws<Halibut.HalibutClientException>(() => echo.SayHello("hello", new HalibutProxyRequestOptions(cts.Token)));
+                ex.Message.Should().Contain("The operation was canceled");
+            }
+        }
+    }
+    
+    public interface IClientEchoService
+    {
+        int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -62,7 +62,7 @@ namespace Halibut.Tests
                         se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
                         se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
                     });
-
+                
                 var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
                 res.Should().Be("Hello!!");
             }

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
+using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
 namespace Halibut.Tests
@@ -24,6 +25,7 @@ namespace Halibut.Tests
                 var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(point =>
                 {
                     point.RetryCountLimit = 1000000;
+                    point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
                 },
                     CancellationToken.None);
 
@@ -31,11 +33,37 @@ namespace Halibut.Tests
                 cts.CancelAfter(TimeSpan.FromMilliseconds(100));
                 var func = new Func<string>(() => echo.SayHello("hello", new HalibutProxyRequestOptions(cts.Token)));
                 var ex = Assert.Throws<Halibut.HalibutClientException>(() => echo.SayHello("hello", new HalibutProxyRequestOptions(cts.Token)));
-                ex.Message.Should().Contain("The operation was canceled");
+                ex.Message.Should().ContainAny("The operation was canceled");
+            }
+        }
+        
+        [Test]
+        public void CannotHaveServiceWithHalibutProxyRequestOptions()
+        {
+            using (var clientAndService = ClientServiceBuilder.Listening()
+                       .NoService()
+                       .WithService(new AmNotAllowed())
+                       .Build())
+            {
+
+                Assert.Throws<TypeNotAllowedException>(() => clientAndService.CreateClient<IAmNotAllowed>());
             }
         }
     }
-    
+
+    public interface IAmNotAllowed
+    {
+        public void Foo(HalibutProxyRequestOptions opts);
+    }
+
+    public class AmNotAllowed : IAmNotAllowed
+    {
+        public void Foo(HalibutProxyRequestOptions opts)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public interface IClientEchoService
     {
         int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -328,6 +328,14 @@ namespace Halibut.ServiceModel
         public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger) { }
         public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, System.Threading.CancellationToken, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger, System.Threading.CancellationToken cancellationToken) { }
     }
+    public class HalibutProxyRequestOptions
+    {
+        public HalibutProxyRequestOptions(Nullable<System.Threading.CancellationToken> connectCancellationToken) { }
+        public Nullable<System.Threading.CancellationToken> ConnectCancellationToken { get; }
+    }
+    public interface IHalibutProxy
+    {
+    }
     public interface IPendingRequestQueue
     {
         public bool IsEmpty { get; }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -54,7 +54,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
-        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
@@ -100,7 +100,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
-        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -100,6 +100,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -333,9 +333,6 @@ namespace Halibut.ServiceModel
         public HalibutProxyRequestOptions(Nullable<System.Threading.CancellationToken> connectCancellationToken) { }
         public Nullable<System.Threading.CancellationToken> ConnectCancellationToken { get; }
     }
-    public interface IHalibutProxy
-    {
-    }
     public interface IPendingRequestQueue
     {
         public bool IsEmpty { get; }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -54,6 +54,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -54,6 +54,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
@@ -319,6 +320,11 @@ namespace Halibut.ServiceModel
         public IReadOnlyList<Type> RegisteredServiceTypes { get; }
         public Halibut.ServiceModel.IServiceLease CreateService(string serviceName) { }
         public void Register<TContract>(Func<TContract> implementation) { }
+    }
+    public class HalibutProxyRequestOptions
+    {
+        public HalibutProxyRequestOptions(Nullable<System.Threading.CancellationToken> connectCancellationToken) { }
+        public Nullable<System.Threading.CancellationToken> ConnectCancellationToken { get; }
     }
     public interface IPendingRequestQueue
     {

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -326,9 +326,6 @@ namespace Halibut.ServiceModel
         public HalibutProxyRequestOptions(Nullable<System.Threading.CancellationToken> connectCancellationToken) { }
         public Nullable<System.Threading.CancellationToken> ConnectCancellationToken { get; }
     }
-    public interface IHalibutProxy
-    {
-    }
     public interface IPendingRequestQueue
     {
         public bool IsEmpty { get; }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -54,7 +54,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
-        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }
@@ -100,7 +100,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
-        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -100,6 +100,7 @@ namespace Halibut
         public int Listen() { }
         public int Listen(int port) { }
         public int Listen(IPEndPoint endpoint) { }
+        public TClientService CreateClient<TService, TClientService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint) { }
         public TService CreateClient<TService>(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint) { }

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -326,6 +326,9 @@ namespace Halibut.ServiceModel
         public HalibutProxyRequestOptions(Nullable<System.Threading.CancellationToken> connectCancellationToken) { }
         public Nullable<System.Threading.CancellationToken> ConnectCancellationToken { get; }
     }
+    public interface IHalibutProxy
+    {
+    }
     public interface IPendingRequestQueue
     {
         public bool IsEmpty { get; }

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -156,6 +156,13 @@ namespace Halibut.Tests.Util
                 modifyServiceEndpoint(serviceEndpoint);
                 return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
             }
+            
+            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            {
+                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                modifyServiceEndpoint(serviceEndpoint);
+                return octopus.CreateClient<TService, TClientService>(serviceEndpoint, cancellationToken);
+            }
 
             public void Dispose()
             {

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -157,11 +157,11 @@ namespace Halibut.Tests.Util
                 return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
             }
             
-            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
                 modifyServiceEndpoint(serviceEndpoint);
-                return octopus.CreateClient<TService, TClientService>(serviceEndpoint, cancellationToken);
+                return octopus.CreateClient<TService, TClientService>(serviceEndpoint);
             }
 
             public void Dispose()

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -200,7 +200,12 @@ namespace Halibut
             return CreateClient<TService, TService>(endpoint, cancellationToken);
         }
 
-        public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint, CancellationToken cancellationToken)
+        public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint)
+        {
+            return CreateClient<TService, TClientService>(endpoint, CancellationToken.None);
+        }
+
+        private TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint, CancellationToken cancellationToken)
         {
             typeRegistry.AddToMessageContract(typeof(TService));
             var logger = logs.ForEndpoint(endpoint.BaseUri);

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -206,7 +206,7 @@ namespace Halibut
             var logger = logs.ForEndpoint(endpoint.BaseUri);
 #if HAS_REAL_PROXY
 #pragma warning disable 618
-            return (TService)new HalibutProxy(SendOutgoingRequest, typeof(TService), endpoint, logger, cancellationToken).GetTransparentProxy();
+            return (TClientService)new HalibutProxy(SendOutgoingRequest, typeof(TService), typeof(TClientService), endpoint, logger, cancellationToken).GetTransparentProxy();
 #pragma warning restore 618
 #else
             var proxy = DispatchProxy.Create<TClientService, HalibutProxy>();

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -194,8 +194,13 @@ namespace Halibut
         {
             return CreateClient<TService>(endpoint, CancellationToken.None);
         }
-        
+
         public TService CreateClient<TService>(ServiceEndPoint endpoint, CancellationToken cancellationToken)
+        {
+            return CreateClient<TService, TService>(endpoint, cancellationToken);
+        }
+
+        public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint, CancellationToken cancellationToken)
         {
             typeRegistry.AddToMessageContract(typeof(TService));
             var logger = logs.ForEndpoint(endpoint.BaseUri);
@@ -204,7 +209,7 @@ namespace Halibut
             return (TService)new HalibutProxy(SendOutgoingRequest, typeof(TService), endpoint, logger, cancellationToken).GetTransparentProxy();
 #pragma warning restore 618
 #else
-            var proxy = DispatchProxy.Create<TService, HalibutProxy>();
+            var proxy = DispatchProxy.Create<TClientService, HalibutProxy>();
 #pragma warning disable 618
             (proxy as HalibutProxy).Configure(SendOutgoingRequest, typeof(TService), endpoint, logger, cancellationToken);
 #pragma warning restore 618

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -34,7 +34,6 @@ namespace Halibut
         /// Creates a Halibut client mapping the methods from TClientService to TService.
         /// </summary>
         /// <param name="endpoint"></param>
-        /// <param name="cancellationToken"></param>
         /// <typeparam name="TService">The interface the remote service implements.</typeparam>
         /// <typeparam name="TClientService">The type that will be returned. Must have the same methods as TService except
         /// that each method may have an additional argument at the end of HalibutProxyRequestOptions. When requests are made
@@ -45,7 +44,7 @@ namespace Halibut
         /// TClientService would be: IClientFoo { void Bar(string, HalibutProxyRequestOptions); }
         /// </typeparam>
         /// <returns></returns>
-        public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint, CancellationToken cancellationToken);
+        public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint);
         void Trust(string clientThumbprint);
         void RemoveTrust(string clientThumbprint);
         void TrustOnly(IReadOnlyList<string> thumbprints);

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -29,6 +29,23 @@ namespace Halibut
         TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint, CancellationToken cancellationToken);
         TService CreateClient<TService>(ServiceEndPoint endpoint);
         TService CreateClient<TService>(ServiceEndPoint endpoint, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Creates a Halibut client mapping the methods from TClientService to TService.
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <param name="cancellationToken"></param>
+        /// <typeparam name="TService">The interface the remote service implements.</typeparam>
+        /// <typeparam name="TClientService">The type that will be returned. Must have the same methods as TService except
+        /// that each method may have an additional argument at the end of HalibutProxyRequestOptions. When requests are made
+        /// to the service the HalibutProxyRequestOptions is dropped and the request is sent as though it was called on the
+        /// equivalent method of TService.
+        ///
+        /// For example if TService is interface IFoo { void Bar(string); }
+        /// TClientService would be: IClientFoo { void Bar(string, HalibutProxyRequestOptions); }
+        /// </typeparam>
+        /// <returns></returns>
+        public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint, CancellationToken cancellationToken);
         void Trust(string clientThumbprint);
         void RemoveTrust(string clientThumbprint);
         void TrustOnly(IReadOnlyList<string> thumbprints);

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -159,8 +159,7 @@ namespace Halibut.ServiceModel
                 return globalCancellationToken;
             }
 
-            CancellationToken ct = (CancellationToken) halibutProxyRequestOptions.ConnectCancellationToken;
-            return CancellationTokenSource.CreateLinkedTokenSource(globalCancellationToken, ct).Token;
+            return (CancellationToken) halibutProxyRequestOptions.ConnectCancellationToken;
         }
         
         void EnsureNotError(ResponseMessage responseMessage)

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -39,11 +39,11 @@ namespace Halibut.ServiceModel
 
             try
             {
-                var bits = TrimOffHalibutProxyRequestOptions(methodCall.Args);
+                var trimmedArgsAndHalibutProxyRequestOptions = TrimOffHalibutProxyRequestOptions(methodCall.Args);
                 
-                var request = CreateRequest(methodCall, bits.args);
+                var request = CreateRequest(methodCall, trimmedArgsAndHalibutProxyRequestOptions.args);
 
-                var response = DispatchRequest(request, ConnectingCancellationToken(bits.halibutProxyRequestOptions));
+                var response = DispatchRequest(request, ConnectingCancellationToken(trimmedArgsAndHalibutProxyRequestOptions.halibutProxyRequestOptions));
 
                 EnsureNotError(response);
 
@@ -110,9 +110,9 @@ namespace Halibut.ServiceModel
             if (!configured)
                 throw new Exception("Proxy not configured");
 
-            var bits = TrimOffHalibutProxyRequestOptions(args);
-            args = bits.args;
-            var halibutProxyRequestOptions = bits.halibutProxyRequestOptions;
+            var trimmedArgsAndHalibutProxyRequestOptions = TrimOffHalibutProxyRequestOptions(args);
+            args = trimmedArgsAndHalibutProxyRequestOptions.args;
+            var halibutProxyRequestOptions = trimmedArgsAndHalibutProxyRequestOptions.halibutProxyRequestOptions;
 
             var request = CreateRequest(targetMethod, args);
 

--- a/source/Halibut/ServiceModel/HalibutProxyRequestOptions.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyRequestOptions.cs
@@ -1,0 +1,16 @@
+
+
+using System.Threading;
+
+namespace Halibut.ServiceModel
+{
+    public class HalibutProxyRequestOptions
+    {
+        public CancellationToken? ConnectCancellationToken { get; }
+
+        public HalibutProxyRequestOptions(CancellationToken? connectCancellationToken)
+        {
+            this.ConnectCancellationToken = connectCancellationToken;
+        }
+    }
+}

--- a/source/Halibut/ServiceModel/HalibutProxyRequestOptions.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyRequestOptions.cs
@@ -6,6 +6,10 @@ namespace Halibut.ServiceModel
 {
     public class HalibutProxyRequestOptions
     {
+        /// <summary>
+        /// When cancelled, this will only stop a RPC call if it is known to not be
+        /// received by the service.
+        /// </summary>
         public CancellationToken? ConnectCancellationToken { get; }
 
         public HalibutProxyRequestOptions(CancellationToken? connectCancellationToken)

--- a/source/Halibut/Util/TypeExtensionMethods.cs
+++ b/source/Halibut/Util/TypeExtensionMethods.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Halibut.ServiceModel;
 
 namespace Halibut.Util
 {
@@ -20,7 +21,7 @@ namespace Halibut.Util
 
         public static bool AllowedOnHalibutInterface(this Type type)
         {
-            if (type == typeof(object) || type == typeof(Task))
+            if (type == typeof(object) || type == typeof(Task) || type == typeof(HalibutProxyRequestOptions))
             {
                 return false;
             }


### PR DESCRIPTION
# Background

Adds the ability to trigger the `ConnetCancellationToken` on individual calls to the proxy.

All changes are client side meaning we wont get surprises around sending something new to existing clients.

A `HalibutProxyRequestOptions` wrapper object is used since the cancellationToken is not a normal one and it is likely we would like different cancellation tokens or options in the future. Keeping them all as one object minimises complexity in the proxy and minimises changes to halibut.

# Results

## Before

To cancel a request not yet sent:
```
var proxy = halibutRuntime.CreateService<IFoo>(serviceEndpoint, cancellationToken);
proxy.Bar(); // May be cancelled by the cts.

// To make a new request with a new token we need to make a new proxy object.
var proxy = halibutRuntime.CreateService<IFoo>(serviceEndpoint, someOtherCanellationToken);
proxy.Bar(); // May be cancelled by the cts.
```
## After

```
var proxy = halibutRuntime.CreateService<IFoo, IClientFoo>(serviceEndpoint);

proxy.Bar(new HalibutProxyRequestOptions(cancellationToken));

// To make a new request with a new token we can just pass it to the call.
proxy.Bar(new HalibutProxyRequestOptions(someOtherCanellationToken));
```


# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
