### PR TITLE
Add the ability for Halibut client to cache responses from the Service

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/EchoService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/EchoService.cs
@@ -30,5 +30,35 @@ namespace Halibut.TestUtils.SampleProgram.Base
             File.Delete(tempFile);
             return length;
         }
+
+        public Guid NonCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall(Guid input)
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid AnotherCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCallThatThrowsAnException(string exceptionMessage)
+        {
+            throw new Exception(exceptionMessage + " " + Guid.NewGuid());
+        }
+
+        public Guid TwoSecondCachableCall()
+        {
+            return Guid.NewGuid();
+        }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/IEchoService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/IEchoService.cs
@@ -11,5 +11,27 @@ namespace Halibut.TestUtils.SampleProgram.Base
         bool Crash();
 
         int CountBytes(DataStream stream);
+
+        Guid NonCachableCall();
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid CachableCall();
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid CachableCall(Guid input);
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid AnotherCachableCall();
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid CachableCallThatThrowsAnException(string exceptionMessage);
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid TwoSecondCachableCall();
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_237/Halibut.TestUtils.CompatBinary.v5_0_237.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_237/Halibut.TestUtils.CompatBinary.v5_0_237.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <LangVersion>9.0</LangVersion>
+        <RootNamespace>Halibut.TestUtils.SampleProgram.v5_0_237</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Halibut" Version="5.0.237" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_237/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_237/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Halibut.TestUtils.SampleProgram.Base;
+
+namespace Halibut.TestUtils.SampleProgram.v5_0_237
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+           return BackwardsCompatProgramBase.Main(args);
+        }
+    }
+}

--- a/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectly.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectly.cs
@@ -12,7 +12,10 @@ namespace Halibut.Tests.BackwardsCompatibility
         [Test]
         public async Task OldInvocationExceptionMessages_AreMappedTo_ServiceInvocationHalibutClientException_Polling()
         {
-            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithPollingService().WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder
+                       .WithPollingService()
+                       .WithServiceVersion(PreviousServiceVersions.v5_0_429)
+                       .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>(se =>
                 {
@@ -27,7 +30,10 @@ namespace Halibut.Tests.BackwardsCompatibility
         [Test]
         public async Task OldInvocationExceptionMessages_AreMappedTo_ServiceInvocationHalibutClientException_Listening()
         {
-            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithListeningService().WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder
+                       .WithListeningService()
+                       .WithServiceVersion(PreviousServiceVersions.v5_0_429)
+                       .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>(se =>
                 {

--- a/source/Halibut.Tests/BackwardsCompatibility/Util/PreviousServiceVersions.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/Util/PreviousServiceVersions.cs
@@ -1,0 +1,11 @@
+﻿namespace Halibut.Tests.BackwardsCompatibility.Util
+{
+    public static class PreviousServiceVersions
+    {
+        // Version prior to new exception types being added to Halibut. All exceptions are HalibutClientException
+        public const string v5_0_429 = "5.0.429";
+
+        // The last release with meaningful changes prior to Script Service V2
+        public const string v5_0_237_Used_In_Tentacle_6_3_417 = "5.0.237";
+    }
+}

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -55,17 +55,28 @@ namespace Halibut.Tests
         [TestCase(ServiceConnectionType.Polling)]
         public async Task CanTalkToOldServicesWhichDontKnowAboutHalibutProxyRequestOptions(ServiceConnectionType serviceConnectionType)
         {
-            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithService(serviceConnectionType).WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder.WithService(serviceConnectionType).WithServiceVersion("5.0.429").Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
                     {
                         se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
                         se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
                     });
-                
+
                 var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
                 res.Should().Be("Hello!!");
             }
+        }
+
+        public interface IClientEchoService
+        {
+            int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
         }
     }
 
@@ -80,16 +91,5 @@ namespace Halibut.Tests
         {
             throw new NotImplementedException();
         }
-    }
-
-    public interface IClientEchoService
-    {
-        int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-        string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-        bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-        int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
     }
 }

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Halibut\Halibut.csproj" />
     <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_237\Halibut.TestUtils.CompatBinary.v5_0_237.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Halibut.Tests/ProtocolFixture.cs
+++ b/source/Halibut.Tests/ProtocolFixture.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -86,7 +86,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => new PendingRequestQueue(new InMemoryConnectionLog("x")));
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -111,7 +111,7 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
+            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), (req, ex) => ResponseMessage.FromException(req, ex), 5);
 
             AssertOutput(@"
 --> MX-SUBSCRIBE subscriptionId
@@ -147,7 +147,7 @@ namespace Halibut.Tests
             requestQueue.Dequeue().Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => requestQueue);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -172,7 +172,7 @@ namespace Halibut.Tests
             requestQueue.DequeueAsync().Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => requestQueue).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -192,11 +192,11 @@ namespace Halibut.Tests
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
+            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, 5);
 
             stream.NextReadReturns(new RequestMessage());
 
-            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5);
+            protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, 5);
 
             AssertOutput(@"
 --> MX-SUBSCRIBE subscriptionId
@@ -248,13 +248,13 @@ namespace Halibut.Tests
             queue.Enqueue(new RequestMessage());
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => requestQueue);
 
             queue.Enqueue(new RequestMessage());
 
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue);
+            protocol.ExchangeAsServer(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => requestQueue);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -286,13 +286,13 @@ namespace Halibut.Tests
             queue.Enqueue(new RequestMessage());
             stream.SetNumberOfReads(2);
 
-            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => requestQueue).Wait();
 
             queue.Enqueue(new RequestMessage());
 
             stream.SetNumberOfReads(1);
 
-            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue).Wait();
+            protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ResponseMessage.FromException, ri => requestQueue).Wait();
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -45,6 +45,7 @@ namespace Halibut
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public Func<string, string, Halibut.UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
         public static bool OSSupportsWebSockets { get; }
+        public Halibut.Transport.Caching.OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         protected Halibut.UnauthorizedClientConnectResponse HandleUnauthorizedClientConnect(string clientName, string thumbPrint) { }
         public bool IsTrusted(string remoteThumbprint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
@@ -92,6 +93,7 @@ namespace Halibut
     {
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public Func<string, string, Halibut.UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
+        public Halibut.Transport.Caching.OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         public bool IsTrusted(string remoteThumbprint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
@@ -389,8 +391,9 @@ namespace Halibut.ServiceModel
     }
     public class ServiceInvoker : Halibut.ServiceModel.IServiceInvoker
     {
-        public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
+        public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory, Guid halibutRuntimeProcessIdentifier) { }
         public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+        public static Object[] GetArguments(Halibut.Transport.Protocol.RequestMessage requestMessage, MethodInfo methodInfo) { }
     }
 }
 namespace Halibut.Transport
@@ -444,9 +447,9 @@ namespace Halibut.Transport
     }
     public class PollingClient : Halibut.ServiceModel.IPollingClient, IDisposable
     {
-        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest) { }
-        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest, Halibut.Diagnostics.ILog log) { }
-        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> handleIncomingRequest, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Halibut.Transport.Protocol.IncomingRequestProcessorAction handleIncomingRequest, Halibut.Transport.Protocol.ExceptionHandlingAction exceptionHander) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Halibut.Transport.Protocol.IncomingRequestProcessorAction handleIncomingRequest, Halibut.Transport.Protocol.ExceptionHandlingAction exceptionHander, Halibut.Diagnostics.ILog log) { }
+        public PollingClient(Uri subscription, Halibut.Transport.ISecureClient secureClient, Halibut.Transport.Protocol.IncomingRequestProcessorAction handleIncomingRequest, Halibut.Transport.Protocol.ExceptionHandlingAction exceptionHander, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
         public void Dispose() { }
         public void Start() { }
     }
@@ -511,6 +514,25 @@ namespace Halibut.Transport
         public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
     }
 }
+namespace Halibut.Transport.Caching
+{
+    public class CacheResponseAttribute : Attribute, _Attribute
+    {
+        public CacheResponseAttribute(int durationInSeconds) { }
+        public int DurationInSeconds { get; set; }
+    }
+    public interface ICachable
+    {
+        public string CacheKey { get; }
+    }
+    public sealed class OverrideErrorResponseMessageCachingAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public OverrideErrorResponseMessageCachingAction(Object @object, IntPtr method) { }
+        public bool EndInvoke(IAsyncResult result) { }
+        public bool Invoke(Halibut.Transport.Protocol.ResponseMessage responseMessage) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.ResponseMessage responseMessage, AsyncCallback callback, Object @object) { }
+    }
+}
 namespace Halibut.Transport.Protocol
 {
     public class ConnectionInitializationFailedException : Exception, ISerializable, _Exception
@@ -518,6 +540,13 @@ namespace Halibut.Transport.Protocol
         public ConnectionInitializationFailedException(string message) { }
         public ConnectionInitializationFailedException(string message, Exception innerException) { }
         public ConnectionInitializationFailedException(Exception innerException) { }
+    }
+    public sealed class ExceptionHandlingAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public ExceptionHandlingAction(Object @object, IntPtr method) { }
+        public Halibut.Transport.Protocol.ResponseMessage EndInvoke(IAsyncResult result) { }
+        public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage, Exception exception) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.RequestMessage requestMessage, Exception exception, AsyncCallback callback, Object @object) { }
     }
     public sealed class ExchangeAction : MulticastDelegate, ICloneable, ISerializable
     {
@@ -567,6 +596,13 @@ namespace Halibut.Transport.Protocol
         public T ReadMessage<T>(Stream stream) { }
         public void WriteMessage<T>(Stream stream, T message) { }
     }
+    public sealed class IncomingRequestProcessorAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public IncomingRequestProcessorAction(Object @object, IntPtr method) { }
+        public Halibut.Transport.Protocol.ResponseMessage EndInvoke(IAsyncResult result) { }
+        public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.RequestMessage requestMessage, AsyncCallback callback, Object @object) { }
+    }
     public class InMemoryDataStreamReceiver : Halibut.IDataStreamReceiver
     {
         public InMemoryDataStreamReceiver(Action<Stream> writer) { }
@@ -584,10 +620,10 @@ namespace Halibut.Transport.Protocol
     {
         public MessageExchangeProtocol(Halibut.Transport.Protocol.IMessageExchangeStream stream, Halibut.Diagnostics.ILog log) { }
         public Halibut.Transport.Protocol.ResponseMessage ExchangeAsClient(Halibut.Transport.Protocol.RequestMessage request) { }
-        public Task ExchangeAsServerAsync(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
+        public Task ExchangeAsServerAsync(Halibut.Transport.Protocol.IncomingRequestProcessorAction incomingRequestProcessor, Halibut.Transport.Protocol.ExceptionHandlingAction exceptionHandler, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
         public void EndCommunicationWithServer() { }
-        public void ExchangeAsServer(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
-        public void ExchangeAsSubscriber(Uri subscriptionId, Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> incomingRequestProcessor, int maxAttempts) { }
+        public void ExchangeAsServer(Halibut.Transport.Protocol.IncomingRequestProcessorAction incomingRequestProcessor, Halibut.Transport.Protocol.ExceptionHandlingAction exceptionHandler, Func<Halibut.Transport.Protocol.RemoteIdentity, Halibut.ServiceModel.IPendingRequestQueue> pendingRequests) { }
+        public void ExchangeAsSubscriber(Uri subscriptionId, Halibut.Transport.Protocol.IncomingRequestProcessorAction incomingRequestProcessor, Halibut.Transport.Protocol.ExceptionHandlingAction exceptionHandler, int maxAttempts) { }
         public void StopAcceptingClientRequests() { }
     }
     public class MessageExchangeStream : Halibut.Transport.Protocol.IMessageExchangeStream
@@ -660,11 +696,13 @@ namespace Halibut.Transport.Protocol
     {
         public ResponseMessage() { }
         public Halibut.Transport.Protocol.ServerError Error { get; set; }
+        public Nullable<Guid> HalibutRuntimeProcessIdentifier { get; set; }
         public string Id { get; set; }
         public Object Result { get; set; }
-        public static Halibut.Transport.Protocol.ResponseMessage FromError(Halibut.Transport.Protocol.RequestMessage request, string message) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromError(Halibut.Transport.Protocol.RequestMessage request, string message, Guid halibutRuntimeProcessIdentifier) { }
         public static Halibut.Transport.Protocol.ResponseMessage FromException(Halibut.Transport.Protocol.RequestMessage request, Exception ex) { }
-        public static Halibut.Transport.Protocol.ResponseMessage FromResult(Halibut.Transport.Protocol.RequestMessage request, Object result) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromException(Halibut.Transport.Protocol.RequestMessage request, Exception ex, Nullable<Guid> halibutRuntimeProcessIdentifier) { }
+        public static Halibut.Transport.Protocol.ResponseMessage FromResult(Halibut.Transport.Protocol.RequestMessage request, Object result, Guid halibutRuntimeProcessIdentifier) { }
     }
     public class ServerError
     {

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -1,0 +1,324 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.BackwardsCompatibility.Util;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using Halibut.Transport.Caching;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class ResponseMessageCacheFixture
+    {
+        public static object[] ServiceConnectionTypeAndVersion =
+        {
+            new object[] { ServiceConnectionType.Polling, null },
+            new object[] { ServiceConnectionType.Listening, null },
+            new object[] { ServiceConnectionType.Polling, PreviousServiceVersions.v5_0_237_Used_In_Tentacle_6_3_417 },
+            new object[] { ServiceConnectionType.Listening, PreviousServiceVersions.v5_0_237_Used_In_Tentacle_6_3_417 }
+        };
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatDoesNotSupportCaching_ResponsesShouldNotBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                var result1 = client.NonCachableCall();
+                var result2 = client.NonCachableCall();
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatDoesNotSupportCaching_WithClientInterface_ResponsesShouldNotBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService, IClientEchoService>();
+
+                var result1 = client.NonCachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+                var result2 = client.NonCachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                var result1 = client.CachableCall();
+                var result2 = client.CachableCall();
+
+                result1.Should().Be(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_WithClientInterface_ResponseShouldBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService, IClientEchoService>();
+
+                var result1 = client.CachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+                var result2 = client.CachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+
+                result1.Should().Be(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseForServiceWithInputParametersShouldBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                var guid = Guid.NewGuid();
+                var result1 = client.CachableCall(guid);
+                var result2 = client.CachableCall(guid);
+
+                result1.Should().Be(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_CachedItemShouldBeInvalidatedAfterTheCacheDurationExpires(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                var result1 = client.TwoSecondCachableCall();
+                var result2 = client.TwoSecondCachableCall();
+
+                result1.Should().Be(result2);
+
+                await Task.Delay(TimeSpan.FromSeconds(3));
+
+                var result3 = client.TwoSecondCachableCall();
+
+                result3.Should().NotBe(result1);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                var result1 = client.CachableCall();
+                var result2 = client.AnotherCachableCall();
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentEndpoints(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndServiceOne = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var clientOne = clientAndServiceOne.CreateClient<IEchoService>();
+
+                using var clientAndServiceTwo = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+                var clientTwo = clientAndServiceTwo.CreateClient<IEchoService>();
+
+                var result1 = clientOne.CachableCall();
+                var result2 = clientTwo.CachableCall();
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentInputParameters(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                var result1 = client.CachableCall(Guid.NewGuid());
+                var result2 = client.CachableCall(Guid.NewGuid());
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ClientShouldBeAbleToForceSpecificErrorResponsesToBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                clientAndService.Octopus.OverrideErrorResponseMessageCaching = (response) =>
+                {
+                    if (response.Error.Message.Contains("CACHE ME"))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                };
+
+                var client = clientAndService.CreateClient<IEchoService>();
+
+                Exception exception1 = null;
+                Exception exception2 = null;
+
+                TryCatch(() => client.CachableCallThatThrowsAnException($"UNCACHED"), e => exception1 = e);
+                TryCatch(() => client.CachableCallThatThrowsAnException($"UNCACHED"), e => exception2 = e);
+
+                exception1.Should().NotBeNull();
+                exception2.Should().NotBeNull();
+                exception1!.Message.Should().NotBe(exception2!.Message);
+
+
+                Exception exception3 = null;
+                Exception exception4 = null;
+
+                TryCatch(() => client.CachableCallThatThrowsAnException($"CACHE ME"), e => exception3 = e);
+                TryCatch(() => client.CachableCallThatThrowsAnException($"CACHE ME"), e => exception4 = e);
+
+                exception3.Should().NotBeNull();
+                exception4.Should().NotBeNull();
+                exception3!.Message.Should().Be(exception4!.Message);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ErrorResponsesShouldNotBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<IEchoService>();
+                Exception exception1 = null;
+                Exception exception2 = null;
+
+                TryCatch(() => client.CachableCallThatThrowsAnException($"Exception"), e => exception1 = e);
+                TryCatch(() => client.CachableCallThatThrowsAnException($"Exception"), e => exception2 = e);
+
+                exception1.Should().NotBeNull();
+                exception1!.Message.Should().StartWith("Exception");
+                exception2.Should().NotBeNull();
+                exception2!.Message.Should().StartWith("Exception");
+                exception1!.Message.Should().NotBe(exception2.Message);
+            }
+        }
+
+        [Test]
+        public async Task CachedResponseShouldBeInvalidated_WhenServerKnowsTheTentacleProcessRestarted()
+        {
+            var (server, tentacle, client, delegateServiceFactory, serverPort) = Setup();
+            using (server)
+            using (tentacle)
+            {
+                var result1 = client.CachableCall();
+
+                tentacle.Dispose();
+                using (var restartedTentacle = SetupTentacle(delegateServiceFactory, serverPort))
+                {
+                    var result2 = client.CachableCall();
+                    // The cache will be invalid as we haven't made a call to know the tentacle process has restarted.
+                    result1.Should().Be(result2);
+
+                    // We need to make a call to know the tentacle has restarted.
+                    // The cache will be invalid up until this point.
+                    try
+                    {
+                        client.NonCachableCall();
+                    }
+                    catch (HalibutClientException)
+                    {
+                        // Work around a known dequeue to broken pipe bug
+                        client.NonCachableCall();
+                    }
+
+                    var result3 = client.CachableCall();
+
+                    result1.Should().NotBe(result3);
+                }
+            }
+        }
+
+        static (HalibutRuntime server, HalibutRuntime tentacle, IEchoService client, DelegateServiceFactory services, int serverPort) Setup()
+        {
+            var services = new DelegateServiceFactory();
+            var service = new EchoService();
+            services.Register<IEchoService>(() => service);
+            var server = new HalibutRuntime(Certificates.Octopus);
+            server.Trust(Certificates.TentaclePollingPublicThumbprint);
+            var serverPort = server.Listen();
+
+            var tentacle = SetupTentacle(services, serverPort);
+
+            var client = server.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
+
+            return (server, tentacle,  client, services, serverPort);
+        }
+
+        static HalibutRuntime SetupTentacle(DelegateServiceFactory services, int serverPort)
+        {
+            var tentacle = new HalibutRuntime(services, Certificates.TentaclePolling);
+            tentacle.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + serverPort), Certificates.OctopusPublicThumbprint));
+            return tentacle;
+        }
+
+        static async Task<IClientAndService> CreateClientAndService(ServiceConnectionType serviceConnectionType, string halibutServiceVersion, HalibutRuntime? octopus = null, int? octopusListeningPort = null)
+        {
+            return halibutServiceVersion == null ?
+                ClientServiceBuilder
+                    .ForServiceConnectionType(serviceConnectionType)
+                    .WithService<IEchoService>(new EchoService())
+                    .WithExistingOctopus(octopus, octopusListeningPort)
+                    .Build() :
+                await ClientAndPreviousServiceVersionBuilder
+                    .ForServiceConnectionType(serviceConnectionType)
+                    .WithServiceVersion(halibutServiceVersion)
+                    .WithExistingOctopus(octopus, octopusListeningPort)
+                    .Build();
+        }
+
+        void TryCatch(Action action, Action<Exception> handleExption)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                handleExption(e);
+            }
+        }
+
+        public interface IClientEchoService
+        {
+            Guid NonCachableCall(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            [CacheResponse(600)]
+            Guid CachableCall(HalibutProxyRequestOptions halibutProxyRequestOptions);
+        }
+    }
+}

--- a/source/Halibut.Tests/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/SecureListenerFixture.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests
         PerformanceCounter GetCounterForCurrentProcess(string categoryName, string counterName)
         {
             var pid = Process.GetCurrentProcess().Id;
-            
+
             var instanceName = new PerformanceCounterCategory("Process")
                 .GetInstanceNames()
                 .FirstOrDefault(instance =>
@@ -31,10 +31,10 @@ namespace Halibut.Tests
             {
                 throw new Exception("Could not find instance name for process.");
             }
-            
+
             return new PerformanceCounter(categoryName, counterName, instanceName, true);
         }
-        
+
         [Test]
         [WindowsTest]
         public void SecureListenerDoesNotCreateHundredsOfIoEventsPerSecondOnWindows()
@@ -44,12 +44,12 @@ namespace Halibut.Tests
             using (var opsPerSec = GetCounterForCurrentProcess("Process", "IO Other Operations/sec"))
             {
                 var client = new SecureListener(
-                    new IPEndPoint(new IPAddress(new byte[]{ 127, 0, 0, 1 }), 1093), 
+                    new IPEndPoint(new IPAddress(new byte[]{ 127, 0, 0, 1 }), 0),
                     Certificates.TentacleListening,
                     null,
                     null,
                     thumbprint => true,
-                    new LogFactory(), 
+                    new LogFactory(),
                     () => ""
                 );
 
@@ -58,18 +58,18 @@ namespace Halibut.Tests
                     .Average();
 
                 float listeningAverage;
-            
+
                 using (client)
                 {
                     client.Start();
-                
+
                     listeningAverage = CollectCounterValues(opsPerSec)
                         .Take(secondsToSample)
                         .Average();
                 }
 
                 var idleAverageWithErrorMargin = idleAverage * 250f;
-            
+
                 TestContext.Out.WriteLine($"idle average:      {idleAverage} ops/second");
                 TestContext.Out.WriteLine($"listening average: {listeningAverage} ops/second");
                 TestContext.Out.WriteLine($"expectation:     < {idleAverageWithErrorMargin} ops/second");
@@ -77,11 +77,11 @@ namespace Halibut.Tests
                 listeningAverage.Should().BeLessThan(idleAverageWithErrorMargin);
             }
         }
-        
+
         IEnumerable<float> CollectCounterValues(PerformanceCounter counter)
         {
             var sleepTime = TimeSpan.FromSeconds(1);
-            
+
             while (true)
             {
                 Thread.Sleep(sleepTime);

--- a/source/Halibut.Tests/TestServices/EchoService.cs
+++ b/source/Halibut.Tests/TestServices/EchoService.cs
@@ -33,5 +33,35 @@ namespace Halibut.Tests.TestServices
             File.Delete(tempFile);
             return length;
         }
+
+        public Guid NonCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid AnotherCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall(Guid input)
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCallThatThrowsAnException(string exceptionMessage)
+        {
+            throw new Exception(exceptionMessage + " " + Guid.NewGuid());
+        }
+
+        public Guid TwoSecondCachableCall()
+        {
+            return Guid.NewGuid();
+        }
     }
 }

--- a/source/Halibut.Tests/TestServices/IEchoService.cs
+++ b/source/Halibut.Tests/TestServices/IEchoService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Halibut.Transport.Caching;
 
 namespace Halibut.Tests.TestServices
 {
@@ -11,5 +12,22 @@ namespace Halibut.Tests.TestServices
         bool Crash();
 
         int CountBytes(DataStream stream);
+
+        Guid NonCachableCall();
+
+        [CacheResponse(600)]
+        Guid CachableCall();
+
+        [CacheResponse(600)]
+        Guid AnotherCachableCall();
+
+        [CacheResponse(600)]
+        Guid CachableCall(Guid input);
+
+        [CacheResponse(600)]
+        Guid CachableCallThatThrowsAnException(string exceptionMessage);
+
+        [CacheResponse(2)]
+        Guid TwoSecondCachableCall();
     }
 }

--- a/source/Halibut.Tests/Util/IClientAndService.cs
+++ b/source/Halibut.Tests/Util/IClientAndService.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using System;
+using System.Threading;
+using Halibut.Tests.Util.TcpUtils;
+
+namespace Halibut.Tests.Util
+{
+    public interface IClientAndService : IDisposable
+    {
+        IHalibutRuntime Octopus { get; }
+        PortForwarder PortForwarder { get; }
+        TService CreateClient<TService>();
+        TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint);
+        TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken);
+        TClientService CreateClient<TService, TClientService>();
+        TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint);
+    }
+}

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -21,13 +21,13 @@ namespace Halibut.Tests
             {
                 var svc = clientAndService.CreateClient<IDoSomeActionService>();
 
-                doSomeActionService.ActionDelegate = () => clientAndService.portForwarder.Dispose();
+                doSomeActionService.ActionDelegate = () => clientAndService.PortForwarder.Dispose();
 
                 // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
                 var killPortForwarderTask = Task.Run(() => svc.Action());
-                
+
                 await Task.WhenAny(killPortForwarderTask, Task.Delay(TimeSpan.FromSeconds(10)));
-                
+
                 killPortForwarderTask.Status.Should().Be(TaskStatus.Faulted, "We should immediately get an error response.");
             }
         }

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
 
                 echo.SayHello("Bob");
 
-                (clientAndService.portForwarder as PortForwarder).PauseExistingConnections();
+                (clientAndService.PortForwarder as PortForwarder)!.PauseExistingConnections();
 
                 var sayHelloTask = Task.Run(() => echo.SayHello("Bob"));
 

--- a/source/Halibut.sln
+++ b/source/Halibut.sln
@@ -38,9 +38,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{B742FF5E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{55223D02-0CE9-4325-9A4D-5E88A544B633}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halibut.TestUtils.CompatBinary.v5_0_429", "Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj", "{66014922-3A83-42A2-8C23-D327160175C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v5_0_429", "Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj", "{66014922-3A83-42A2-8C23-D327160175C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halibut.TestUtils.CompatBinary.Base", "Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj", "{BBC31D50-5170-49D9-A42D-625768705B7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.Base", "Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj", "{BBC31D50-5170-49D9-A42D-625768705B7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v5_0_237", "Halibut.TestUtils.CompatBinary.v5_0_237\Halibut.TestUtils.CompatBinary.v5_0_237.csproj", "{1718896B-5089-462C-AD60-E189A86A12F9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -188,6 +190,18 @@ Global
 		{BBC31D50-5170-49D9-A42D-625768705B7B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{BBC31D50-5170-49D9-A42D-625768705B7B}.Release|x86.ActiveCfg = Release|Any CPU
 		{BBC31D50-5170-49D9-A42D-625768705B7B}.Release|x86.Build.0 = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|x86.Build.0 = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -33,11 +33,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
   </ItemGroup>
 

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using Halibut.Diagnostics;
+using Halibut.Transport.Caching;
 
 namespace Halibut
 {
@@ -54,5 +55,7 @@ namespace Halibut
         void SetFriendlyHtmlPageContent(string html);
         void Disconnect(ServiceEndPoint endpoint);
         Func<string, string, UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
+
+        OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
     }
 }

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -13,10 +13,12 @@ namespace Halibut.ServiceModel
     public class ServiceInvoker : IServiceInvoker
     {
         readonly IServiceFactory factory;
+        readonly Guid halibutRuntimeProcessIdentifier;
 
-        public ServiceInvoker(IServiceFactory factory)
+        public ServiceInvoker(IServiceFactory factory, Guid halibutRuntimeProcessIdentifier)
         {
             this.factory = factory;
+            this.halibutRuntimeProcessIdentifier = halibutRuntimeProcessIdentifier;
         }
 
         public ResponseMessage Invoke(RequestMessage requestMessage)
@@ -32,7 +34,8 @@ namespace Halibut.ServiceModel
                 var method = SelectMethod(methods, requestMessage);
                 var args = GetArguments(requestMessage, method);
                 var result = method.Invoke(lease.Service, args);
-                return ResponseMessage.FromResult(requestMessage, result);
+
+                return ResponseMessage.FromResult(requestMessage, result, halibutRuntimeProcessIdentifier);
             }
         }
 
@@ -103,7 +106,7 @@ namespace Halibut.ServiceModel
             throw new AmbiguousMethodMatchHalibutClientException(message.ToString(), new AmbiguousMatchException(message.ToString()));
         }
 
-        static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)
+        public static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)
         {
             var methodParams = methodInfo.GetParameters();
             var args = new object[methodParams.Length];

--- a/source/Halibut/Transport/Caching/CacheResponseAttribute.cs
+++ b/source/Halibut/Transport/Caching/CacheResponseAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Halibut.Transport.Caching
+{
+    public class CacheResponseAttribute : Attribute
+    {
+        public CacheResponseAttribute(int durationInSeconds)
+        {
+            DurationInSeconds = durationInSeconds;
+        }
+
+        public int DurationInSeconds { get; set; }
+    }
+}

--- a/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
+++ b/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Halibut.Transport.Caching
+{
+    internal class CachingKeyGenerator
+    {
+        const char LinkChar = ':';
+
+        public string GetCacheKey(MethodInfo methodInfo, object[] args, string prefix)
+        {
+            var methodArguments = args?.Any() == true
+                ? args.Select(ParameterCacheKeys.GenerateCacheKey)
+                : new[] { "0" };
+            return GenerateCacheKey(methodInfo, prefix, methodArguments);
+        }
+
+        public string GetCacheKeyPrefix(MethodInfo methodInfo, string prefix)
+        {
+            if (!string.IsNullOrWhiteSpace(prefix)) return $"{prefix}{LinkChar}";
+
+            var typeName = methodInfo.DeclaringType?.Name;
+            var methodName = methodInfo.Name;
+
+            return $"{typeName}{LinkChar}{methodName}{LinkChar}";
+        }
+
+        string GenerateCacheKey(MethodInfo methodInfo, string prefix, IEnumerable<string> parameters)
+        {
+            var cacheKeyPrefix = GetCacheKeyPrefix(methodInfo, prefix);
+
+            var builder = new StringBuilder();
+            builder.Append(cacheKeyPrefix);
+            builder.Append(string.Join(LinkChar.ToString(), parameters));
+            return builder.ToString();
+        }
+    }
+}

--- a/source/Halibut/Transport/Caching/ICachable.cs
+++ b/source/Halibut/Transport/Caching/ICachable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Halibut.Transport.Caching
+{
+    public interface ICachable
+    {
+        /// <summary>
+        /// Gets the cache key.
+        /// </summary>
+        /// <value>The cache key.</value>
+        string CacheKey { get; }
+    }
+}

--- a/source/Halibut/Transport/Caching/ParameterCacheKeys.cs
+++ b/source/Halibut/Transport/Caching/ParameterCacheKeys.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Halibut.Transport.Caching
+{
+    static class ParameterCacheKeys
+    {
+        public static string GenerateCacheKey(object parameter)
+        {
+            if (parameter == null) return string.Empty;
+            if (parameter is ICachable cachable) return cachable.CacheKey;
+            if (parameter is string key) return key;
+            if (parameter is DateTime dateTime) return dateTime.ToString("O");
+            if (parameter is DateTimeOffset dateTimeOffset) return dateTimeOffset.ToString("O");
+            if (parameter is IEnumerable enumerable) return GenerateCacheKey(enumerable.Cast<object>());
+            return parameter.ToString();
+        }
+
+        static string GenerateCacheKey(IEnumerable<object> parameter)
+        {
+            if (parameter == null) return string.Empty;
+            return "[" + string.Join(",", parameter) + "]";
+        }
+    }
+}

--- a/source/Halibut/Transport/Caching/ResponseCache.cs
+++ b/source/Halibut/Transport/Caching/ResponseCache.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Caching;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Transport.Caching
+{
+    /// <summary>
+    /// Allows the Response Caching behaviour to be modified for Error responses.
+    /// By default all errors responses are not cached.
+    /// </summary>
+    /// <param name="responseMessage">The error response message</param>
+    /// <returns>True to allow the error response message to be cached, otherwise false.</returns>
+    public delegate bool OverrideErrorResponseMessageCachingAction(ResponseMessage responseMessage);
+
+    internal class ResponseCache
+    {
+        readonly MemoryCache responseMessageCache = new("ResponseMessageCache");
+
+        public ResponseMessage GetCachedResponse(ServiceEndPoint endPoint, RequestMessage request, MethodInfo methodInfo)
+        {
+            var responseCanBeCached = CanBeCached(methodInfo);
+            if (!responseCanBeCached) return null;
+
+            var cacheKey = GetCacheKey(endPoint, methodInfo, request);
+            var wrapper = responseMessageCache.GetCacheItem(cacheKey)?.Value as CacheItemWrapper;
+
+            return wrapper?.ResponseMessage;
+
+        }
+
+        public void CacheResponse(ServiceEndPoint endPoint, RequestMessage request, MethodInfo methodInfo, ResponseMessage response, OverrideErrorResponseMessageCachingAction overrideErrorResponseMessageCachingAction)
+        {
+            var responseCanBeCached = CanBeCached(methodInfo, response, overrideErrorResponseMessageCachingAction);
+            if (!responseCanBeCached) return;
+
+            FixMissingHalibutRuntimeProcessIdentifier(response);
+
+            var cacheKey = GetCacheKey(endPoint, methodInfo, request);
+            var cacheDuration = GetCacheDuration(methodInfo);
+
+            var wrapper = new CacheItemWrapper
+            {
+                HalibutRuntimeUniqueIdentifier = response.HalibutRuntimeProcessIdentifier!.Value,
+                ResponseMessage = response,
+                EndPoint = endPoint
+            };
+            responseMessageCache.Add(cacheKey, wrapper, new CacheItemPolicy { AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(cacheDuration) });
+        }
+
+        public void InvalidateStaleCachedResponses(ServiceEndPoint endPoint, ResponseMessage response)
+        {
+            FixMissingHalibutRuntimeProcessIdentifier(response);
+
+            var cacheItems = responseMessageCache.ToList();
+
+            foreach (var item in cacheItems)
+            {
+                var wrapper = item.Value as CacheItemWrapper;
+
+                if (wrapper.EndPoint == endPoint && wrapper.HalibutRuntimeUniqueIdentifier != response.HalibutRuntimeProcessIdentifier)
+                {
+                    responseMessageCache.Remove(item.Key);
+                }
+            }
+        }
+
+        bool CanBeCached(MethodInfo methodInfo)
+        {
+            return methodInfo.GetCustomAttribute<CacheResponseAttribute>() != null;
+        }
+
+        bool CanBeCached(MethodInfo methodInfo, ResponseMessage response, OverrideErrorResponseMessageCachingAction overrideErrorResponseMessageCachingAction)
+        {
+            if (!CanBeCached(methodInfo))
+            {
+                return false;
+            }
+
+            if (response.Error != null)
+            {
+                var overrideCacheResult = overrideErrorResponseMessageCachingAction?.Invoke(response);
+
+                return overrideCacheResult ?? false;
+            }
+
+            return true;
+        }
+
+        void FixMissingHalibutRuntimeProcessIdentifier(ResponseMessage response)
+        {
+            // Halibut prior to caching being added will return null for HalibutRuntimeProcessIdentifier
+            response.HalibutRuntimeProcessIdentifier ??= Guid.Empty;
+        }
+
+        int GetCacheDuration(MethodInfo methodInfo)
+        {
+            var cacheAttribute = methodInfo.GetCustomAttribute<CacheResponseAttribute>();
+
+            return cacheAttribute?.DurationInSeconds ?? 0;
+        }
+
+        string GetCacheKey(ServiceEndPoint endpoint, MethodInfo methodInfo, RequestMessage request)
+        {
+            var arguments = ServiceInvoker.GetArguments(request, methodInfo);
+            var cacheKey = new CachingKeyGenerator().GetCacheKey(methodInfo, arguments, null);
+
+            return $"{endpoint.BaseUri.AbsoluteUri}:{cacheKey}";
+        }
+
+        class CacheItemWrapper
+        {
+            public ServiceEndPoint EndPoint { get; set; }
+            public Guid HalibutRuntimeUniqueIdentifier { get; set; }
+            public ResponseMessage ResponseMessage { get; set; }
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -15,29 +15,61 @@ namespace Halibut.Transport.Protocol
         [JsonProperty("result")]
         public object Result { get; set; }
 
-        public static ResponseMessage FromResult(RequestMessage request, object result)
+        [JsonProperty("halibutRuntimeProcessIdentifier")]
+        public Guid? HalibutRuntimeProcessIdentifier { get; set; }
+
+        public static ResponseMessage FromResult(RequestMessage request, object result, Guid halibutRuntimeProcessIdentifier)
         {
-            return new ResponseMessage { Id = request.Id, Result = result };
+            return new ResponseMessage
+            {
+                Id = request.Id,
+                Result = result,
+                HalibutRuntimeProcessIdentifier = halibutRuntimeProcessIdentifier
+            };
         }
 
-        public static ResponseMessage FromError(RequestMessage request, string message)
+        public static ResponseMessage FromError(RequestMessage request, string message, Guid halibutRuntimeProcessIdentifier)
         {
-            return new ResponseMessage { Id = request.Id, Error = new ServerError { Message = message } };
+            return new ResponseMessage
+            {
+                Id = request.Id,
+                Error = new ServerError
+                {
+                    Message = message
+                },
+                HalibutRuntimeProcessIdentifier = halibutRuntimeProcessIdentifier
+            };
         }
 
         public static ResponseMessage FromException(RequestMessage request, Exception ex)
         {
-            return new ResponseMessage {Id = request.Id, Error = ServerErrorFromException(ex)};
+            return FromException(request, ex, null);
+        }
+
+        public static ResponseMessage FromException(RequestMessage request, Exception ex, Guid? halibutRuntimeProcessIdentifier)
+        {
+            return new ResponseMessage
+            {
+                Id = request.Id,
+                Error = ServerErrorFromException(ex),
+                HalibutRuntimeProcessIdentifier = halibutRuntimeProcessIdentifier
+            };
         }
 
         internal static ServerError ServerErrorFromException(Exception ex)
         {
-            string ErrorType = null;
+            string errorType = null;
             if (ex is HalibutClientException)
             {
-                ErrorType = ex.GetType().FullName;
+                errorType = ex.GetType().FullName;
             }
-            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), HalibutErrorType = ErrorType };
+
+            return new ServerError
+            {
+                Message = ex.UnpackFromContainers().Message,
+                Details = ex.ToString(),
+                HalibutErrorType = errorType
+            };
         }
     }
 }


### PR DESCRIPTION
# Background

This PR allows a Halibut client to cache responses from the Service for selected RPC calls.

The interface used by the client can have an attribute applied that instructs Halibut to cache the response from the service for the specified duration in seconds.

```
public interface IMyService
{
    [CacheResponse(600)]
    Guid CachableCall();
}
```

The responses are cached in a `System.Runtime.Caching.MemoryCache`

By default, only non-error responses are cached.

## Cache Invalidation

A best effort is made to invalidate the cache when it is deemed stale for an endpoint. This is defined as the endpoint process restarting and is designed to take into account the endpoint being upgraded or downgraded, which could mean the response is invalid.

At least one service call that is either not cached or is cached but is a cache miss must be made for the cache mechanism to determine that the process running Halibut for an endpoint has restarted since items were cached. 

## Caching Error Responses

It is possible to cache an error response by overriding the cache behaviour on an error-by-error basis. This allows for scenarios such as caching the error response when a `NoMatchingServiceOrMethodHalibutClientException` exception is thrown.

```
IHalibutRuntime halibut = ....;
halibut.OverrideErrorResponseMessageCaching = (response) =>
{
    if (response.Error.Message.Contains("CACHE ME"))
    {
        return true;
    }

    return false;
};
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
