### PR TITLE
Reduce the O(n) of invalidating a cache

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -9,7 +9,7 @@
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Halibut/Transport/Caching/TypedMemoryCache.cs
+++ b/source/Halibut/Transport/Caching/TypedMemoryCache.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Caching;
+
+namespace Halibut.Transport.Caching
+{
+    public class TypedMemoryCache<K, V> where K: class where V : class
+    {
+        MemoryCache memoryCache;
+        Func<K, string> toKeyFunction;
+
+        public TypedMemoryCache(string name, Func<K, string> toKeyFunction)
+        {
+            this.toKeyFunction = toKeyFunction;
+            memoryCache = new MemoryCache(name);
+        }
+
+        public V GetCacheItem(K cacheKey)
+        {
+            return memoryCache.GetCacheItem(toKeyFunction(cacheKey))?.Value as V;
+        }
+
+        public void Add(K cacheKey, V wrapper, CacheItemPolicy cacheItemPolicy)
+        {
+            memoryCache.Add(toKeyFunction(cacheKey), wrapper, cacheItemPolicy);
+        }
+
+        public V GetOrAddNotAtomic(K cacheKey, V valueIfOneDoesNotAlreadyExist, CacheItemPolicy policy)
+        {
+            var current = GetCacheItem(cacheKey);
+            if (current != null) return current;
+            Add(cacheKey, valueIfOneDoesNotAlreadyExist, policy);
+            return GetCacheItem(cacheKey);
+        }
+
+        public void RemoveMatching(Func<V, bool> removeIfMatches)
+        {
+            var cacheItems = memoryCache.ToList();
+
+            foreach (var item in cacheItems)
+            {
+                var wrapper = item.Value as V;
+
+                if (removeIfMatches(wrapper))
+                {
+                    memoryCache.Remove(item.Key);
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut/Transport/Caching/TypedMemoryCache.cs
+++ b/source/Halibut/Transport/Caching/TypedMemoryCache.cs
@@ -26,12 +26,12 @@ namespace Halibut.Transport.Caching
             }
 
             value = (V) cacheItem.Value;
-            return false;
+            return true;
         }
 
         internal void Add(K cacheKey, V wrapper, CacheItemPolicy cacheItemPolicy)
         {
-            memoryCache.Add(toKeyFunction(cacheKey), wrapper, cacheItemPolicy);
+            memoryCache.Set(toKeyFunction(cacheKey), wrapper, cacheItemPolicy);
         }
 
         internal V GetOrAddNotAtomic(K cacheKey, V valueIfOneDoesNotAlreadyExist, CacheItemPolicy policy)

--- a/source/Halibut/Transport/Caching/TypedMemoryCache.cs
+++ b/source/Halibut/Transport/Caching/TypedMemoryCache.cs
@@ -1,52 +1,45 @@
+#nullable enable
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Caching;
 
 namespace Halibut.Transport.Caching
 {
-    public class TypedMemoryCache<K, V> where K: class where V : class
+    internal class TypedMemoryCache<K, V> where K : class
     {
-        MemoryCache memoryCache;
-        Func<K, string> toKeyFunction;
+        readonly MemoryCache memoryCache;
+        readonly Func<K, string> toKeyFunction;
 
-        public TypedMemoryCache(string name, Func<K, string> toKeyFunction)
+        internal TypedMemoryCache(string name, Func<K, string> toKeyFunction)
         {
             this.toKeyFunction = toKeyFunction;
             memoryCache = new MemoryCache(name);
         }
 
-        public V GetCacheItem(K cacheKey)
+        internal bool TryGetCacheItem(K cacheKey, out V? value)
         {
-            return memoryCache.GetCacheItem(toKeyFunction(cacheKey))?.Value as V;
+            var cacheItem = memoryCache.GetCacheItem(toKeyFunction(cacheKey));
+            if (cacheItem == null)
+            {
+                value = default;
+                return false;
+            }
+
+            value = (V) cacheItem.Value;
+            return false;
         }
 
-        public void Add(K cacheKey, V wrapper, CacheItemPolicy cacheItemPolicy)
+        internal void Add(K cacheKey, V wrapper, CacheItemPolicy cacheItemPolicy)
         {
             memoryCache.Add(toKeyFunction(cacheKey), wrapper, cacheItemPolicy);
         }
 
-        public V GetOrAddNotAtomic(K cacheKey, V valueIfOneDoesNotAlreadyExist, CacheItemPolicy policy)
+        internal V GetOrAddNotAtomic(K cacheKey, V valueIfOneDoesNotAlreadyExist, CacheItemPolicy policy)
         {
-            var current = GetCacheItem(cacheKey);
+            if (TryGetCacheItem(cacheKey, out var current)) return current!;
             if (current != null) return current;
             Add(cacheKey, valueIfOneDoesNotAlreadyExist, policy);
-            return GetCacheItem(cacheKey);
-        }
-
-        public void RemoveMatching(Func<V, bool> removeIfMatches)
-        {
-            var cacheItems = memoryCache.ToList();
-
-            foreach (var item in cacheItems)
-            {
-                var wrapper = item.Value as V;
-
-                if (removeIfMatches(wrapper))
-                {
-                    memoryCache.Remove(item.Key);
-                }
-            }
+            return valueIfOneDoesNotAlreadyExist;
         }
     }
 }


### PR DESCRIPTION
# Background

When invalidating the cache, don't scan every single endpoint instead only scan within the endpoint we just talked to.

If we don't do this, then we would be doing a O(n) operation on every call, which would be expensive relative to the tens of milliseconds this aims to save.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
