### PR TITLE
Support Microsoft Changes from KB5025823 around X509Certificate / X509Certificate2

### DIFF
--- a/source/Halibut/Transport/ClientCertificateValidator.cs
+++ b/source/Halibut/Transport/ClientCertificateValidator.cs
@@ -15,7 +15,7 @@ namespace Halibut.Transport
 
         public bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
         {
-            var providedCert = new X509Certificate2(certificate.Export(X509ContentType.Cert)); // Copy the cert so that we can reference it later
+            var providedCert = new X509Certificate2(certificate.Export(X509ContentType.Cert), (string)null!); // Copy the cert so that we can reference it later
             var providedThumbprint = providedCert.Thumbprint;
 
             if (providedThumbprint == endPoint.RemoteThumbprint)

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -37,7 +37,7 @@ namespace Halibut.Transport
                                 throw new Exception("The server did not provide an SSL certificate");
 
 #pragma warning disable PC001 // API not supported on all platforms - X509Certificate2 not supported on macOS
-                            return new ServiceEndPoint(serviceEndpoint.BaseUri, new X509Certificate2(ssl.RemoteCertificate.Export(X509ContentType.Cert)).Thumbprint);
+                            return new ServiceEndPoint(serviceEndpoint.BaseUri, new X509Certificate2(ssl.RemoteCertificate.Export(X509ContentType.Cert), (string)null!).Thumbprint);
 #pragma warning restore PC001 // API not supported on all platforms - X509Certificate2 not supported on macOS
                         }
                     }

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -328,7 +328,7 @@ namespace Halibut.Transport
                 return null;
             }
 
-            var thumbprint = new X509Certificate2(stream.RemoteCertificate.Export(X509ContentType.Cert)).Thumbprint;
+            var thumbprint = new X509Certificate2(stream.RemoteCertificate.Export(X509ContentType.Cert), (string)null!).Thumbprint;
             return thumbprint;
         }
 

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -199,7 +199,7 @@ namespace Halibut.Transport
                 return false;
             }
 
-            var thumbprint = new X509Certificate2(certificate.Export(X509ContentType.Cert)).Thumbprint;
+            var thumbprint = new X509Certificate2(certificate.Export(X509ContentType.Cert), (string)null!).Thumbprint;
             var isAuthorized = verifyClientThumbprint(thumbprint);
 
             if (!isAuthorized)

--- a/source/Halibut/Transport/ServerCertificateInterceptor.cs
+++ b/source/Halibut/Transport/ServerCertificateInterceptor.cs
@@ -38,7 +38,7 @@ namespace Halibut.Transport
                     {
                         if (certificates.ContainsKey(clientId))
                         {
-                            var providedCert = new X509Certificate2(certificate.Export(X509ContentType.Cert)); // Copy the cert so that we can reference it later
+                            var providedCert = new X509Certificate2(certificate.Export(X509ContentType.Cert), (string)null!); // Copy the cert so that we can reference it later
                             certificates[clientId] = providedCert;
                             return true;
                         }


### PR DESCRIPTION
# Background

Microsoft published a [security update](https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b) on 13th June 2023 regarding how .NET applications import x509 certificates.

This PR updates Halibut to support these changes.

# Results

Previously, a CryptographicException may have been thrown when initializing Halibut connections when running the affected version of the .NET runtime.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
