### PR TITLE
Use client service builder in more tests

### DIFF
--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = ClientServiceBuilder.Listening()
                        .NoService()
-                       .WithService(new EchoService())
+                       .WithService<IEchoService>(() => new EchoService())
                        .Build())
             {
                 var data = new byte[1024 * 1024 + 15];
@@ -43,7 +43,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = ClientServiceBuilder.Listening()
                        .NoService()
-                       .WithService(new AmNotAllowed())
+                       .WithService<IAmNotAllowed>(() => new AmNotAllowed())
                        .Build())
             {
                 Assert.Throws<TypeNotAllowedException>(() => clientAndService.CreateClient<IAmNotAllowed>());

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -50,7 +50,7 @@ namespace Halibut.Tests.Diagnostics
                 DoSomeActionService doSomeActionService = new DoSomeActionService();
                 services.Register<IDoSomeActionService>(() => doSomeActionService);
                 
-                using (var clientAndService = ClientServiceBuilder.Listening().WithServiceFactory(services).WithPortForwarding().Build())
+                using (var clientAndService = ClientServiceBuilder.Polling().WithServiceFactory(services).WithPortForwarding().Build())
                 {
                     var svc = clientAndService.CreateClient<IDoSomeActionService>();
 

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -49,26 +49,18 @@ namespace Halibut.Tests.Diagnostics
                 var services = new DelegateServiceFactory();
                 DoSomeActionService doSomeActionService = new DoSomeActionService();
                 services.Register<IDoSomeActionService>(() => doSomeActionService);
-                using (var octopus = new HalibutRuntime(Certificates.Octopus))
+                
+                using (var clientAndService = ClientServiceBuilder.Listening().WithServiceFactory(services).WithPortForwarding().Build())
                 {
-                    var octopusPort = octopus.Listen();
-                    using (var portForwarder = PortForwarderUtil.ForwardingToLocalPort(octopusPort).Build())
-                    using (var tentaclePolling = new HalibutRuntime(services, Certificates.TentaclePolling))
-                    {
-                        octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
+                    var svc = clientAndService.CreateClient<IDoSomeActionService>();
 
-                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port), Certificates.OctopusPublicThumbprint));
+                    doSomeActionService.ActionDelegate = () => clientAndService.portForwarder.Dispose();
 
-                        var svc = octopus.CreateClient<IDoSomeActionService>("poll://SQ-TENTAPOLL", Certificates.TentaclePollingPublicThumbprint);
-
-                        doSomeActionService.ActionDelegate = () => portForwarder.Dispose();
-
-                        // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
-                        Assert.Throws<HalibutClientException>(() => svc.Action())
-                            .IsNetworkError()
-                            .Should()
-                            .Be(HalibutNetworkExceptionType.UnknownError, "Since currently we get a message envelope is null message");
-                    }
+                    // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
+                    Assert.Throws<HalibutClientException>(() => svc.Action())
+                        .IsNetworkError()
+                        .Should()
+                        .Be(HalibutNetworkExceptionType.UnknownError, "Since currently we get a message envelope is null message");
                 }
             }
 

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -57,8 +57,9 @@ namespace Halibut.Tests.Diagnostics
                     doSomeActionService.ActionDelegate = () => clientAndService.portForwarder.Dispose();
 
                     // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
-                    Assert.Throws<HalibutClientException>(() => svc.Action())
-                        .IsNetworkError()
+                    var exception = Assert.Throws<HalibutClientException>(() => svc.Action());
+                    new SerilogLoggerBuilder().Build().Information(exception, "Got an exception, we were expecting one");
+                    exception.IsNetworkError()
                         .Should()
                         .Be(HalibutNetworkExceptionType.UnknownError, "Since currently we get a message envelope is null message");
                 }

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using FluentAssertions;
 using Halibut.ServiceModel;
 using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
@@ -18,13 +19,9 @@ namespace Halibut.Tests
             var services = new DelegateServiceFactory();
             services.Register<IReadDataSteamService>(() => new ReadDataStreamService());
             
-            using (var octopus = new HalibutRuntime(Certificates.Octopus))
-            using (var tentacleListening = new HalibutRuntime(services, Certificates.TentacleListening))
+            using (var clientAndService = ClientServiceBuilder.Listening().WithServiceFactory(services).Build())
             {
-                var tentaclePort = tentacleListening.Listen();
-                tentacleListening.Trust(Certificates.OctopusPublicThumbprint);
-
-                var readDataSteamService = octopus.CreateClient<IReadDataSteamService>("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint);
+                var readDataSteamService = clientAndService.CreateClient<IReadDataSteamService>();
 
                 var dataStreams = CreateDataStreams();
 

--- a/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
+++ b/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
@@ -19,14 +19,12 @@ namespace Halibut.Tests
             var started = DateTime.UtcNow;
             var calls = new List<DateTime>();
 
-            var (server, tentacle, portForwarder, _, doSomeActionService) = SetupPollingServerAndTentacle(() =>
+            var (clientAndService, _, doSomeActionService) = SetupPollingServerAndTentacle(() =>
             {
                 calls.Add(DateTime.UtcNow);
             });
-
-            using (server)
-            using (tentacle)
-            using (portForwarder)
+            
+            using (clientAndService)
             {
                 doSomeActionService.Action();
             }
@@ -41,18 +39,16 @@ namespace Halibut.Tests
             var started = DateTime.UtcNow;
             var calls = new List<DateTime>();
 
-            var (server, tentacle, portForwarder, _, doSomeActionService) = SetupPollingServerAndTentacle(() =>
+            var (clientAndService, _, doSomeActionService) = SetupPollingServerAndTentacle(() =>
             {
                 calls.Add(DateTime.UtcNow);
             });
-
-            using (server)
-            using (tentacle)
-            using (portForwarder)
+            
+            using (clientAndService)
             {
                 doSomeActionService.Action();
 
-                portForwarder.CloseExistingConnections();
+                clientAndService.portForwarder.CloseExistingConnections();
 
                 // First Reconnect
                 try
@@ -65,7 +61,7 @@ namespace Halibut.Tests
                     doSomeActionService.Action();
                 }
 
-                portForwarder.CloseExistingConnections();
+                clientAndService.portForwarder.CloseExistingConnections();
 
                 // Second Reconnect
                 try
@@ -90,65 +86,23 @@ namespace Halibut.Tests
             secondReconnect.Should().BeOnOrAfter(firstReconnect).And.BeCloseTo(firstReconnect, TimeSpan.FromSeconds(8));
         }
 
-        (HalibutRuntime server,
-            IHalibutRuntime tentacle,
-            PortForwarder portForwarder,
+        (ClientServiceBuilder.ClientAndService,
             IEchoService echoService,
             IDoSomeActionService doSomeActionService)
             SetupPollingServerAndTentacle(Action doSomeActionServiceAction)
         {
-            var server = SetupServer();
-            var portForwarder = SetupPortForwarder(server);
-            var serverUri = new Uri("https://localhost:" + portForwarder.PublicEndpoint.Port);
-            var tentacle = SetupPollingTentacle(serverUri, "poll://SQ-TENTAPOLL", doSomeActionServiceAction);
-            var (echoService, doSomeActionService) = SetupServices(server, "poll://SQ-TENTAPOLL");
+            var clientAndService = ClientServiceBuilder.Polling().WithPortForwarding()
+                .WithService<IDoSomeActionService>(() => new DoSomeActionService(doSomeActionServiceAction))
+                .WithService<IEchoService>(() => new EchoService())
+                .Build();
+            
+            
+            var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService>();
+            var echoService = clientAndService.CreateClient<IEchoService>();
+            
             EnsureTentacleIsConnected(echoService);
 
-            return (server, tentacle, portForwarder, echoService, doSomeActionService);
-        }
-
-        static HalibutRuntime SetupPollingTentacle(Uri url, string pollingEndpoint, Action doSomeServiceAction)
-        {
-            var services = new DelegateServiceFactory();
-            var doSomeActionService = new DoSomeActionService(doSomeServiceAction);
-
-            services.Register<IDoSomeActionService>(() => doSomeActionService);
-            services.Register<IEchoService>(() => new EchoService());
-
-            var pollingTentacle = new HalibutRuntimeBuilder()
-                .WithServiceFactory(services)
-                .WithServerCertificate(Certificates.TentaclePolling)
-                .Build();
-
-            pollingTentacle.Poll(new Uri(pollingEndpoint), new ServiceEndPoint(url, Certificates.OctopusPublicThumbprint));
-
-            return pollingTentacle;
-        }
-
-        static PortForwarder SetupPortForwarder(IHalibutRuntime halibut)
-        {
-            var octopusPort = halibut.Listen();
-            var portForwarder = PortForwarderUtil.ForwardingToLocalPort(octopusPort).Build();
-
-            return portForwarder;
-        }
-
-        static HalibutRuntime SetupServer()
-        {
-            var octopus = new HalibutRuntimeBuilder()
-                .WithServerCertificate(Certificates.Octopus)
-                .Build();
-
-            octopus.Trust(Certificates.TentaclePollingPublicThumbprint);
-
-            return octopus;
-        }
-
-        static (IEchoService scriptService, IDoSomeActionService doSomeActionService) SetupServices(HalibutRuntime octopus, string endpoint)
-        {
-            var doSomeActionService = octopus.CreateClient<IDoSomeActionService>(endpoint, Certificates.TentaclePollingPublicThumbprint);
-            var scriptService = octopus.CreateClient<IEchoService>(endpoint, Certificates.TentaclePollingPublicThumbprint);
-            return (scriptService, doSomeActionService);
+            return (clientAndService, echoService, doSomeActionService);
         }
 
         static void EnsureTentacleIsConnected(IEchoService echoService)

--- a/source/Halibut.Tests/Util/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Util/ClientServiceBuilder.cs
@@ -50,11 +50,6 @@ namespace Halibut.Tests.Util
             return this;
         }
 
-        public ClientServiceBuilder WithService<TContract>(TContract implementation)
-        {
-            return WithService(() => implementation);
-        }
-
         public ClientServiceBuilder WithService<TContract>(Func<TContract> implementation)
         {
             if (serviceFactory == null) serviceFactory = new DelegateServiceFactory();
@@ -124,10 +119,10 @@ namespace Halibut.Tests.Util
 
         public class ClientAndService : IDisposable
         {
-            readonly HalibutRuntime octopus;
-            readonly HalibutRuntime? tentacle;
+            public HalibutRuntime Octopus { get; }
+            public HalibutRuntime? Tentacle { get; }
             public readonly PortForwarder? portForwarder;
-            readonly Uri serviceUri;
+            public Uri ServiceUri { get; }
             readonly CertAndThumbprint serviceCertAndThumbprint; // for creating a client
             readonly DisposableCollection disposableCollection;
 
@@ -137,9 +132,9 @@ namespace Halibut.Tests.Util
                 CertAndThumbprint serviceCertAndThumbprint,
                 PortForwarder? portForwarder, DisposableCollection disposableCollection)
             {
-                this.octopus = octopus;
-                this.tentacle = tentacle;
-                this.serviceUri = serviceUri;
+                this.Octopus = octopus;
+                this.Tentacle = tentacle;
+                this.ServiceUri = serviceUri;
                 this.serviceCertAndThumbprint = serviceCertAndThumbprint;
                 this.portForwarder = portForwarder;
                 this.disposableCollection = disposableCollection;
@@ -157,22 +152,22 @@ namespace Halibut.Tests.Util
 
             public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
             {
-                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                var serviceEndpoint = new ServiceEndPoint(ServiceUri, serviceCertAndThumbprint.Thumbprint);
                 modifyServiceEndpoint(serviceEndpoint);
-                return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
+                return Octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
             }
             
             public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
-                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                var serviceEndpoint = new ServiceEndPoint(ServiceUri, serviceCertAndThumbprint.Thumbprint);
                 modifyServiceEndpoint(serviceEndpoint);
-                return octopus.CreateClient<TService, TClientService>(serviceEndpoint);
+                return Octopus.CreateClient<TService, TClientService>(serviceEndpoint);
             }
 
             public void Dispose()
             {
-                octopus.Dispose();
-                tentacle?.Dispose();
+                Octopus.Dispose();
+                Tentacle?.Dispose();
                 portForwarder?.Dispose();
                 disposableCollection.Dispose();
             }

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -15,7 +15,7 @@ namespace Halibut.Tests
         {
             DoSomeActionService doSomeActionService = new DoSomeActionService();
             using (var clientAndService = ClientServiceBuilder.Polling()
-                       .WithService<IDoSomeActionService>(doSomeActionService)
+                       .WithService<IDoSomeActionService>(() => doSomeActionService)
                        .WithPortForwarding()
                        .Build())
             {

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests
         public async Task HalibutCanRecoverFromIdleTcpDisconnect2()
         {
             using (var clientAndService = ClientServiceBuilder.Listening()
-                       .WithService<IEchoService>(new EchoService())
+                       .WithService<IEchoService>(() => new EchoService())
                        .WithPortForwarding()
                        .Build())
             {


### PR DESCRIPTION
# Background

Updates more tests to make use of the `ClientServiceBuilder` removing the boiler plate around setting up listening/polling halibut communications.

Doing so will make expanding test coverage by making it possible to for a single test:
- vary the type of comms e.g. Polling/Listening
- vary network conditions e.g. add latency
- to be in a form that will be easier to add backwards compatibility testing to later on.


Also removes a slight trap from the `ClientServiceBuilder`
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
