### PR TITLE
Simulate a network in which the last n bytes arrive late.

### DIFF
--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -236,7 +236,7 @@ namespace Halibut.Tests
                        .WithServiceFactory(GetDelegateServiceFactory())
                        .WithPortForwarding(octopusPort => PortForwarderUtil.ForwardingToLocalPort(octopusPort)
                            .WithSendDelay(TimeSpan.FromMilliseconds(20))
-                           .WithDelaySendingLastNBytes(numberOfBytesToDelaySending)
+                           .WithNumberOfBytesToDelaySending(numberOfBytesToDelaySending)
                            .Build())
                        .Build())
             {

--- a/source/Halibut.Tests/Util/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests/Util/TestContextConnectionLog.cs
@@ -37,8 +37,10 @@ namespace Halibut.Tests.Util
         void WriteInternal(LogEvent logEvent)
         {
             var logLevel = GetLogLevel(logEvent);
-
-            TestContext.WriteLine(string.Format("{6} {5, 16}: {0}:{1} {2}  {3} {4}", logLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name, DateTime.UtcNow.ToString("o")));
+            
+            new SerilogLoggerBuilder().Build()
+                .ForContext<TestContextConnectionLog>()
+                .Information(string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name));
         }
 
         static LogLevel GetLogLevel(LogEvent logEvent)

--- a/source/Octopus.TestPortForwarder/PortForwarder.cs
+++ b/source/Octopus.TestPortForwarder/PortForwarder.cs
@@ -17,7 +17,7 @@ namespace Octopus.TestPortForwarder
         readonly List<TcpPump> pumps = new();
         readonly ILogger logger;
         readonly TimeSpan sendDelay;
-        readonly int delaySendingLastNBytes;
+        readonly int numberOfBytesToDelaySending;
         Func<BiDirectionalDataTransferObserver> factory;
         bool active = false;
 
@@ -26,7 +26,7 @@ namespace Octopus.TestPortForwarder
         public PortForwarder(Uri originServer,
             TimeSpan sendDelay,
             Func<BiDirectionalDataTransferObserver> factory,
-            int delaySendingLastNBytes,
+            int numberOfBytesToDelaySending,
             ILogger logger,
             int? listeningPort = null)
         {
@@ -35,7 +35,7 @@ namespace Octopus.TestPortForwarder
             this.sendDelay = sendDelay;
             this.factory = factory;
             this.logger = logger;
-            this.delaySendingLastNBytes = delaySendingLastNBytes;
+            this.numberOfBytesToDelaySending = numberOfBytesToDelaySending;
             var scheme = originServer.Scheme;
 
             Start();
@@ -117,7 +117,7 @@ namespace Octopus.TestPortForwarder
                         var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
                         var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
-                        var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay, factory, delaySendingLastNBytes, logger);
+                        var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay, factory, numberOfBytesToDelaySending, logger);
                         AddNewPump(pump, cancellationToken);
                     }
                     catch (SocketException ex)

--- a/source/Octopus.TestPortForwarder/PortForwarder.cs
+++ b/source/Octopus.TestPortForwarder/PortForwarder.cs
@@ -17,6 +17,7 @@ namespace Octopus.TestPortForwarder
         readonly List<TcpPump> pumps = new();
         readonly ILogger logger;
         readonly TimeSpan sendDelay;
+        readonly int delaySendingLastNBytes;
         Func<BiDirectionalDataTransferObserver> factory;
         bool active = false;
 
@@ -25,6 +26,7 @@ namespace Octopus.TestPortForwarder
         public PortForwarder(Uri originServer,
             TimeSpan sendDelay,
             Func<BiDirectionalDataTransferObserver> factory,
+            int delaySendingLastNBytes,
             ILogger logger,
             int? listeningPort = null)
         {
@@ -33,6 +35,7 @@ namespace Octopus.TestPortForwarder
             this.sendDelay = sendDelay;
             this.factory = factory;
             this.logger = logger;
+            this.delaySendingLastNBytes = delaySendingLastNBytes;
             var scheme = originServer.Scheme;
 
             Start();
@@ -114,7 +117,7 @@ namespace Octopus.TestPortForwarder
                         var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
                         var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
-                        var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay, factory, logger);
+                        var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay, factory, delaySendingLastNBytes, logger);
                         AddNewPump(pump, cancellationToken);
                     }
                     catch (SocketException ex)

--- a/source/Octopus.TestPortForwarder/PortForwarderBuilder.cs
+++ b/source/Octopus.TestPortForwarder/PortForwarderBuilder.cs
@@ -11,7 +11,7 @@ namespace Octopus.TestPortForwarder
         TimeSpan sendDelay = TimeSpan.Zero;
         readonly List<Func<BiDirectionalDataTransferObserver>> observerFactory = new();
         int? listeningPort;
-        int delaySendingLastNBytes = 0;
+        int numberOfBytesToDelaySending = 0;
         readonly ILogger logger;
 
         public PortForwarderBuilder(Uri originServer, ILogger logger)
@@ -50,7 +50,7 @@ namespace Octopus.TestPortForwarder
 
         public PortForwarderBuilder WithDelaySendingLastNBytes(int numberOfBytesToDelaySending)
         {
-            this.delaySendingLastNBytes = numberOfBytesToDelaySending;
+            this.numberOfBytesToDelaySending = numberOfBytesToDelaySending;
             return this;
         }
 
@@ -61,7 +61,7 @@ namespace Octopus.TestPortForwarder
                     var results = observerFactory.Select(factory => factory()).ToArray();
                     return BiDirectionalDataTransferObserver.Combiner(results);
                 },
-                delaySendingLastNBytes,
+                numberOfBytesToDelaySending,
                 logger,
                 listeningPort);
         }

--- a/source/Octopus.TestPortForwarder/PortForwarderBuilder.cs
+++ b/source/Octopus.TestPortForwarder/PortForwarderBuilder.cs
@@ -11,6 +11,7 @@ namespace Octopus.TestPortForwarder
         TimeSpan sendDelay = TimeSpan.Zero;
         readonly List<Func<BiDirectionalDataTransferObserver>> observerFactory = new();
         int? listeningPort;
+        int delaySendingLastNBytes = 0;
         readonly ILogger logger;
 
         public PortForwarderBuilder(Uri originServer, ILogger logger)
@@ -36,9 +37,20 @@ namespace Octopus.TestPortForwarder
             return this;
         }
 
+        /// <summary>
+        /// If possible avoid using this as it may not be possible to bind to the given port.
+        /// </summary>
+        /// <param name="listeningPort"></param>
+        /// <returns></returns>
         public PortForwarderBuilder ListenOnPort(int? listeningPort)
         {
             this.listeningPort = listeningPort;
+            return this;
+        }
+
+        public PortForwarderBuilder WithDelaySendingLastNBytes(int numberOfBytesToDelaySending)
+        {
+            this.delaySendingLastNBytes = numberOfBytesToDelaySending;
             return this;
         }
 
@@ -49,6 +61,7 @@ namespace Octopus.TestPortForwarder
                     var results = observerFactory.Select(factory => factory()).ToArray();
                     return BiDirectionalDataTransferObserver.Combiner(results);
                 },
+                delaySendingLastNBytes,
                 logger,
                 listeningPort);
         }

--- a/source/Octopus.TestPortForwarder/PortForwarderBuilder.cs
+++ b/source/Octopus.TestPortForwarder/PortForwarderBuilder.cs
@@ -48,7 +48,7 @@ namespace Octopus.TestPortForwarder
             return this;
         }
 
-        public PortForwarderBuilder WithDelaySendingLastNBytes(int numberOfBytesToDelaySending)
+        public PortForwarderBuilder WithNumberOfBytesToDelaySending(int numberOfBytesToDelaySending)
         {
             this.numberOfBytesToDelaySending = numberOfBytesToDelaySending;
             return this;

--- a/source/Octopus.TestPortForwarder/SocketPump.cs
+++ b/source/Octopus.TestPortForwarder/SocketPump.cs
@@ -92,15 +92,14 @@ namespace Octopus.TestPortForwarder
             }
         }
         
-        async Task WriteToSocketDelayingSendingTheLastNBytes(Socket writeTo, byte[] buffer, int bufferLength, int delaySendingLastNBytes, CancellationToken cancellationToken)
+        static async Task WriteToSocketDelayingSendingTheLastNBytes(Socket writeTo, byte[] buffer, int bufferLength, int delaySendingLastNBytes, CancellationToken cancellationToken)
         {
-            int howMuchToSend = bufferLength - delaySendingLastNBytes;
+            var howMuchToSend = bufferLength - delaySendingLastNBytes;
             if(howMuchToSend < 0) howMuchToSend = bufferLength;
-            int sent = await WriteToSocket(writeTo, buffer, 0, howMuchToSend, cancellationToken);
+            var sent = await WriteToSocket(writeTo, buffer, 0, howMuchToSend, cancellationToken);
             if (howMuchToSend < bufferLength)
             {
                 await Task.Delay(10);
-                int restToSend = bufferLength - howMuchToSend;
                 sent += await WriteToSocket(writeTo, buffer, howMuchToSend, bufferLength - howMuchToSend, cancellationToken);
             }
             if (sent != bufferLength)
@@ -111,14 +110,14 @@ namespace Octopus.TestPortForwarder
         
         static async Task<int> WriteToSocket(Socket writeTo, byte[] buffer, int initialOffset, int totalBytesToSend, CancellationToken cancellationToken)
         {
-            ArraySegment<byte> toSend = new ArraySegment<byte>(buffer, initialOffset, totalBytesToSend);
+            var toSend = new ArraySegment<byte>(buffer, initialOffset, totalBytesToSend);
 
-            int offset = 0;
+            var offset = 0;
             while (totalBytesToSend - offset > 0)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                ArraySegment<byte> outputBuffer = toSend.Slice(offset, totalBytesToSend - offset);
+                var outputBuffer = toSend.Slice(offset, totalBytesToSend - offset);
 
 #if DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS
                 var sendAsyncCancellationTokenSource = new CancellationTokenSource();

--- a/source/Octopus.TestPortForwarder/SocketPump.cs
+++ b/source/Octopus.TestPortForwarder/SocketPump.cs
@@ -155,4 +155,14 @@ namespace Octopus.TestPortForwarder
             SOCKET_OPEN
         }
     }
+
+#if NET48
+    public static class ArraySegmentExtensionMethods
+    {
+        public static ArraySegment<T> Slice<T>(this ArraySegment<T> arraySegment, int index, int count)
+        {
+            return new ArraySegment<T>(arraySegment.Array!, arraySegment.Offset + index, count);
+        }
+    }
+#endif
 }

--- a/source/Octopus.TestPortForwarder/TcpPump.cs
+++ b/source/Octopus.TestPortForwarder/TcpPump.cs
@@ -18,12 +18,13 @@ namespace Octopus.TestPortForwarder
         readonly CancellationTokenSource cancellationTokenSource = new();
         readonly ILogger logger;
         readonly TimeSpan sendDelay;
+        readonly int delaySendingLastNBytes;
         bool isDisposing;
         bool isDisposed;
         public bool IsPaused { get; set; }
         private Func<BiDirectionalDataTransferObserver> factory;
 
-        public TcpPump(Socket clientSocket, Socket originSocket, EndPoint originEndPoint, TimeSpan sendDelay, Func<BiDirectionalDataTransferObserver> factory, ILogger logger)
+        public TcpPump(Socket clientSocket, Socket originSocket, EndPoint originEndPoint, TimeSpan sendDelay, Func<BiDirectionalDataTransferObserver> factory, int delaySendingLastNBytes, ILogger logger)
         {
             this.logger = logger.ForContext<TcpPump>();
             this.clientSocket = clientSocket ?? throw new ArgumentNullException(nameof(clientSocket));
@@ -31,6 +32,7 @@ namespace Octopus.TestPortForwarder
             this.originEndPoint = originEndPoint ?? throw new ArgumentNullException(nameof(originEndPoint));
             this.sendDelay = sendDelay;
             this.factory = factory;
+            this.delaySendingLastNBytes = delaySendingLastNBytes;
             clientEndPoint = clientSocket.RemoteEndPoint ?? throw new ArgumentException("Remote endpoint is null", nameof(clientSocket));
         }
 
@@ -64,8 +66,8 @@ namespace Octopus.TestPortForwarder
 
                         var biDirectionalCallBack = factory();
                         // If the connection was ok, then set-up a pump both ways
-                        var pump1 = Task.Run(async () => await PumpBytes(clientSocket, originSocket, new SocketPump(this, () => this.IsPaused, sendDelay, biDirectionalCallBack.DataTransferObserverClientToOrigin), cancellationToken).ConfigureAwait(false), cancellationToken);
-                        var pump2 = Task.Run(async () => await PumpBytes(originSocket, clientSocket, new SocketPump(this, () => this.IsPaused, sendDelay, biDirectionalCallBack.DataTransferObserverOriginToClient), cancellationToken).ConfigureAwait(false), cancellationToken);
+                        var pump1 = Task.Run(async () => await PumpBytes(clientSocket, originSocket, new SocketPump(this, () => this.IsPaused, sendDelay, biDirectionalCallBack.DataTransferObserverClientToOrigin, delaySendingLastNBytes, logger), cancellationToken).ConfigureAwait(false), cancellationToken);
+                        var pump2 = Task.Run(async () => await PumpBytes(originSocket, clientSocket, new SocketPump(this, () => this.IsPaused, sendDelay, biDirectionalCallBack.DataTransferObserverOriginToClient, delaySendingLastNBytes, logger), cancellationToken).ConfigureAwait(false), cancellationToken);
 
                         // When one is finished, they are both "done" so stop them
                         await Task.WhenAny(pump1, pump2).ConfigureAwait(false);


### PR DESCRIPTION
# Background

Expands the available simulated networks to allow for sending the last n bytes late. For example if `hello` was sent over the wire and `n=1` then the port forwarder would forward `hell` and `10ms` later `o` would be sent.

The idea is to find and prevent bugs where we are unintentionally dropping read bytes. No bugs were found.

This PR also:
* Adds logging to the halibut instances created by the Client and Service builder.
* Switches the existing Test halibut logging to using `SeriLog` (will be useful later when that is improved).
* Passes the logger down to the SocketPump, not used but does make desperate debugging easier. The amount of logs coming out of the socket pump is too noisy to keep, so no logging code is kept in the pump.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
