### PR TITLE
Simple RPC response caching

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
@@ -26,6 +26,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
             var services = new DelegateServiceFactory();
             services.Register<IEchoService>(() => new EchoService());
+            services.Register<ICachingService>(() => new CachingService());
             using (var tentaclePolling = new HalibutRuntime(services, TentacleCert))
             {
                 switch (serviceConnectionType)

--- a/source/Halibut.TestUtils.CompatBinary.Base/CachingService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/CachingService.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class CachingService : ICachingService
+    {
+        public Guid NonCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall(Guid input)
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid AnotherCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCallThatThrowsAnException(string exceptionMessage)
+        {
+            throw new Exception(exceptionMessage + " " + Guid.NewGuid());
+        }
+
+        public Guid TwoSecondCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/CachingService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/CachingService.cs
@@ -24,9 +24,9 @@ namespace Halibut.TestUtils.SampleProgram.Base
             return Guid.NewGuid();
         }
 
-        public Guid CachableCallThatThrowsAnException(string exceptionMessage)
+        public Guid CachableCallThatThrowsAnExceptionWithARandomExceptionMessage(string exceptionMessagePrefix)
         {
-            throw new Exception(exceptionMessage + " " + Guid.NewGuid());
+            throw new Exception(exceptionMessagePrefix + " " + Guid.NewGuid());
         }
 
         public Guid TwoSecondCachableCall()

--- a/source/Halibut.TestUtils.CompatBinary.Base/ICachingService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ICachingService.cs
@@ -20,7 +20,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
         // It is applied on the client interface in the Halibut.Tests project
-        Guid CachableCallThatThrowsAnException(string exceptionMessage);
+        Guid CachableCallThatThrowsAnExceptionWithARandomExceptionMessage(string exceptionMessagePrefix);
 
         // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
         // It is applied on the client interface in the Halibut.Tests project

--- a/source/Halibut.TestUtils.CompatBinary.Base/ICachingService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ICachingService.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public interface ICachingService
+    {
+        Guid NonCachableCall();
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid CachableCall();
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid CachableCall(Guid input);
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid AnotherCachableCall();
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid CachableCallThatThrowsAnException(string exceptionMessage);
+
+        // The CacheResponse Attribute cannot be applied / isn't need for the Service interface
+        // It is applied on the client interface in the Halibut.Tests project
+        Guid TwoSecondCachableCall();
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_237/Halibut.TestUtils.CompatBinary.v5_0_237.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_237/Halibut.TestUtils.CompatBinary.v5_0_237.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <LangVersion>9.0</LangVersion>
+        <RootNamespace>Halibut.TestUtils.SampleProgram.v5_0_237</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Halibut" Version="5.0.237" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_237/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_237/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Halibut.TestUtils.SampleProgram.Base;
+
+namespace Halibut.TestUtils.SampleProgram.v5_0_237
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+           return BackwardsCompatProgramBase.Main(args);
+        }
+    }
+}

--- a/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectly.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectly.cs
@@ -12,7 +12,10 @@ namespace Halibut.Tests.BackwardsCompatibility
         [Test]
         public async Task OldInvocationExceptionMessages_AreMappedTo_ServiceInvocationHalibutClientException_Polling()
         {
-            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithPollingService().WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder
+                       .WithPollingService()
+                       .WithServiceVersion(PreviousServiceVersions.v5_0_429)
+                       .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>(se =>
                 {
@@ -27,7 +30,10 @@ namespace Halibut.Tests.BackwardsCompatibility
         [Test]
         public async Task OldInvocationExceptionMessages_AreMappedTo_ServiceInvocationHalibutClientException_Listening()
         {
-            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithListeningService().WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder
+                       .WithListeningService()
+                       .WithServiceVersion(PreviousServiceVersions.v5_0_429)
+                       .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>(se =>
                 {

--- a/source/Halibut.Tests/BackwardsCompatibility/Util/PreviousServiceVersions.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/Util/PreviousServiceVersions.cs
@@ -1,0 +1,11 @@
+﻿namespace Halibut.Tests.BackwardsCompatibility.Util
+{
+    public static class PreviousServiceVersions
+    {
+        // Version prior to new exception types being added to Halibut. All exceptions are HalibutClientException
+        public const string v5_0_429 = "5.0.429";
+
+        // The last release with meaningful changes prior to Script Service V2
+        public const string v5_0_237_Used_In_Tentacle_6_3_417 = "5.0.237";
+    }
+}

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -55,17 +55,28 @@ namespace Halibut.Tests
         [TestCase(ServiceConnectionType.Polling)]
         public async Task CanTalkToOldServicesWhichDontKnowAboutHalibutProxyRequestOptions(ServiceConnectionType serviceConnectionType)
         {
-            using (var clientAndService = await ClientAndPreviousVersionServiceBuilder.WithService(serviceConnectionType).WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder.WithService(serviceConnectionType).WithServiceVersion("5.0.429").Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
                     {
                         se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
                         se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
                     });
-                
+
                 var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
                 res.Should().Be("Hello!!");
             }
+        }
+
+        public interface IClientEchoService
+        {
+            int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
         }
     }
 
@@ -80,16 +91,5 @@ namespace Halibut.Tests
         {
             throw new NotImplementedException();
         }
-    }
-
-    public interface IClientEchoService
-    {
-        int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-        string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-        bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-        int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
     }
 }

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\Octopus.TestPortForwarder\Octopus.TestPortForwarder.csproj" />
     <ProjectReference Include="..\Halibut\Halibut.csproj" />
     <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_237\Halibut.TestUtils.CompatBinary.v5_0_237.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NET6.0.approved.cs
@@ -45,6 +45,7 @@ namespace Halibut
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public Func<string, string, Halibut.UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
         public static bool OSSupportsWebSockets { get; }
+        public Halibut.Transport.Caching.OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         protected Halibut.UnauthorizedClientConnectResponse HandleUnauthorizedClientConnect(string clientName, string thumbPrint) { }
         public bool IsTrusted(string remoteThumbprint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
@@ -92,6 +93,7 @@ namespace Halibut
     {
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public Func<string, string, Halibut.UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
+        public Halibut.Transport.Caching.OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         public bool IsTrusted(string remoteThumbprint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
@@ -326,8 +328,8 @@ namespace Halibut.ServiceModel
     {
         public HalibutProxy() { }
         protected Object Invoke(MethodInfo targetMethod, Object[] args) { }
-        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger) { }
-        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, System.Threading.CancellationToken, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger, System.Threading.CancellationToken cancellationToken) { }
+        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, MethodInfo, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger) { }
+        public void Configure(Func<Halibut.Transport.Protocol.RequestMessage, MethodInfo, System.Threading.CancellationToken, Halibut.Transport.Protocol.ResponseMessage> messageRouter, Type contractType, Halibut.ServiceEndPoint endPoint, Halibut.Diagnostics.ILog logger, System.Threading.CancellationToken cancellationToken) { }
     }
     public class HalibutProxyRequestOptions
     {
@@ -398,6 +400,7 @@ namespace Halibut.ServiceModel
     {
         public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
         public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+        public static Object[] GetArguments(Halibut.Transport.Protocol.RequestMessage requestMessage, MethodInfo methodInfo) { }
     }
 }
 namespace Halibut.Transport
@@ -502,6 +505,21 @@ namespace Halibut.Transport
         public TcpConnectionFactory(X509Certificate2 clientCertificate) { }
         public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
         public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+    }
+}
+namespace Halibut.Transport.Caching
+{
+    public class CacheResponseAttribute : Attribute
+    {
+        public CacheResponseAttribute(int durationInSeconds) { }
+        public int DurationInSeconds { get; set; }
+    }
+    public sealed class OverrideErrorResponseMessageCachingAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public OverrideErrorResponseMessageCachingAction(Object @object, IntPtr method) { }
+        public bool EndInvoke(IAsyncResult result) { }
+        public bool Invoke(Halibut.Transport.Protocol.ResponseMessage responseMessage) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.ResponseMessage responseMessage, AsyncCallback callback, Object @object) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
+++ b/source/Halibut.Tests/PublicSurfaceAreaFixture.ThePublicSurfaceAreaShouldNotRegress.NETFramework.approved.cs
@@ -45,6 +45,7 @@ namespace Halibut
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public Func<string, string, Halibut.UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
         public static bool OSSupportsWebSockets { get; }
+        public Halibut.Transport.Caching.OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         protected Halibut.UnauthorizedClientConnectResponse HandleUnauthorizedClientConnect(string clientName, string thumbPrint) { }
         public bool IsTrusted(string remoteThumbprint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
@@ -92,6 +93,7 @@ namespace Halibut
     {
         public Halibut.Diagnostics.ILogFactory Logs { get; }
         public Func<string, string, Halibut.UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
+        public Halibut.Transport.Caching.OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         public bool IsTrusted(string remoteThumbprint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint) { }
         public Halibut.ServiceEndPoint Discover(Halibut.ServiceEndPoint endpoint, System.Threading.CancellationToken cancellationToken) { }
@@ -391,6 +393,7 @@ namespace Halibut.ServiceModel
     {
         public ServiceInvoker(Halibut.ServiceModel.IServiceFactory factory) { }
         public Halibut.Transport.Protocol.ResponseMessage Invoke(Halibut.Transport.Protocol.RequestMessage requestMessage) { }
+        public static Object[] GetArguments(Halibut.Transport.Protocol.RequestMessage requestMessage, MethodInfo methodInfo) { }
     }
 }
 namespace Halibut.Transport
@@ -509,6 +512,21 @@ namespace Halibut.Transport
         public WebSocketConnectionFactory(X509Certificate2 clientCertificate) { }
         public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log) { }
         public Halibut.Transport.IConnection EstablishNewConnection(Halibut.Transport.Protocol.ExchangeProtocolBuilder exchangeProtocolBuilder, Halibut.ServiceEndPoint serviceEndpoint, Halibut.Diagnostics.ILog log, System.Threading.CancellationToken cancellationToken) { }
+    }
+}
+namespace Halibut.Transport.Caching
+{
+    public class CacheResponseAttribute : Attribute, _Attribute
+    {
+        public CacheResponseAttribute(int durationInSeconds) { }
+        public int DurationInSeconds { get; set; }
+    }
+    public sealed class OverrideErrorResponseMessageCachingAction : MulticastDelegate, ICloneable, ISerializable
+    {
+        public OverrideErrorResponseMessageCachingAction(Object @object, IntPtr method) { }
+        public bool EndInvoke(IAsyncResult result) { }
+        public bool Invoke(Halibut.Transport.Protocol.ResponseMessage responseMessage) { }
+        public IAsyncResult BeginInvoke(Halibut.Transport.Protocol.ResponseMessage responseMessage, AsyncCallback callback, Object @object) { }
     }
 }
 namespace Halibut.Transport.Protocol

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.BackwardsCompatibility.Util;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using Halibut.Transport.Caching;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class ResponseMessageCacheFixture
+    {
+        public static object[] ServiceConnectionTypeAndVersion =
+        {
+            new object[] { ServiceConnectionType.Polling, null },
+            new object[] { ServiceConnectionType.Listening, null },
+            new object[] { ServiceConnectionType.Polling, PreviousServiceVersions.v5_0_237_Used_In_Tentacle_6_3_417 },
+            new object[] { ServiceConnectionType.Listening, PreviousServiceVersions.v5_0_237_Used_In_Tentacle_6_3_417 }
+        };
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatDoesNotSupportCaching_ResponsesShouldNotBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                var result1 = client.NonCachableCall();
+                var result2 = client.NonCachableCall();
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatDoesNotSupportCaching_WithClientInterface_ResponsesShouldNotBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService, IClientCachingService>();
+
+                var result1 = client.NonCachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+                var result2 = client.NonCachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                var result1 = client.CachableCall();
+                var result2 = client.CachableCall();
+
+                result1.Should().Be(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_WithClientInterface_ResponseShouldBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService, IClientCachingService>();
+
+                var result1 = client.CachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+                var result2 = client.CachableCall(new HalibutProxyRequestOptions(CancellationToken.None));
+
+                result1.Should().Be(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseForServiceWithInputParametersShouldBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                var guid = Guid.NewGuid();
+                var result1 = client.CachableCall(guid);
+                var result2 = client.CachableCall(guid);
+
+                result1.Should().Be(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_CachedItemShouldBeInvalidatedAfterTheCacheDurationExpires(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                var result1 = client.TwoSecondCachableCall();
+                var result2 = client.TwoSecondCachableCall();
+
+                result1.Should().Be(result2);
+
+                await Task.Delay(TimeSpan.FromSeconds(3));
+
+                var result3 = client.TwoSecondCachableCall();
+
+                result3.Should().NotBe(result1);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                var result1 = client.CachableCall();
+                var result2 = client.AnotherCachableCall();
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentEndpoints(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndServiceOne = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var clientOne = clientAndServiceOne.CreateClient<ICachingService>();
+
+                using var clientAndServiceTwo = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+                var clientTwo = clientAndServiceTwo.CreateClient<ICachingService>();
+
+                var result1 = clientOne.CachableCall();
+                var result2 = clientTwo.CachableCall();
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentInputParameters(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                var result1 = client.CachableCall(Guid.NewGuid());
+                var result2 = client.CachableCall(Guid.NewGuid());
+
+                result1.Should().NotBe(result2);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ClientShouldBeAbleToForceSpecificErrorResponsesToBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                clientAndService.Octopus.OverrideErrorResponseMessageCaching = (response) =>
+                {
+                    if (response.Error.Message.Contains("CACHE ME"))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                };
+
+                var client = clientAndService.CreateClient<ICachingService>();
+
+                Exception exception1 = null;
+                Exception exception2 = null;
+
+                TryCatch(() => client.CachableCallThatThrowsAnException($"UNCACHED"), e => exception1 = e);
+                TryCatch(() => client.CachableCallThatThrowsAnException($"UNCACHED"), e => exception2 = e);
+
+                exception1.Should().NotBeNull();
+                exception2.Should().NotBeNull();
+                exception1!.Message.Should().NotBe(exception2!.Message);
+
+
+                Exception exception3 = null;
+                Exception exception4 = null;
+
+                TryCatch(() => client.CachableCallThatThrowsAnException($"CACHE ME"), e => exception3 = e);
+                TryCatch(() => client.CachableCallThatThrowsAnException($"CACHE ME"), e => exception4 = e);
+
+                exception3.Should().NotBeNull();
+                exception4.Should().NotBeNull();
+                exception3!.Message.Should().Be(exception4!.Message);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(ServiceConnectionTypeAndVersion))]
+        public async Task ForAServiceThatSupportsCaching_ErrorResponsesShouldNotBeCached(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            using var clientAndService = await CreateClientAndService(serviceConnectionType, halibutServiceVersion);
+            {
+                var client = clientAndService.CreateClient<ICachingService>();
+                Exception exception1 = null;
+                Exception exception2 = null;
+
+                TryCatch(() => client.CachableCallThatThrowsAnException($"Exception"), e => exception1 = e);
+                TryCatch(() => client.CachableCallThatThrowsAnException($"Exception"), e => exception2 = e);
+
+                exception1.Should().NotBeNull();
+                exception1!.Message.Should().StartWith("Exception");
+                exception2.Should().NotBeNull();
+                exception2!.Message.Should().StartWith("Exception");
+                exception1!.Message.Should().NotBe(exception2.Message);
+            }
+        }
+
+        static async Task<IClientAndService> CreateClientAndService(ServiceConnectionType serviceConnectionType, string halibutServiceVersion)
+        {
+            return halibutServiceVersion == null ?
+                ClientServiceBuilder
+                    .ForMode(serviceConnectionType)
+                    .WithService<ICachingService>(() => new CachingService())
+                    .Build() :
+                await ClientAndPreviousServiceVersionBuilder
+                    .ForServiceConnectionType(serviceConnectionType)
+                    .WithServiceVersion(halibutServiceVersion)
+                    .Build();
+        }
+
+        void TryCatch(Action action, Action<Exception> handleException)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception e)
+            {
+                handleException(e);
+            }
+        }
+
+        public interface IClientCachingService
+        {
+            Guid NonCachableCall(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+            [CacheResponse(600)]
+            Guid CachableCall(HalibutProxyRequestOptions halibutProxyRequestOptions);
+        }
+    }
+}

--- a/source/Halibut.Tests/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/SecureListenerFixture.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests
         PerformanceCounter GetCounterForCurrentProcess(string categoryName, string counterName)
         {
             var pid = Process.GetCurrentProcess().Id;
-            
+
             var instanceName = new PerformanceCounterCategory("Process")
                 .GetInstanceNames()
                 .FirstOrDefault(instance =>
@@ -32,10 +32,10 @@ namespace Halibut.Tests
             {
                 throw new Exception("Could not find instance name for process.");
             }
-            
+
             return new PerformanceCounter(categoryName, counterName, instanceName, true);
         }
-        
+
         [Test]
         [WindowsTest]
         public void SecureListenerDoesNotCreateHundredsOfIoEventsPerSecondOnWindows()
@@ -45,12 +45,12 @@ namespace Halibut.Tests
             using (var opsPerSec = GetCounterForCurrentProcess("Process", "IO Other Operations/sec"))
             {
                 var client = new SecureListener(
-                    new IPEndPoint(new IPAddress(new byte[]{ 127, 0, 0, 1 }), 1093), 
+                    new IPEndPoint(new IPAddress(new byte[]{ 127, 0, 0, 1 }), 0),
                     Certificates.TentacleListening,
                     null,
                     null,
                     thumbprint => true,
-                    new LogFactory(), 
+                    new LogFactory(),
                     () => ""
                 );
 
@@ -59,18 +59,18 @@ namespace Halibut.Tests
                     .Average();
 
                 float listeningAverage;
-            
+
                 using (client)
                 {
                     client.Start();
-                
+
                     listeningAverage = CollectCounterValues(opsPerSec)
                         .Take(secondsToSample)
                         .Average();
                 }
 
                 var idleAverageWithErrorMargin = idleAverage * 250f;
-            
+
                 TestContext.Out.WriteLine($"idle average:      {idleAverage} ops/second");
                 TestContext.Out.WriteLine($"listening average: {listeningAverage} ops/second");
                 TestContext.Out.WriteLine($"expectation:     < {idleAverageWithErrorMargin} ops/second");
@@ -78,11 +78,11 @@ namespace Halibut.Tests
                 listeningAverage.Should().BeLessThan(idleAverageWithErrorMargin);
             }
         }
-        
+
         IEnumerable<float> CollectCounterValues(PerformanceCounter counter)
         {
             var sleepTime = TimeSpan.FromSeconds(1);
-            
+
             while (true)
             {
                 Thread.Sleep(sleepTime);

--- a/source/Halibut.Tests/TestServices/CachingService.cs
+++ b/source/Halibut.Tests/TestServices/CachingService.cs
@@ -24,9 +24,9 @@ namespace Halibut.Tests.TestServices
             return Guid.NewGuid();
         }
 
-        public Guid CachableCallThatThrowsAnException(string exceptionMessage)
+        public Guid CachableCallThatThrowsAnExceptionWithARandomExceptionMessage(string exceptionMessagePrefix)
         {
-            throw new Exception(exceptionMessage + " " + Guid.NewGuid());
+            throw new Exception(exceptionMessagePrefix + " " + Guid.NewGuid());
         }
 
         public Guid TwoSecondCachableCall()

--- a/source/Halibut.Tests/TestServices/CachingService.cs
+++ b/source/Halibut.Tests/TestServices/CachingService.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Halibut.Tests.TestServices
+{
+    public class CachingService : ICachingService
+    {
+        public Guid NonCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid AnotherCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCall(Guid input)
+        {
+            return Guid.NewGuid();
+        }
+
+        public Guid CachableCallThatThrowsAnException(string exceptionMessage)
+        {
+            throw new Exception(exceptionMessage + " " + Guid.NewGuid());
+        }
+
+        public Guid TwoSecondCachableCall()
+        {
+            return Guid.NewGuid();
+        }
+    }
+}

--- a/source/Halibut.Tests/TestServices/ICachingService.cs
+++ b/source/Halibut.Tests/TestServices/ICachingService.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Halibut.Transport.Caching;
+
+namespace Halibut.Tests.TestServices
+{
+    public interface ICachingService
+    {
+        Guid NonCachableCall();
+
+        [CacheResponse(600)]
+        Guid CachableCall();
+
+        [CacheResponse(600)]
+        Guid AnotherCachableCall();
+
+        [CacheResponse(600)]
+        Guid CachableCall(Guid input);
+
+        [CacheResponse(600)]
+        Guid CachableCallThatThrowsAnException(string exceptionMessage);
+
+        [CacheResponse(2)]
+        Guid TwoSecondCachableCall();
+    }
+}

--- a/source/Halibut.Tests/TestServices/ICachingService.cs
+++ b/source/Halibut.Tests/TestServices/ICachingService.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.TestServices
         Guid CachableCall(Guid input);
 
         [CacheResponse(600)]
-        Guid CachableCallThatThrowsAnException(string exceptionMessage);
+        Guid CachableCallThatThrowsAnExceptionWithARandomExceptionMessage(string exceptionMessagePrefix);
 
         [CacheResponse(2)]
         Guid TwoSecondCachableCall();

--- a/source/Halibut.Tests/Util/IClientAndService.cs
+++ b/source/Halibut.Tests/Util/IClientAndService.cs
@@ -1,0 +1,18 @@
+#nullable enable
+using System;
+using System.Threading;
+using Octopus.TestPortForwarder;
+
+namespace Halibut.Tests.Util
+{
+    public interface IClientAndService : IDisposable
+    {
+        HalibutRuntime Octopus { get; }
+        PortForwarder PortForwarder { get; }
+        TService CreateClient<TService>();
+        TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint);
+        TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken);
+        TClientService CreateClient<TService, TClientService>();
+        TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint);
+    }
+}

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -21,13 +21,13 @@ namespace Halibut.Tests
             {
                 var svc = clientAndService.CreateClient<IDoSomeActionService>();
 
-                doSomeActionService.ActionDelegate = () => clientAndService.portForwarder.Dispose();
+                doSomeActionService.ActionDelegate = () => clientAndService.PortForwarder.Dispose();
 
                 // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
                 var killPortForwarderTask = Task.Run(() => svc.Action());
-                
+
                 await Task.WhenAny(killPortForwarderTask, Task.Delay(TimeSpan.FromSeconds(10)));
-                
+
                 killPortForwarderTask.Status.Should().Be(TaskStatus.Faulted, "We should immediately get an error response.");
             }
         }

--- a/source/Halibut.sln
+++ b/source/Halibut.sln
@@ -38,9 +38,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{B742FF5E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{55223D02-0CE9-4325-9A4D-5E88A544B633}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halibut.TestUtils.CompatBinary.v5_0_429", "Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj", "{66014922-3A83-42A2-8C23-D327160175C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v5_0_429", "Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj", "{66014922-3A83-42A2-8C23-D327160175C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halibut.TestUtils.CompatBinary.Base", "Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj", "{BBC31D50-5170-49D9-A42D-625768705B7B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.Base", "Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj", "{BBC31D50-5170-49D9-A42D-625768705B7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v5_0_237", "Halibut.TestUtils.CompatBinary.v5_0_237\Halibut.TestUtils.CompatBinary.v5_0_237.csproj", "{1718896B-5089-462C-AD60-E189A86A12F9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Octopus.TestPortForwarder", "Octopus.TestPortForwarder\Octopus.TestPortForwarder.csproj", "{ACF73278-BC28-4C60-ACF9-CAC3C5ACA45C}"
 EndProject
@@ -216,6 +218,18 @@ Global
 		{E0C851B9-DD65-4E0D-B215-6B43748A9C3E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{E0C851B9-DD65-4E0D-B215-6B43748A9C3E}.Release|x86.ActiveCfg = Release|Any CPU
 		{E0C851B9-DD65-4E0D-B215-6B43748A9C3E}.Release|x86.Build.0 = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Debug|x86.Build.0 = Debug|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{1718896B-5089-462C-AD60-E189A86A12F9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -34,11 +34,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
   </ItemGroup>
 

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using Halibut.Diagnostics;
+using Halibut.Transport.Caching;
 
 namespace Halibut
 {
@@ -54,5 +55,7 @@ namespace Halibut
         void SetFriendlyHtmlPageContent(string html);
         void Disconnect(ServiceEndPoint endpoint);
         Func<string, string, UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
+
+        OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
     }
 }

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -103,7 +103,7 @@ namespace Halibut.ServiceModel
             throw new AmbiguousMethodMatchHalibutClientException(message.ToString(), new AmbiguousMatchException(message.ToString()));
         }
 
-        static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)
+        public static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)
         {
             var methodParams = methodInfo.GetParameters();
             var args = new object[methodParams.Length];

--- a/source/Halibut/Transport/Caching/CacheResponseAttribute.cs
+++ b/source/Halibut/Transport/Caching/CacheResponseAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Halibut.Transport.Caching
+{
+    public class CacheResponseAttribute : Attribute
+    {
+        public CacheResponseAttribute(int durationInSeconds)
+        {
+            DurationInSeconds = durationInSeconds;
+        }
+
+        public int DurationInSeconds { get; set; }
+    }
+}

--- a/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
+++ b/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
@@ -6,11 +6,11 @@ using System.Text;
 
 namespace Halibut.Transport.Caching
 {
-    internal class CachingKeyGenerator
+    class CachingKeyGenerator
     {
         const char LinkChar = ':';
 
-        public string GetCacheKey(MethodInfo methodInfo, object[] args, string prefix)
+        internal string GetCacheKey(MethodInfo methodInfo, object[] args, string prefix)
         {
             var methodArguments = args?.Any() == true
                 ? args.Select(ParameterCacheKeys.GenerateCacheKey)
@@ -18,7 +18,7 @@ namespace Halibut.Transport.Caching
             return GenerateCacheKey(methodInfo, prefix, methodArguments);
         }
 
-        public string GetCacheKeyPrefix(MethodInfo methodInfo, string prefix)
+        string GetCacheKeyPrefix(MethodInfo methodInfo, string prefix)
         {
             if (!string.IsNullOrWhiteSpace(prefix)) return $"{prefix}{LinkChar}";
 

--- a/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
+++ b/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Halibut.Transport.Caching
+{
+    internal class CachingKeyGenerator
+    {
+        const char LinkChar = ':';
+
+        public string GetCacheKey(MethodInfo methodInfo, object[] args, string prefix)
+        {
+            var methodArguments = args?.Any() == true
+                ? args.Select(ParameterCacheKeys.GenerateCacheKey)
+                : new[] { "0" };
+            return GenerateCacheKey(methodInfo, prefix, methodArguments);
+        }
+
+        public string GetCacheKeyPrefix(MethodInfo methodInfo, string prefix)
+        {
+            if (!string.IsNullOrWhiteSpace(prefix)) return $"{prefix}{LinkChar}";
+
+            var typeName = methodInfo.DeclaringType?.Name;
+            var methodName = methodInfo.Name;
+
+            return $"{typeName}{LinkChar}{methodName}{LinkChar}";
+        }
+
+        string GenerateCacheKey(MethodInfo methodInfo, string prefix, IEnumerable<string> parameters)
+        {
+            var cacheKeyPrefix = GetCacheKeyPrefix(methodInfo, prefix);
+
+            var builder = new StringBuilder();
+            builder.Append(cacheKeyPrefix);
+            builder.Append(string.Join(LinkChar.ToString(), parameters));
+            return builder.ToString();
+        }
+    }
+}

--- a/source/Halibut/Transport/Caching/ParameterCacheKeys.cs
+++ b/source/Halibut/Transport/Caching/ParameterCacheKeys.cs
@@ -7,7 +7,7 @@ namespace Halibut.Transport.Caching
 {
     static class ParameterCacheKeys
     {
-        public static string GenerateCacheKey(object parameter)
+        internal static string GenerateCacheKey(object parameter)
         {
             if (parameter == null) return string.Empty;
             if (parameter is string key) return key;

--- a/source/Halibut/Transport/Caching/ParameterCacheKeys.cs
+++ b/source/Halibut/Transport/Caching/ParameterCacheKeys.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Halibut.Transport.Caching
+{
+    static class ParameterCacheKeys
+    {
+        public static string GenerateCacheKey(object parameter)
+        {
+            if (parameter == null) return string.Empty;
+            if (parameter is string key) return key;
+            if (parameter is Guid guid) return guid.ToString();
+            if (parameter is DateTime dateTime) return dateTime.ToString("O");
+            if (parameter is DateTimeOffset dateTimeOffset) return dateTimeOffset.ToString("O");
+            if (parameter is IEnumerable enumerable) return GenerateCacheKey(enumerable.Cast<object>());
+
+            throw new ArgumentOutOfRangeException($"Parameter of type {parameter.GetType()} cannot be used as a cache key.");
+        }
+
+        static string GenerateCacheKey(IEnumerable<object> parameter)
+        {
+            if (parameter == null) return string.Empty;
+            return "[" + string.Join(",", parameter) + "]";
+        }
+    }
+}

--- a/source/Halibut/Transport/Caching/ResponseCache.cs
+++ b/source/Halibut/Transport/Caching/ResponseCache.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Caching;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Transport.Caching
+{
+    /// <summary>
+    /// Allows the Response Caching behaviour to be modified for Error responses.
+    /// By default all errors responses are not cached.
+    /// </summary>
+    /// <param name="responseMessage">The error response message</param>
+    /// <returns>True to allow the error response message to be cached, otherwise false.</returns>
+    public delegate bool OverrideErrorResponseMessageCachingAction(ResponseMessage responseMessage);
+
+    internal class ResponseCache
+    {
+        readonly MemoryCache responseMessageCache = new("ResponseMessageCache");
+
+        public ResponseMessage GetCachedResponse(ServiceEndPoint endPoint, RequestMessage request, MethodInfo methodInfo)
+        {
+            var responseCanBeCached = CanBeCached(methodInfo);
+            if (!responseCanBeCached) return null;
+
+            var cacheKey = GetCacheKey(endPoint, methodInfo, request);
+            var wrapper = responseMessageCache.GetCacheItem(cacheKey)?.Value as CacheItemWrapper;
+
+            return wrapper?.ResponseMessage;
+
+        }
+
+        public void CacheResponse(ServiceEndPoint endPoint, RequestMessage request, MethodInfo methodInfo, ResponseMessage response, OverrideErrorResponseMessageCachingAction overrideErrorResponseMessageCachingAction)
+        {
+            var responseCanBeCached = CanBeCached(methodInfo, response, overrideErrorResponseMessageCachingAction);
+            if (!responseCanBeCached) return;
+
+            var cacheKey = GetCacheKey(endPoint, methodInfo, request);
+            var cacheDuration = GetCacheDuration(methodInfo);
+
+            var wrapper = new CacheItemWrapper
+            {
+                ResponseMessage = response,
+                EndPoint = endPoint
+            };
+            responseMessageCache.Add(cacheKey, wrapper, new CacheItemPolicy { AbsoluteExpiration = DateTimeOffset.UtcNow.AddSeconds(cacheDuration) });
+        }
+
+        bool CanBeCached(MethodInfo methodInfo)
+        {
+            return methodInfo.GetCustomAttribute<CacheResponseAttribute>() != null;
+        }
+
+        bool CanBeCached(MethodInfo methodInfo, ResponseMessage response, OverrideErrorResponseMessageCachingAction overrideErrorResponseMessageCachingAction)
+        {
+            if (!CanBeCached(methodInfo))
+            {
+                return false;
+            }
+
+            if (response.Error != null)
+            {
+                var overrideCacheResult = overrideErrorResponseMessageCachingAction?.Invoke(response);
+
+                return overrideCacheResult ?? false;
+            }
+
+            return true;
+        }
+
+        int GetCacheDuration(MethodInfo methodInfo)
+        {
+            var cacheAttribute = methodInfo.GetCustomAttribute<CacheResponseAttribute>();
+
+            return cacheAttribute?.DurationInSeconds ?? 0;
+        }
+
+        string GetCacheKey(ServiceEndPoint endpoint, MethodInfo methodInfo, RequestMessage request)
+        {
+            var arguments = ServiceInvoker.GetArguments(request, methodInfo);
+            var cacheKey = new CachingKeyGenerator().GetCacheKey(methodInfo, arguments, null);
+
+            return $"{endpoint.BaseUri.AbsoluteUri}:{cacheKey}";
+        }
+
+        class CacheItemWrapper
+        {
+            public ServiceEndPoint EndPoint { get; set; }
+            public ResponseMessage ResponseMessage { get; set; }
+        }
+    }
+}

--- a/source/Halibut/Transport/Caching/ResponseCache.cs
+++ b/source/Halibut/Transport/Caching/ResponseCache.cs
@@ -14,7 +14,7 @@ namespace Halibut.Transport.Caching
     /// <returns>True to allow the error response message to be cached, otherwise false.</returns>
     public delegate bool OverrideErrorResponseMessageCachingAction(ResponseMessage responseMessage);
 
-    internal class ResponseCache
+    class ResponseCache
     {
         readonly MemoryCache responseMessageCache = new("ResponseMessageCache");
 


### PR DESCRIPTION
# Background

This PR allows a Halibut client to cache responses from the Service for selected RPC calls.

The interface used by the client can have an attribute applied that instructs Halibut to cache the response from the service for the specified duration in seconds.

```
public interface IMyService
{
    [CacheResponse(600)]
    Guid CachableCall();
}
```

The responses are cached in a `System.Runtime.Caching.MemoryCache`

By default, only non-error responses are cached.

## Cache Validity

The cached items are expired from the cache after the absolute cache duration specified on the `CacheResponseAtttribute`. No other cache invalidation is performed.

The implementor must ensure that caching responses from a service call make sense and that any possible validity issues arising from caching are handled. Halibut has no logic to invalidate a cache other than at the absolute expiration of a cached item.

## Caching Error Responses

It is possible to cache an error response by overriding the cache behaviour on an error-by-error basis. This allows for scenarios such as caching the error response when a `NoMatchingServiceOrMethodHalibutClientException` exception is thrown.

```
IHalibutRuntime halibut = ....;
halibut.OverrideErrorResponseMessageCaching = (response) =>
{
    if (response.Error.Message.Contains("CACHE ME"))
    {
        return true;
    }

    return false;
};
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
