### PR TITLE
What pump is that?

### DIFF
--- a/source/Octopus.TestPortForwarder/TcpPump.cs
+++ b/source/Octopus.TestPortForwarder/TcpPump.cs
@@ -29,7 +29,7 @@ namespace Octopus.TestPortForwarder
         bool isDisposed;
         public bool IsPaused { get; set; }
         private Func<BiDirectionalDataTransferObserver> factory;
-        readonly long pumpNumber = NextTcpPumpNumber();
+        public long PumpNumber { get; } = NextTcpPumpNumber();
 
         public TcpPump(Socket clientSocket, Socket originSocket, EndPoint originEndPoint, TimeSpan sendDelay, Func<BiDirectionalDataTransferObserver> factory, int numberOfBytesToDelaySending, ILogger logger)
         {
@@ -42,11 +42,7 @@ namespace Octopus.TestPortForwarder
             this.numberOfBytesToDelaySending = numberOfBytesToDelaySending;
             clientEndPoint = clientSocket.RemoteEndPoint ?? throw new ArgumentException("Remote endpoint is null", nameof(clientSocket));
         }
-
-        public string DescribePump()
-        {
-            return $"Forwarding connection from {clientEndPoint.ToString()} to {originEndPoint.ToString()} [{pumpNumber}]";
-        }
+        
         public event EventHandler<EventArgs> Stopped;
 
         public void Start()

--- a/source/Octopus.TestPortForwarder/TcpPump.cs
+++ b/source/Octopus.TestPortForwarder/TcpPump.cs
@@ -11,6 +11,12 @@ namespace Octopus.TestPortForwarder
 {
     public class TcpPump : IDisposable
     {
+        static long tcpPumpNumner = 0;
+
+        static long NextTcpPumpNumber()
+        {
+            return Interlocked.Increment(ref tcpPumpNumner);
+        }
         readonly Socket clientSocket;
         readonly EndPoint clientEndPoint;
         readonly Socket originSocket;
@@ -23,6 +29,7 @@ namespace Octopus.TestPortForwarder
         bool isDisposed;
         public bool IsPaused { get; set; }
         private Func<BiDirectionalDataTransferObserver> factory;
+        readonly long pumpNumber = NextTcpPumpNumber();
 
         public TcpPump(Socket clientSocket, Socket originSocket, EndPoint originEndPoint, TimeSpan sendDelay, Func<BiDirectionalDataTransferObserver> factory, int numberOfBytesToDelaySending, ILogger logger)
         {
@@ -36,6 +43,10 @@ namespace Octopus.TestPortForwarder
             clientEndPoint = clientSocket.RemoteEndPoint ?? throw new ArgumentException("Remote endpoint is null", nameof(clientSocket));
         }
 
+        public string DescribePump()
+        {
+            return $"Forwarding connection from {clientEndPoint.ToString()} to {originEndPoint.ToString()} [{pumpNumber}]";
+        }
         public event EventHandler<EventArgs> Stopped;
 
         public void Start()

--- a/source/Octopus.TestPortForwarder/TcpPump.cs
+++ b/source/Octopus.TestPortForwarder/TcpPump.cs
@@ -11,11 +11,11 @@ namespace Octopus.TestPortForwarder
 {
     public class TcpPump : IDisposable
     {
-        static long tcpPumpNumner = 0;
+        static long numberOfTcpPumpsCreated = 0;
 
         static long NextTcpPumpNumber()
         {
-            return Interlocked.Increment(ref tcpPumpNumner);
+            return Interlocked.Increment(ref numberOfTcpPumpsCreated);
         }
         readonly Socket clientSocket;
         readonly EndPoint clientEndPoint;


### PR DESCRIPTION
# Background

It is currently hard to determine if the bytes flowing over a port forwarder are for an existing TCP connection or for a new one.

With this change we can now log out the pump number in the data observers making it easier to see which connection data is being logged about.

A simple ID appears to be sufficient for this.

With this it would be possible to log something like:
```
[Pump:1] Client sent 45 bytes
[Pump:1] Tentacle sent 38 bytes
[Pump:1] Client sent 600 bytes
[Pump:2] Tentacle sent 100 bytes <--- This is bytes being sent over a new TCP connection since each connection gets a pump.
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
