### PR TITLE
Test old client versions work with the latest service version.

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateEchoService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateEchoService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class DelegateEchoService : IEchoService
+    {
+        readonly IEchoService echoService;
+
+        public DelegateEchoService(IEchoService echoService)
+        {
+            this.echoService = echoService;
+        }
+
+        public int LongRunningOperation()
+        {
+            Console.WriteLine("Forwarding LongRunningOperation() call to delegate");
+            return echoService.LongRunningOperation();
+        }
+
+        public string SayHello(string name)
+        {
+            Console.WriteLine("Forwarding SayHello() call to delegate");
+            return echoService.SayHello(name);
+        }
+
+        public bool Crash()
+        {
+            Console.WriteLine("Forwarding Crash() call to delegate");
+            return echoService.Crash();
+        }
+
+        public int CountBytes(DataStream stream)
+        {
+            Console.WriteLine("Forwarding CountBytes() call to delegate");
+            return echoService.CountBytes(stream);
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextConnectionLog.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextConnectionLog.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Halibut.Diagnostics;
+
+
+namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
+{
+    internal class TestContextConnectionLog : ILog
+    {
+        readonly string endpoint;
+        readonly string name;
+
+        public TestContextConnectionLog(string endpoint, string name)
+        {
+            this.endpoint = endpoint;
+            this.name = name;
+        }
+
+        public void Write(EventType type, string message, params object[] args)
+        {
+            WriteInternal(new LogEvent(type, message, null, args));
+        }
+
+        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        {
+            WriteInternal(new LogEvent(type, message, ex, args));
+        }
+
+        public IList<LogEvent> GetLogs()
+        {
+            throw new NotImplementedException();
+        }
+
+        void WriteInternal(LogEvent logEvent)
+        {
+            var logMessage = string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEvent.Type, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name);
+            Console.WriteLine(logMessage);
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextLogFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextLogFactory.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Halibut.Diagnostics;
+
+
+namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
+{
+    public class TestContextLogFactory : ILogFactory
+    {
+        readonly string name;
+        readonly ConcurrentDictionary<string, TestContextConnectionLog> events = new ConcurrentDictionary<string, TestContextConnectionLog>();
+        readonly HashSet<Uri> endpoints = new HashSet<Uri>();
+        readonly HashSet<string> prefixes = new HashSet<string>();
+
+        public TestContextLogFactory(string name)
+        {
+            this.name = name;
+        }
+
+        public Uri[] GetEndpoints()
+        {
+            lock (endpoints)
+                return endpoints.ToArray();
+        }
+
+        public string[] GetPrefixes()
+        {
+            lock (prefixes)
+                return prefixes.ToArray();
+        }
+
+        public ILog ForEndpoint(Uri endpoint)
+        {
+            endpoint = NormalizeEndpoint(endpoint);
+            lock (endpoints)
+                endpoints.Add(endpoint);
+            return events.GetOrAdd(endpoint.ToString(), e => new TestContextConnectionLog(endpoint.ToString(), name));
+        }
+
+        public ILog ForPrefix(string prefix)
+        {
+            lock (prefixes)
+                prefixes.Add(prefix);
+            return events.GetOrAdd(prefix, e => new TestContextConnectionLog(prefix, name));
+        }
+
+        static Uri NormalizeEndpoint(Uri endpoint)
+        {
+            return ServiceEndPoint.IsWebSocketAddress(endpoint)
+                ? new Uri(endpoint.AbsoluteUri.ToLowerInvariant())
+                : new Uri(endpoint.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped).TrimEnd('/').ToLowerInvariant());
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Halibut.ServiceModel;
+using Halibut.TestUtils.SampleProgram.Base.LogUtils;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    /// <summary>
+    /// Creates a Proxy Service which forwards requests to another halibut client, which itself
+    /// makes requests to a service such as one running in the test CLR.
+    /// 
+    /// This is used when testing the compatibility of a old client with latest service, since this
+    /// has the old client which is making requests to the new service in the test CLR.
+    /// The Proxy 
+    /// </summary>
+    public class ProxyServiceForwardingRequestToClient
+    {
+        public static int Run(string[] args)
+        {
+            var tentacleCertPath = Environment.GetEnvironmentVariable("tentaclecertpath");
+            Console.WriteLine($"Using tentacle cert path: {tentacleCertPath}");
+            var serviceCert = new X509Certificate2(tentacleCertPath);
+            
+            Console.WriteLine("Tentacle/service cert details " + serviceCert);
+
+            
+            var octopusCertPath = Environment.GetEnvironmentVariable("octopuscertpath");
+            Console.WriteLine($"Using octopus cert path: {octopusCertPath}");
+            var clientCert = new X509Certificate2(octopusCertPath);
+            Console.WriteLine("Octopus/Client cert details " + clientCert);
+            
+
+            ServiceConnectionType serviceConnectionType = ServiceConnectionTypeFromString(Environment.GetEnvironmentVariable("ServiceConnectionType"));
+            string addressToPoll = null;
+            if (serviceConnectionType == ServiceConnectionType.Polling)
+            {
+                addressToPoll = Environment.GetEnvironmentVariable("octopusservercommsport");
+                Console.WriteLine($"Will poll: {addressToPoll}");
+            }
+
+            string serivceAddressToConnectTo = null; 
+            if (serviceConnectionType == ServiceConnectionType.Listening)
+            {
+                serivceAddressToConnectTo = Environment.GetEnvironmentVariable("realServiceListenAddress");
+                Console.WriteLine($"Will forward request to: {serivceAddressToConnectTo}");
+            }
+            
+            // Create a client which will send RPC calls to the service in the Test CLR.
+            Console.WriteLine("This should be bob:");
+            Console.WriteLine(clientCert.ToString());
+            using (var client = new HalibutRuntimeBuilder()
+                       .WithServerCertificate(clientCert)
+                       .WithLogFactory(new TestContextLogFactory("ProxyClient"))
+                       .Build())
+            {
+                // 
+                Console.WriteLine("Next line should be: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D");
+                Console.WriteLine("Client will trust: " + serviceCert.Thumbprint);
+                client.Trust(serviceCert.Thumbprint);
+
+                
+                Uri realServiceUri = null;
+                switch (serviceConnectionType)
+                {
+                    case ServiceConnectionType.Polling:
+                        var clientPollingListeningPort = client.Listen();
+                        Console.WriteLine("Polling listener is listening on port: " + clientPollingListeningPort);
+                        
+                        // This needs to be done within the CLR.
+                        //tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll), octopusThumbprint));
+                        realServiceUri = new Uri("poll://SQ-TENTAPOLL");
+                        break;
+                    case ServiceConnectionType.Listening:
+                        realServiceUri = new Uri(serivceAddressToConnectTo);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                var realServiceEndpoint = new ServiceEndPoint(realServiceUri, serviceCert.Thumbprint);
+
+                var forwardingEchoService = client.CreateClient<IEchoService>(realServiceEndpoint);
+                
+                // We can only test in listening mode since in polling not everything is setup yet.
+                // Console.WriteLine("Testing can communicate with service from external proxy client");
+                // forwardingEchoService.SayHello("Hello");
+                // Console.WriteLine("Testing passed, we can talk from the external binary back to the service");
+
+
+                // Connects as service to the client.
+                var services = new DelegateServiceFactory();
+                services.Register<IEchoService>(() => new DelegateEchoService(forwardingEchoService));
+                using (var proxyService = new HalibutRuntimeBuilder()
+                           .WithServiceFactory(services)
+                           .WithServerCertificate(serviceCert)
+                           .WithLogFactory(new TestContextLogFactory("ProxyService"))
+                           .Build())
+                {
+                    switch (serviceConnectionType)
+                    {
+                        case ServiceConnectionType.Polling:
+                            proxyService.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll), clientCert.Thumbprint));
+                            break;
+                        case ServiceConnectionType.Listening:
+                            var port = proxyService.Listen();
+                            Console.WriteLine($"Listening on port: {port}");
+                            proxyService.Trust(clientCert.Thumbprint);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    Console.WriteLine("RunningAndReady");
+                    Console.WriteLine("Will Now sleep");
+                    Console.Out.Flush();
+                    Thread.Sleep(1000000);
+                }
+            }
+
+            return 1;
+        }
+        
+
+        public static ServiceConnectionType ServiceConnectionTypeFromString(string s)
+        {
+            if (Enum.TryParse(s, out ServiceConnectionType serviceConnectionType))
+            {
+                return serviceConnectionType;
+            }
+
+            throw new Exception($"Unknown service type '{s}'");
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -65,9 +65,6 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     case ServiceConnectionType.Polling:
                         var clientPollingListeningPort = client.Listen();
                         Console.WriteLine("Polling listener is listening on port: " + clientPollingListeningPort);
-                        
-                        // This needs to be done within the CLR.
-                        //tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll), octopusThumbprint));
                         realServiceUri = new Uri("poll://SQ-TENTAPOLL");
                         break;
                     case ServiceConnectionType.Listening:
@@ -80,12 +77,6 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 var realServiceEndpoint = new ServiceEndPoint(realServiceUri, serviceCert.Thumbprint);
 
                 var forwardingEchoService = client.CreateClient<IEchoService>(realServiceEndpoint);
-                
-                // We can only test in listening mode since in polling not everything is setup yet.
-                // Console.WriteLine("Testing can communicate with service from external proxy client");
-                // forwardingEchoService.SayHello("Hello");
-                // Console.WriteLine("Testing passed, we can talk from the external binary back to the service");
-
 
                 // Connects as service to the client.
                 var services = new DelegateServiceFactory();

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -31,7 +31,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             Console.WriteLine("Octopus/Client cert details " + clientCert);
             
 
-            ServiceConnectionType serviceConnectionType = ServiceConnectionTypeFromString(Environment.GetEnvironmentVariable("ServiceConnectionType"));
+            ServiceConnectionType serviceConnectionType = BackwardsCompatProgramBase.ServiceConnectionTypeFromString(Environment.GetEnvironmentVariable("ServiceConnectionType"));
             string addressToPoll = null;
             if (serviceConnectionType == ServiceConnectionType.Polling)
             {
@@ -119,17 +119,6 @@ namespace Halibut.TestUtils.SampleProgram.Base
             }
 
             return 1;
-        }
-        
-
-        public static ServiceConnectionType ServiceConnectionTypeFromString(string s)
-        {
-            if (Enum.TryParse(s, out ServiceConnectionType serviceConnectionType))
-            {
-                return serviceConnectionType;
-            }
-
-            throw new Exception($"Unknown service type '{s}'");
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -54,7 +54,6 @@ namespace Halibut.TestUtils.SampleProgram.Base
                        .WithLogFactory(new TestContextLogFactory("ProxyClient"))
                        .Build())
             {
-                // 
                 Console.WriteLine("Next line should be: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D");
                 Console.WriteLine("Client will trust: " + serviceCert.Thumbprint);
                 client.Trust(serviceCert.Thumbprint);
@@ -114,6 +113,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     Console.WriteLine("RunningAndReady");
                     Console.WriteLine("Will Now sleep");
                     Console.Out.Flush();
+                    // Now sleep until the processes is killed externally.
                     Thread.Sleep(1000000);
                 }
             }

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_429/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_429/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Halibut.Diagnostics;
 using Halibut.TestUtils.SampleProgram.Base;
 
 namespace Halibut.TestUtils.SampleProgram.v5_0_429
@@ -7,6 +8,8 @@ namespace Halibut.TestUtils.SampleProgram.v5_0_429
     {
         public static int Main(string[] args)
         {
+            var s = HalibutLimits.PollingRequestQueueTimeout;
+            Console.WriteLine(s);
            return BackwardsCompatProgramBase.Main(args);
         }
     }

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_429/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_429/Program.cs
@@ -8,9 +8,7 @@ namespace Halibut.TestUtils.SampleProgram.v5_0_429
     {
         public static int Main(string[] args)
         {
-            var s = HalibutLimits.PollingRequestQueueTimeout;
-            Console.WriteLine(s);
-           return BackwardsCompatProgramBase.Main(args);
+            return BackwardsCompatProgramBase.Main(args);
         }
     }
 }

--- a/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.BackwardsCompatibility
         {
             using (var clientAndService = await ClientAndPreviousServiceVersionBuilder
                        .ForServiceConnectionType(serviceConnectionType)
-                       .WithServiceVersion(PreviousServiceVersions.v5_0_429)
+                       .WithServiceVersion(PreviousVersions.v5_0_429)
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>(se =>

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -23,7 +23,7 @@ namespace Halibut.Tests.BackwardsCompatibility
                        .Build())
             {
                 
-                var echo = clientAndService.CreateClientToTheProxy<IEchoService>();
+                var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("hello");
             }
 
@@ -40,7 +40,7 @@ namespace Halibut.Tests.BackwardsCompatibility
                        .Build())
             {
                 
-                var echo = clientAndService.CreateClientToTheProxy<IEchoService>();
+                var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("hello");
             }
 

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -2,7 +2,9 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Tests.BackwardsCompatibility.Util;
+using Halibut.Tests.Support;
 using Halibut.Tests.Support.BackwardsCompatibility;
+using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.TestServices;
 using NUnit.Framework;
 
@@ -11,28 +13,12 @@ namespace Halibut.Tests.BackwardsCompatibility
     public class TestOldClientWithNewService
     {
         [Test]
-        public async Task Listening()
+        [TestCaseSource(typeof(ServiceConnectionTypesToTestExcludingWebSockets))]
+        public async Task SimplePreviousClientTest(ServiceConnectionType serviceConnectionType)
         {
             var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
-            using (var clientAndService = await PreviousClientVersionAndServiceBuilder
-                       .WithListeningService()
+            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.ForServiceConnectionType(serviceConnectionType)
                        .WithClientVersion(PreviousVersions.v5_0_429)
-                       .WithEchoServiceService(echoService)
-                       .Build())
-            {
-                
-                var echo = clientAndService.CreateClient<IEchoService>();
-                echo.SayHello("hello");
-            }
-
-            echoService.SayHelloCallCount.Should().Be(1);
-        }
-        
-        [Test]
-        public async Task Polling()
-        {
-            var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
-            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.WithPollingService().WithClientVersion(PreviousVersions.v5_0_429)
                        .WithEchoServiceService(echoService)
                        .Build())
             {

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Exceptions;
 using Halibut.Tests.BackwardsCompatibility.Util;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.TestServices;
-using Halibut.Tests.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.BackwardsCompatibility

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -12,11 +12,13 @@ namespace Halibut.Tests.BackwardsCompatibility
     public class TestOldClientWithNewService
     {
         [Test]
+        [TestCaseSource()]
         public async Task Listening()
         {
-            new SerilogLoggerBuilder().Build().Information("Hello");
             var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
-            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.WithListeningService().WithClientVersion(PreviousServiceVersions.v5_0_429)
+            using (var clientAndService = await PreviousClientVersionAndServiceBuilder
+                       .WithListeningService()
+                       .WithClientVersion(PreviousVersions.v5_0_429)
                        .WithEchoServiceService(echoService)
                        .Build())
             {
@@ -31,9 +33,8 @@ namespace Halibut.Tests.BackwardsCompatibility
         [Test]
         public async Task Polling()
         {
-            new SerilogLoggerBuilder().Build().Information("Hello");
             var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
-            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.WithPollingService().WithClientVersion(PreviousServiceVersions.v5_0_429)
+            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.WithPollingService().WithClientVersion(PreviousVersions.v5_0_429)
                        .WithEchoServiceService(echoService)
                        .Build())
             {

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -23,7 +23,7 @@ namespace Halibut.Tests.BackwardsCompatibility
                        .Build())
             {
                 
-                var echo = clientAndService.CreateClient<IEchoService>();
+                var echo = clientAndService.CreateClientToTheProxy<IEchoService>();
                 echo.SayHello("hello");
             }
 
@@ -40,7 +40,7 @@ namespace Halibut.Tests.BackwardsCompatibility
                        .Build())
             {
                 
-                var echo = clientAndService.CreateClient<IEchoService>();
+                var echo = clientAndService.CreateClientToTheProxy<IEchoService>();
                 echo.SayHello("hello");
             }
 

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Tests.BackwardsCompatibility.Util;
-using Halibut.Tests.Support;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.TestServices;
 using NUnit.Framework;
@@ -12,7 +11,6 @@ namespace Halibut.Tests.BackwardsCompatibility
     public class TestOldClientWithNewService
     {
         [Test]
-        [TestCaseSource()]
         public async Task Listening()
         {
             var echoService = new CallRecordingEchoServiceDecorator(new EchoService());

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Exceptions;
+using Halibut.Tests.BackwardsCompatibility.Util;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests.BackwardsCompatibility
+{
+    public class TestOldClientWithNewService
+    {
+        [Test]
+        public async Task Listening()
+        {
+            new SerilogLoggerBuilder().Build().Information("Hello");
+            var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
+            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.WithListeningService().WithClientVersion(PreviousServiceVersions.v5_0_429)
+                       .WithEchoServiceService(echoService)
+                       .Build())
+            {
+                
+                var echo = clientAndService.CreateClient<IEchoService>();
+                echo.SayHello("hello");
+            }
+
+            echoService.SayHelloCallCount.Should().Be(1);
+        }
+        
+        [Test]
+        public async Task Polling()
+        {
+            new SerilogLoggerBuilder().Build().Information("Hello");
+            var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
+            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.WithPollingService().WithClientVersion(PreviousServiceVersions.v5_0_429)
+                       .WithEchoServiceService(echoService)
+                       .Build())
+            {
+                
+                var echo = clientAndService.CreateClient<IEchoService>();
+                echo.SayHello("hello");
+            }
+
+            echoService.SayHelloCallCount.Should().Be(1);
+        }
+    }
+}

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
 using Halibut.Tests.BackwardsCompatibility.Util;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
 using NUnit.Framework;

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -54,9 +54,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Util\TcpUtils" />
-  </ItemGroup>
-
+  
 </Project>

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -55,4 +55,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Util\TcpUtils" />
+  </ItemGroup>
+
 </Project>

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -18,8 +18,8 @@ namespace Halibut.Tests
         {
             new object[] { ServiceConnectionType.Polling, null },
             new object[] { ServiceConnectionType.Listening, null },
-            new object[] { ServiceConnectionType.Polling, PreviousServiceVersions.v5_0_236_Used_In_Tentacle_6_3_417 },
-            new object[] { ServiceConnectionType.Listening, PreviousServiceVersions.v5_0_236_Used_In_Tentacle_6_3_417 }
+            new object[] { ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417 },
+            new object[] { ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417 }
         };
 
         [Test]

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryPath.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryPath.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Halibut.Tests.Support.BackwardsCompatibility
+{
+    public class HalibutTestBinaryPath
+    {
+        public string BinPath(string version)
+        {
+            var onDiskVersion = version.Replace(".", "_");
+            var assemblyDir = new DirectoryInfo(Path.GetDirectoryName(typeof(HalibutTestBinaryRunner).Assembly.Location)!);
+            var upAt = assemblyDir.Parent.Parent.Parent.Parent;
+            var projectName = $"Halibut.TestUtils.CompatBinary.v{onDiskVersion}";
+            var executable = Path.Combine(upAt.FullName, projectName, assemblyDir.Parent.Parent.Name, assemblyDir.Parent.Name, assemblyDir.Name, projectName);
+            executable = AddExeForWindows(executable);
+            if (!File.Exists(executable))
+            {
+                throw new Exception("Could not executable at path:\n" +
+                                    executable + "\n" +
+                                    $"Did you forget to update the csproj to depend on {projectName}\n" +
+                                    "If testing a previously untested version of Halibut a new project may be required.");
+            }
+
+            return executable;
+        }
+        
+        string AddExeForWindows(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return path + ".exe";
+            return path;
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using Octopus.Shellfish;
 using Serilog;
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -29,7 +29,6 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.serviceCertAndThumbprint = serviceCertAndThumbprint;
             this.version = version;
         }
-
         public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version) :
             this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version)
         {
@@ -41,32 +40,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             this.webSocketServiceEndpointUri = webSocketServiceEndpointUri;
         }
-
-        string BinaryDir(string version)
-        {
-            var onDiskVersion = version.Replace(".", "_");
-            var assemblyDir = new DirectoryInfo(Path.GetDirectoryName(typeof(HalibutTestBinaryRunner).Assembly.Location)!);
-            var upAt = assemblyDir.Parent.Parent.Parent.Parent;
-            var projectName = $"Halibut.TestUtils.CompatBinary.v{onDiskVersion}";
-            var executable = Path.Combine(upAt.FullName, projectName, assemblyDir.Parent.Parent.Name, assemblyDir.Parent.Name, assemblyDir.Name, projectName);
-            executable = AddExeForWindows(executable);
-            if (!File.Exists(executable))
-            {
-                throw new Exception("Could not executable at path:\n" +
-                                    executable + "\n" +
-                                    $"Did you forget to update the csproj to depend on {projectName}\n" +
-                                    "If testing a previously untested version of Halibut a new project may be required.");
-            }
-
-            return executable;
-        }
-
-        string AddExeForWindows(string path)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return path + ".exe";
-            return path;
-        }
-
+        
         public async Task<RunningOldHalibutBinary> Run()
         {
             var envs = new Dictionary<string, string>();
@@ -123,7 +97,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
                     };
 
-                    ShellExecutor.ExecuteCommand(BinaryDir(version),
+                    ShellExecutor.ExecuteCommand(new HalibutTestBinaryPath().BinPath(version),
                         "",
                         tmp.FullPath,
                         processLogs,

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -74,10 +74,6 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
             var client = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
             client.Trust(serviceCertAndThumbprint.Thumbprint);
 
-            var realService2 = ClientServiceBuilder.ForMode(serviceConnectionType)
-                .WithService<IEchoService>(() => echoService)
-                .Build();
-            
             var tentacle = new HalibutRuntimeBuilder()
                 .WithServiceFactory(new DelegateServiceFactory().Register<IEchoService>(() => echoService))
                 .WithServerCertificate(serviceCertAndThumbprint.Certificate2)

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;
+using Halibut.Tests.Support;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
+using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+
+namespace Halibut.Tests.BackwardsCompatibility.Util
+{
+    /// <summary>
+    /// Used to test old versions of a client talking to a new version of service.
+    /// In this case the client is run out of process, and talks to a service running
+    /// in this process.
+    /// </summary>
+    public class PreviousClientVersionAndServiceBuilder
+    {
+        readonly ServiceConnectionType serviceConnectionType;
+        readonly CertAndThumbprint serviceCertAndThumbprint;
+        readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
+        string version = "5.0.429";
+
+        IEchoService echoService = new EchoService();
+
+        PreviousClientVersionAndServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
+        {
+            this.serviceConnectionType = serviceConnectionType;
+            this.serviceCertAndThumbprint = serviceCertAndThumbprint;
+        }
+
+        public static PreviousClientVersionAndServiceBuilder WithPollingService()
+        {
+            return new PreviousClientVersionAndServiceBuilder(ServiceConnectionType.Polling, CertAndThumbprint.TentaclePolling);
+        }
+
+        public static PreviousClientVersionAndServiceBuilder WithListeningService()
+        {
+            return new PreviousClientVersionAndServiceBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
+        }
+
+        public static PreviousClientVersionAndServiceBuilder ForServiceConnectionType(ServiceConnectionType connectionType)
+        {
+            switch (connectionType)
+            {
+                case ServiceConnectionType.Polling:
+                    return WithPollingService();
+                case ServiceConnectionType.Listening:
+                    return WithListeningService();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(connectionType), connectionType, null);
+            }
+        }
+
+        public PreviousClientVersionAndServiceBuilder WithClientVersion(string version)
+        {
+            this.version = version;
+            return this;
+        }
+
+        public PreviousClientVersionAndServiceBuilder WithEchoServiceService(IEchoService echoService)
+        {
+            this.echoService = echoService;
+            return this;
+        }
+
+        public async Task<ClientAndService> Build()
+        {
+            
+            // We need to build both a Client and a service.
+            if (version == null) throw new Exception("The version of the service must be set.");
+            var client = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
+            client.Trust(serviceCertAndThumbprint.Thumbprint);
+
+            var realService2 = ClientServiceBuilder.ForMode(serviceConnectionType)
+                .WithService<IEchoService>(() => echoService)
+                .Build();
+            
+            var tentacle = new HalibutRuntimeBuilder()
+                .WithServiceFactory(new DelegateServiceFactory().Register<IEchoService>(() => echoService))
+                .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
+                .WithLogFactory(new TestContextLogFactory("Tentacle"))
+                .Build();
+
+            Uri proxyServiceUri;
+            ProxyHalibutTestBinaryRunner.RoundTripRunningOldHalibutBinary runningOldHalibutBinary;
+            if (serviceConnectionType == ServiceConnectionType.Polling)
+            {
+                var clientListenPort = client.Listen();
+                runningOldHalibutBinary = await new ProxyHalibutTestBinaryRunner(serviceConnectionType, clientListenPort, clientCertAndThumbprint, serviceCertAndThumbprint, new Uri("poll://SQ-TENTAPOLL"), version).Run();
+                proxyServiceUri = new Uri("poll://SQ-TENTAPOLL");
+                // TODO support this.
+                
+                tentacle.Poll(proxyServiceUri, new ServiceEndPoint(new Uri("https://localhost:" + runningOldHalibutBinary.proxyClientListenPort), clientCertAndThumbprint.Thumbprint));
+            }
+            else
+            {
+                var port = tentacle.Listen();
+                tentacle.Trust(clientCertAndThumbprint.Thumbprint);
+                runningOldHalibutBinary = await new ProxyHalibutTestBinaryRunner(serviceConnectionType, null, clientCertAndThumbprint, serviceCertAndThumbprint, new Uri("https://localhost:" + port), version).Run();
+                proxyServiceUri = new Uri("https://localhost:" + runningOldHalibutBinary.serviceListenPort);
+            }
+
+            return new ClientAndService(client, runningOldHalibutBinary, proxyServiceUri, serviceCertAndThumbprint, tentacle);
+        }
+
+        public class ClientAndService : IDisposable
+        {
+            readonly HalibutRuntime octopus;
+            readonly ProxyHalibutTestBinaryRunner.RoundTripRunningOldHalibutBinary runningOldHalibutBinary;
+            readonly Uri serviceUri;
+            readonly CertAndThumbprint serviceCertAndThumbprint; // for creating a client
+            readonly HalibutRuntime tentacle;
+
+            public ClientAndService(HalibutRuntime octopus,
+                ProxyHalibutTestBinaryRunner.RoundTripRunningOldHalibutBinary runningOldHalibutBinary,
+                Uri serviceUri,
+                CertAndThumbprint serviceCertAndThumbprint,
+                HalibutRuntime tentacle)
+            {
+                this.octopus = octopus;
+                this.runningOldHalibutBinary = runningOldHalibutBinary;
+                this.serviceUri = serviceUri;
+                this.serviceCertAndThumbprint = serviceCertAndThumbprint;
+                this.tentacle = tentacle;
+            }
+
+            public TService CreateClient<TService>()
+            {
+                return CreateClient<TService>(s => { }, CancellationToken.None);
+            }
+
+            public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint)
+            {
+                return CreateClient<TService>(modifyServiceEndpoint, CancellationToken.None);
+            }
+
+            public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            {
+                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                modifyServiceEndpoint(serviceEndpoint);
+                return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
+            }
+            
+            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
+            {
+                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                modifyServiceEndpoint(serviceEndpoint);
+                return octopus.CreateClient<TService, TClientService>(serviceEndpoint);
+            }
+
+            public void Dispose()
+            {
+                octopus.Dispose();
+                runningOldHalibutBinary.Dispose();
+                tentacle.Dispose();
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -124,28 +124,31 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
                 this.tentacle = tentacle;
             }
 
-            public TService CreateClient<TService>()
+            /// <summary>
+            /// Creates a client, which forwards RPC calls on to a proxy in a external process which will make those calls back
+            /// to service in the this process.
+            /// </summary>
+            /// <typeparam name="TService"></typeparam>
+            /// <returns></returns>
+            public TService CreateClientToTheProxy<TService>()
             {
-                return CreateClient<TService>(s => { }, CancellationToken.None);
+                return CreateClientToTheProxy<TService>(s => { }, CancellationToken.None);
             }
 
-            public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint)
-            {
-                return CreateClient<TService>(modifyServiceEndpoint, CancellationToken.None);
-            }
 
-            public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
+            /// <summary>
+            /// This probably never makes sense to be called, since this modifies the client to the proxy client. If a test
+            /// wanted to set these it is probably setting them on the wrong client
+            /// </summary>
+            /// <param name="modifyServiceEndpoint"></param>
+            /// <param name="cancellationToken"></param>
+            /// <typeparam name="TService"></typeparam>
+            /// <returns></returns>
+            private TService CreateClientToTheProxy<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
             {
                 var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
                 modifyServiceEndpoint(serviceEndpoint);
                 return octopus.CreateClient<TService>(serviceEndpoint, cancellationToken);
-            }
-            
-            public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
-            {
-                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
-                modifyServiceEndpoint(serviceEndpoint);
-                return octopus.CreateClient<TService, TClientService>(serviceEndpoint);
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousVersions.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousVersions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Halibut.Tests.Support.BackwardsCompatibility
 {
-    public static class PreviousServiceVersions
+    public static class PreviousVersions
     {
         // Version prior to new exception types being added to Halibut. All exceptions are HalibutClientException
         public const string v5_0_429 = "5.0.429";

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -5,6 +5,8 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Util;
 using NUnit.Framework;
 using Octopus.Shellfish;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -5,17 +5,12 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Halibut.Tests.Support;
-using Halibut.Tests.Support.BackwardsCompatibility;
-using Halibut.Tests.Util;
-using NUnit.Framework;
 using Octopus.Shellfish;
 
-namespace Halibut.Tests.BackwardsCompatibility.Util
+namespace Halibut.Tests.Support.BackwardsCompatibility
 {
     public class ProxyHalibutTestBinaryRunner
     {
-        // The port the binary should poll.
         readonly ServiceConnectionType serviceConnectionType;
         readonly int? clientServicePort;
         readonly CertAndThumbprint clientCertAndThumbprint;
@@ -33,30 +28,6 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
             this.realServiceListenAddress = realServiceListenAddress;
         }
 
-        string BinaryDir(string version)
-        {
-            var onDiskVersion = version.Replace(".", "_");
-            var assemblyDir = new DirectoryInfo(Path.GetDirectoryName(typeof(HalibutTestBinaryRunner).Assembly.Location)!);
-            var upAt = assemblyDir.Parent.Parent.Parent.Parent;
-            var projectName = $"Halibut.TestUtils.CompatBinary.v{onDiskVersion}";
-            var executable = Path.Combine(upAt.FullName, projectName, assemblyDir.Parent.Parent.Name, assemblyDir.Parent.Name, assemblyDir.Name, projectName);
-            executable = AddExeForWindows(executable);
-            if (!File.Exists(executable))
-            {
-                throw new Exception("Could not executable at path:\n" +
-                                    executable + "\n" +
-                                    $"Did you forget to update the csproj to depend on {projectName}\n" +
-                                    "If testing a previously untested version of Halibut a new project may be required.");
-            }
-
-            return executable;
-        }
-
-        string AddExeForWindows(string path)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return path + ".exe";
-            return path;
-        }
 
         public async Task<RoundTripRunningOldHalibutBinary> Run()
         {
@@ -122,7 +93,7 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
                         if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
                     };
 
-                    ShellExecutor.ExecuteCommand(BinaryDir(version),
+                    ShellExecutor.ExecuteCommand(new HalibutTestBinaryPath().BinPath(version),
                         "",
                         tmp.FullPath,
                         processLogs,

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -5,13 +5,13 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Tests.Util;
 using NUnit.Framework;
 using Octopus.Shellfish;
-using Serilog;
 
-namespace Halibut.Tests.Support.BackwardsCompatibility
+namespace Halibut.Tests.BackwardsCompatibility.Util
 {
-    public class HalibutTestBinaryRunner
+    public class ProxyHalibutTestBinaryRunner
     {
         // The port the binary should poll.
         readonly ServiceConnectionType serviceConnectionType;
@@ -19,27 +19,16 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly CertAndThumbprint clientCertAndThumbprint;
         readonly CertAndThumbprint serviceCertAndThumbprint;
         readonly string version;
-        ILogger logger = new SerilogLoggerBuilder().Build().ForContext<HalibutRuntimeBuilder>();
-        readonly Uri webSocketServiceEndpointUri;
+        readonly Uri realServiceListenAddress;
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version)
+        public ProxyHalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, Uri realServiceListenAddress, string version)
         {
             this.serviceConnectionType = serviceConnectionType;
+            this.clientServicePort = clientServicePort;
             this.clientCertAndThumbprint = clientCertAndThumbprint;
             this.serviceCertAndThumbprint = serviceCertAndThumbprint;
             this.version = version;
-        }
-
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version)
-        {
-            this.clientServicePort = clientServicePort;
-        }
-
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, Uri webSocketServiceEndpointUri, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version)
-        {
-            this.webSocketServiceEndpointUri = webSocketServiceEndpointUri;
+            this.realServiceListenAddress = realServiceListenAddress;
         }
 
         string BinaryDir(string version)
@@ -67,20 +56,20 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return path;
         }
 
-        public async Task<RunningOldHalibutBinary> Run()
+        public async Task<RoundTripRunningOldHalibutBinary> Run()
         {
             var envs = new Dictionary<string, string>();
-            envs.Add("mode", "serviceonly");
+            envs.Add("mode", "proxy");
             envs.Add("tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath);
-            envs.Add("octopusthumbprint", clientCertAndThumbprint.Thumbprint);
+            envs.Add("octopuscertpath", clientCertAndThumbprint.CertificatePfxPath);
             if (clientServicePort != null)
             {
                 envs.Add("octopusservercommsport", "https://localhost:" + clientServicePort);
             }
-            else if (webSocketServiceEndpointUri != null)
+
+            if (realServiceListenAddress != null)
             {
-                envs.Add("sslthubprint", Certificates.SslThumbprint);
-                envs.Add("octopusservercommsport", webSocketServiceEndpointUri.ToString());
+                envs.Add("realServiceListenAddress", realServiceListenAddress.ToString());
             }
 
             envs.Add("ServiceConnectionType", serviceConnectionType.ToString());
@@ -91,9 +80,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             {
                 var tmp = new TmpDirectory();
 
-                var (task, serviceListenPort) = await StartHalibutTestBinary(version, envs, tmp, cts.Token);
+                var (task, serviceListenPort, proxyClientListenPort) = await StartHalibutTestBinary(version, envs, tmp, cts.Token);
 
-                return new RunningOldHalibutBinary(cts, task, tmp, serviceListenPort);
+                return new RoundTripRunningOldHalibutBinary(cts, task, tmp, serviceListenPort, proxyClientListenPort);
             }
             catch (Exception)
             {
@@ -102,12 +91,14 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             }
         }
 
-        async Task<(Task, int?)> StartHalibutTestBinary(string version, Dictionary<string, string> envs, TmpDirectory tmp, CancellationToken cancellationToken)
+        async Task<(Task, int?, int?)> StartHalibutTestBinary(string version, Dictionary<string, string> envs, TmpDirectory tmp, CancellationToken cancellationToken)
         {
             var hasTentacleStarted = new ManualResetEventSlim();
             hasTentacleStarted.Reset();
 
+            var logger = new SerilogLoggerBuilder().Build().ForContext<ProxyHalibutTestBinaryRunner>();
             int? serviceListenPort = null;
+            int? proxyClientListenPort = null;
             var runningTentacle = Task.Run(() =>
             {
                 try
@@ -117,7 +108,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         logger.Information(s);
                         if (s.StartsWith("Listening on port: "))
                         {
-                            serviceListenPort = int.Parse(Regex.Match(s, @"\d+").Value);
+                            serviceListenPort = Int32.Parse(Regex.Match(s, @"\d+").Value);
+                            logger.Information("External halibut binary listening port is: " + serviceListenPort);
+                        }
+
+                        if (s.StartsWith("Polling listener is listening on port: "))
+                        {
+                            proxyClientListenPort = Int32.Parse(Regex.Match(s, @"\d+").Value);
                         }
 
                         if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
@@ -135,7 +132,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 }
                 catch (Exception e)
                 {
-                    logger.Information(e, "Error running Halibut Test Binary");
+                    logger.Error(e, "Error waiting for external process to start");
                     throw;
                 }
             }, cancellationToken);
@@ -150,22 +147,25 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 throw new Exception("Halibut test binary did not appear to start correctly");
             }
 
-            return (runningTentacle, serviceListenPort);
+            logger.Information("External halibut binary started.");
+            return (runningTentacle, serviceListenPort, proxyClientListenPort);
         }
 
-        public class RunningOldHalibutBinary : IDisposable
+        public class RoundTripRunningOldHalibutBinary : IDisposable
         {
             readonly CancellationTokenSource cts;
             readonly Task runningOldHalibutTask;
             readonly TmpDirectory tmpDirectory;
             public readonly int? serviceListenPort;
+            public readonly int? proxyClientListenPort;
 
-            public RunningOldHalibutBinary(CancellationTokenSource cts, Task runningOldHalibutTask, TmpDirectory tmpDirectory, int? serviceListenPort)
+            public RoundTripRunningOldHalibutBinary(CancellationTokenSource cts, Task runningOldHalibutTask, TmpDirectory tmpDirectory, int? serviceListenPort, int? proxyClientListenPort)
             {
                 this.cts = cts;
                 this.runningOldHalibutTask = runningOldHalibutTask;
                 this.tmpDirectory = tmpDirectory;
                 this.serviceListenPort = serviceListenPort;
+                this.proxyClientListenPort = proxyClientListenPort;
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/TestServices/CallRecordingEchoServiceDecorator.cs
+++ b/source/Halibut.Tests/TestServices/CallRecordingEchoServiceDecorator.cs
@@ -1,0 +1,36 @@
+namespace Halibut.Tests.TestServices
+{
+    public class CallRecordingEchoServiceDecorator : IEchoService
+    {
+
+        public int SayHelloCallCount { get; set; } = 0;
+        
+        IEchoService echoService;
+
+        public CallRecordingEchoServiceDecorator(IEchoService echoService)
+        {
+            this.echoService = echoService;
+        }
+
+        public int LongRunningOperation()
+        {
+            return echoService.LongRunningOperation();
+        }
+
+        public string SayHello(string name)
+        {
+            SayHelloCallCount++;
+            return echoService.SayHello(name);
+        }
+
+        public bool Crash()
+        {
+            return echoService.Crash();
+        }
+
+        public int CountBytes(DataStream stream)
+        {
+            return echoService.CountBytes(stream);
+        }
+    }
+}

--- a/source/Halibut/ServiceModel/DelegateServiceFactory.cs
+++ b/source/Halibut/ServiceModel/DelegateServiceFactory.cs
@@ -10,7 +10,7 @@ namespace Halibut.ServiceModel
         readonly Dictionary<string, Func<object>> services = new Dictionary<string, Func<object>>(StringComparer.OrdinalIgnoreCase);
         readonly HashSet<Type> serviceTypes = new HashSet<Type>();
 
-        public void Register<TContract>(Func<TContract> implementation)
+        public DelegateServiceFactory Register<TContract>(Func<TContract> implementation)
         {
             var serviceType = typeof(TContract);
             services.Add(serviceType.Name, () => implementation());
@@ -18,6 +18,8 @@ namespace Halibut.ServiceModel
             {
                 serviceTypes.Add(serviceType);    
             }
+
+            return this;
         }
 
         public IServiceLease CreateService(string serviceName)


### PR DESCRIPTION
# Background

Adds support for testing old clients communicating with new services.

The setup is best described in this image:

![Testing old halibut client@2x (2)](https://github.com/OctopusDeploy/Halibut/assets/7076477/8f165adf-bc67-4274-9ca8-2cced5e07a64)


When Testing an old client with a new services, those tests will also happens to test new client to old service.

[SC-46260]

Since the client is in an external process, it is misleading to use `CreateClient` as the method name since configuration on that client wont work as expected e.g. a `CancellationToken` will be the CT on the top arrow of the diagram, while the test is mostly likely wanting to set that on the CT for the bottom arrow communications.

The result of the build method implements `IClientAndService`, but some methods throw since they don't make sense.

# Other changes

Also adds logging to Halibut within the external binaries to make debugging easier, for example debugging the development of this feature.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
