### PR TITLE
Split out tests from UsageFixture

### DIFF
--- a/source/Halibut.Tests/FriendlyHtmlPageTests.cs
+++ b/source/Halibut.Tests/FriendlyHtmlPageTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.Support;
+using Halibut.Tests.TestServices;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class FriendlyHtmlPageTests
+    {
+        static DelegateServiceFactory GetDelegateServiceFactory()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            return services;
+        }
+        
+        [TestCase("https://127.0.0.1:{port}")]
+        [TestCase("https://127.0.0.1:{port}/")]
+        [TestCase("https://localhost:{port}")]
+        [TestCase("https://localhost:{port}/")]
+        [TestCase("https://{machine}:{port}")]
+        [TestCase("https://{machine}:{port}/")]
+        public async Task SupportsHttpsGet(string uriFormat)
+        {
+            var services = GetDelegateServiceFactory();
+            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            {
+                var listenPort = octopus.Listen();
+                var uri = uriFormat.Replace("{machine}", Dns.GetHostName()).Replace("{port}", listenPort.ToString());
+
+                var result = await DownloadStringIgnoringCertificateValidation(uri);
+
+                result.Should().Be("<html><body><p>Hello!</p></body></html>");
+            }
+        }
+
+        [TestCase("<html><body><h1>Welcome to Octopus Server!</h1><p>It looks like everything is running just like you expected, well done.</p></body></html>", null)]
+        [TestCase("Simple text works too!", null)]
+        [TestCase("", null)]
+        [TestCase(null, "<html><body><p>Hello!</p></body></html>")]
+        public async Task CanSetCustomFriendlyHtmlPage(string html, string expectedResult = null)
+        {
+            var services = GetDelegateServiceFactory();
+            expectedResult = expectedResult ?? html; // Handle the null case which reverts to default html
+
+            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            {
+                octopus.SetFriendlyHtmlPageContent(html);
+                var listenPort = octopus.Listen();
+
+                var result = await DownloadStringIgnoringCertificateValidation("https://localhost:" + listenPort);
+
+                result.Should().Be(expectedResult);
+            }
+        }
+
+        [Test]
+        public async Task CanSetCustomFriendlyHtmlPageHeaders()
+        {
+            var services = GetDelegateServiceFactory();
+            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
+            {
+                octopus.SetFriendlyHtmlPageHeaders(new Dictionary<string, string> {{"X-Content-Type-Options", "nosniff"}, {"X-Frame-Options", "DENY"}});
+                var listenPort = octopus.Listen();
+
+                var result = await GetHeadersIgnoringCertificateValidation("https://localhost:" + listenPort);
+
+                result.Should().Contain(x => x.Key == "X-Content-Type-Options" && x.Value == "nosniff");
+                result.Should().Contain(x => x.Key == "X-Frame-Options" && x.Value == "DENY");
+            }
+        }
+
+        [Test]
+        [System.ComponentModel.Description("Connecting over a non-secure connection should cause the socket to be closed by the server. The socket used to be held open indefinitely for any failure to establish an SslStream.")]
+        public async Task ConnectingOverHttpShouldFailQuickly()
+        {
+            var logger = new SerilogLoggerBuilder().Build();
+            using (var octopus = new HalibutRuntime(GetDelegateServiceFactory(), Certificates.Octopus))
+            {
+                logger.Information("Halibut runtime created.");
+                var listenPort = octopus.Listen();
+                logger.Information("Got port to listen on..");
+                var sw = new Stopwatch();
+                Assert.ThrowsAsync<HttpRequestException>(() =>
+                {
+                    logger.Information("Sending request.");
+                    sw.Start();
+                    try
+                    {
+                        return DownloadStringIgnoringCertificateValidation("http://localhost:" + listenPort);
+                    }
+                    finally
+                    {
+                        sw.Stop();
+                    }
+                });
+
+
+                sw.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        static async Task<string> DownloadStringIgnoringCertificateValidation(string uri)
+        {
+            using (var httpClientHandler = new HttpClientHandler())
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+                using (var client = new HttpClient(httpClientHandler))
+                {
+                    return await client.GetStringAsync(uri);
+                }
+            }
+        }
+
+        static async Task<List<KeyValuePair<string, string>>> GetHeadersIgnoringCertificateValidation(string uri)
+        {
+            using (var httpClientHandler = new HttpClientHandler())
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+                using (var client = new HttpClient(httpClientHandler))
+                {
+                    var headers = new List<KeyValuePair<string, string>>();
+                    var existingServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;
+                    try
+                    {
+                        // We need to ignore server certificate validation errors - the server certificate is self-signed
+                        ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => true;
+                        var response = await client.GetAsync(uri);
+                        foreach (var key in response.Headers)
+                        {
+                            headers.Add(new KeyValuePair<string, string>(key.Key, key.Value.First()));
+                        }
+                    }
+                    finally
+                    {
+                        // And restore it back to default behaviour
+                        ServicePointManager.ServerCertificateValidationCallback = existingServerCertificateValidationCallback;
+                    }
+
+                    return headers;
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
@@ -51,5 +51,18 @@ namespace Halibut.Tests.Transport
 
             Assert.Throws<HalibutClientException>(() => client.Discover(fakeEndpoint), "No such host is known");
         }
+        
+        [Test]
+        public void OctopusCanDiscoverTentacle()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            
+            using (var clientAndService = ClientServiceBuilder.Listening().WithServiceFactory(services).Build())
+            {
+                var info = clientAndService.Octopus.Discover(clientAndService.ServiceUri);
+                info.RemoteThumbprint.Should().Be(Certificates.TentacleListeningPublicThumbprint);
+            }
+        }
     }
 }

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -1,14 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
-using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.TestServices;
@@ -18,20 +13,6 @@ namespace Halibut.Tests
 {
     public class UsageFixture
     {
-        [Test]
-        public void OctopusCanDiscoverTentacle()
-        {
-            using (var clientAndService = ClientServiceBuilder
-                       .Listening()
-                       .WithEchoService()
-                       .Build())
-            {
-                var info = clientAndService.Octopus.Discover(clientAndService.ServiceUri);
-                info.RemoteThumbprint.Should().Be(Certificates.TentacleListeningPublicThumbprint);
-            }
-        }
-
-
         [Test]
         [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
         public void OctopusCanSendMessagesToTentacle_WithEchoService(ServiceConnectionType serviceConnectionType)
@@ -230,142 +211,5 @@ namespace Halibut.Tests
                 progressReported.Should().ContainInOrder(Enumerable.Range(1, 100));
             }
         }
-
-        [TestCase("https://127.0.0.1:{port}")]
-        [TestCase("https://127.0.0.1:{port}/")]
-        [TestCase("https://localhost:{port}")]
-        [TestCase("https://localhost:{port}/")]
-        [TestCase("https://{machine}:{port}")]
-        [TestCase("https://{machine}:{port}/")]
-        public async Task SupportsHttpsGet(string uriFormat)
-        {
-            var services = GetDelegateServiceFactory();
-            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
-            {
-                var listenPort = octopus.Listen();
-                var uri = uriFormat.Replace("{machine}", Dns.GetHostName()).Replace("{port}", listenPort.ToString());
-
-                var result = await DownloadStringIgnoringCertificateValidation(uri);
-
-                result.Should().Be("<html><body><p>Hello!</p></body></html>");
-            }
-        }
-
-        [TestCase("<html><body><h1>Welcome to Octopus Server!</h1><p>It looks like everything is running just like you expected, well done.</p></body></html>", null)]
-        [TestCase("Simple text works too!", null)]
-        [TestCase("", null)]
-        [TestCase(null, "<html><body><p>Hello!</p></body></html>")]
-        public async Task CanSetCustomFriendlyHtmlPage(string html, string expectedResult = null)
-        {
-            var services = GetDelegateServiceFactory();
-            expectedResult = expectedResult ?? html; // Handle the null case which reverts to default html
-
-            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
-            {
-                octopus.SetFriendlyHtmlPageContent(html);
-                var listenPort = octopus.Listen();
-
-                var result = await DownloadStringIgnoringCertificateValidation("https://localhost:" + listenPort);
-
-                result.Should().Be(expectedResult);
-            }
-        }
-
-        [Test]
-        public async Task CanSetCustomFriendlyHtmlPageHeaders()
-        {
-            var services = GetDelegateServiceFactory();
-            using (var octopus = new HalibutRuntime(services, Certificates.Octopus))
-            {
-                octopus.SetFriendlyHtmlPageHeaders(new Dictionary<string, string> {{"X-Content-Type-Options", "nosniff"}, {"X-Frame-Options", "DENY"}});
-                var listenPort = octopus.Listen();
-
-                var result = await GetHeadersIgnoringCertificateValidation("https://localhost:" + listenPort);
-
-                result.Should().Contain(x => x.Key == "X-Content-Type-Options" && x.Value == "nosniff");
-                result.Should().Contain(x => x.Key == "X-Frame-Options" && x.Value == "DENY");
-            }
-        }
-
-        [Test]
-        [System.ComponentModel.Description("Connecting over a non-secure connection should cause the socket to be closed by the server. The socket used to be held open indefinitely for any failure to establish an SslStream.")]
-        public async Task ConnectingOverHttpShouldFailQuickly()
-        {
-            var logger = new SerilogLoggerBuilder().Build();
-            using (var octopus = new HalibutRuntime(GetDelegateServiceFactory(), Certificates.Octopus))
-            {
-                logger.Information("Halibut runtime created.");
-                var listenPort = octopus.Listen();
-                logger.Information("Got port to listen on..");
-                var sw = new Stopwatch();
-                Assert.ThrowsAsync<HttpRequestException>(() =>
-                {
-                    logger.Information("Sending request.");
-                    sw.Start();
-                    try
-                    {
-                        return DownloadStringIgnoringCertificateValidation("http://localhost:" + listenPort);
-                    }
-                    finally
-                    {
-                        sw.Stop();
-                    }
-                });
-
-
-                sw.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(5));
-            }
-        }
-
-        static DelegateServiceFactory GetDelegateServiceFactory()
-        {
-            var services = new DelegateServiceFactory();
-            services.Register<IEchoService>(() => new EchoService());
-            return services;
-        }
-
-        static async Task<string> DownloadStringIgnoringCertificateValidation(string uri)
-        {
-            using (var httpClientHandler = new HttpClientHandler())
-            {
-                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-                using (var client = new HttpClient(httpClientHandler))
-                {
-                    return await client.GetStringAsync(uri);
-                }
-            }
-        }
-
-        static async Task<List<KeyValuePair<string, string>>> GetHeadersIgnoringCertificateValidation(string uri)
-        {
-            using (var httpClientHandler = new HttpClientHandler())
-            {
-                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
-                using (var client = new HttpClient(httpClientHandler))
-                {
-                    var headers = new List<KeyValuePair<string, string>>();
-                    var existingServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;
-                    try
-                    {
-                        // We need to ignore server certificate validation errors - the server certificate is self-signed
-                        ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) => true;
-                        var response = await client.GetAsync(uri);
-                        foreach (var key in response.Headers)
-                        {
-                            headers.Add(new KeyValuePair<string, string>(key.Key, key.Value.First()));
-                        }
-                    }
-                    finally
-                    {
-                        // And restore it back to default behaviour
-                        ServicePointManager.ServerCertificateValidationCallback = existingServerCertificateValidationCallback;
-                    }
-
-                    return headers;
-                }
-            }
-        }
-
-
     }
 }


### PR DESCRIPTION
# Background

Split up tests in Usage Fixture to classes that group what the tests are doing.

[SC-53472]
[SC-53136]

# How to review this PR


Quality :heavy_check_mark:

Is it green when you review it? If so please squash and merge

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
