### PR TITLE
Polling tentacles are slow, so do less iterations with it

### DIFF
--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -9,6 +9,7 @@ using Halibut.Tests.Support;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
 using NUnit.Framework;
 using Octopus.TestPortForwarder;
 
@@ -29,7 +30,7 @@ namespace Halibut.Tests
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Deploy package A").Should().Be("Deploy package A...");
 
-                for (var i = 0; i < 2000; i++)
+                for (var i = 0; i < StandardIterationCount.ForServiceType(serviceConnectionType); i++)
                 {
                     echo.SayHello($"Deploy package A {i}").Should().Be($"Deploy package A {i}...");
                 }
@@ -48,7 +49,7 @@ namespace Halibut.Tests
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Deploy package A").Should().Be("Deploy package A...");
 
-                for (var i = 0; i < 2000; i++)
+                for (var i = 0; i < StandardIterationCount.ForServiceType(serviceConnectionType); i++)
                 {
                     echo.SayHello($"Deploy package A {i}").Should().Be($"Deploy package A {i}...");
                 }

--- a/source/Halibut.Tests/Util/StandardIterationCount.cs
+++ b/source/Halibut.Tests/Util/StandardIterationCount.cs
@@ -1,0 +1,26 @@
+using System;
+using Halibut.Tests.Support;
+
+namespace Halibut.Tests.Util
+{
+    public class StandardIterationCount
+    {
+        public static int ForServiceType(ServiceConnectionType connectionType)
+        {
+            switch (connectionType)
+            {
+                case ServiceConnectionType.Polling:
+                    // Polling is slow, we don't know why
+                    return 100;
+                case ServiceConnectionType.PollingOverWebSocket:
+                    // Assume polling over websockets is also slow
+                    return 100;
+                case ServiceConnectionType.Listening:
+                    // Listening is fast
+                    return 2000;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(connectionType), connectionType, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

These tests used to do 100 iterations with polling and 2000 with listening. We combined the test and increased the number of iterations. Turns out polling is way slower, so this makes the test times increase significantly.

This doesn't solve the underlying it is slow problem, but does workaround it with a class that determines the iteration count depending on the service type.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
