### PR TITLE
Consolidate builder method names

### DIFF
--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -55,7 +55,7 @@ namespace Halibut.Tests
         [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
         public async Task CanTalkToOldServicesWhichDontKnowAboutHalibutProxyRequestOptions(ServiceConnectionType serviceConnectionType)
         {
-            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder.WithService(serviceConnectionType).WithServiceVersion("5.0.429").Build())
+            using (var clientAndService = await ClientAndPreviousServiceVersionBuilder.ForServiceConnectionType(serviceConnectionType).WithServiceVersion("5.0.429").Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
                     {

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -146,7 +146,7 @@ namespace Halibut.Tests.Diagnostics
             public async Task BecauseTheDataStreamHadAnErrorOpeningTheFileWithFileStream_WhenSending_ItIsNotANetworkError(ServiceConnectionType serviceConnectionType)
             {
                 using (var clientAndService = await ClientServiceBuilder
-                           .ForMode(serviceConnectionType)
+                           .ForServiceConnectionType(serviceConnectionType)
                            .WithEchoService()
                            .Build())
                 {
@@ -166,7 +166,7 @@ namespace Halibut.Tests.Diagnostics
             public async Task BecauseTheDataStreamThrowAFileNotFoundException_WhenSending_ItIsNotANetworkError(ServiceConnectionType serviceConnectionType)
             {
                 using (var clientAndService = await ClientServiceBuilder
-                           .ForMode(serviceConnectionType)
+                           .ForServiceConnectionType(serviceConnectionType)
                            .WithEchoService()
                            .Build())
                 {
@@ -186,7 +186,7 @@ namespace Halibut.Tests.Diagnostics
             public async Task BecauseTheServiceThrowAnException_ItIsNotANetworkError(ServiceConnectionType serviceConnectionType)
             {
                 using (var clientAndService = await ClientServiceBuilder
-                           .ForMode(serviceConnectionType)
+                           .ForServiceConnectionType(serviceConnectionType)
                            .WithEchoService()
                            .Build())
                 {

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -46,7 +46,7 @@ namespace Halibut.Tests
         public async Task FailWhenServerThrowsAnException(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .Build())
             {
@@ -135,7 +135,7 @@ namespace Halibut.Tests
         public async Task FailWhenServerThrowsDuringADataStream(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithReadDataStreamService()
                        .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
                        .Build())

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests
             services.Register<IReadDataStreamService>(() => new ReadDataStreamService());
 
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithServiceFactory(services).Build())
             {
                 var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -209,7 +209,7 @@ namespace Halibut.Tests
         {
             return halibutServiceVersion == null ?
                 await ClientServiceBuilder
-                    .ForMode(serviceConnectionType)
+                    .ForServiceConnectionType(serviceConnectionType)
                     .WithCachingService()
                     .Build() :
                 await ClientAndPreviousServiceVersionBuilder

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
@@ -35,12 +35,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return new ClientAndPreviousServiceVersionBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
         }
 
-        public static ClientAndPreviousServiceVersionBuilder ForServiceConnectionType(ServiceConnectionType serviceConnectionType)
-        {
-            return new ClientAndPreviousServiceVersionBuilder(serviceConnectionType, CertAndThumbprint.TentacleListening);
-        }
-
-        public static ClientAndPreviousServiceVersionBuilder WithService(ServiceConnectionType connectionType)
+        public static ClientAndPreviousServiceVersionBuilder ForServiceConnectionType(ServiceConnectionType connectionType)
         {
             switch (connectionType)
             {

--- a/source/Halibut.Tests/Support/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/ClientServiceBuilder.cs
@@ -42,7 +42,7 @@ namespace Halibut.Tests.Support
             return new ClientServiceBuilder(ServiceConnectionType.Listening, CertAndThumbprint.TentacleListening);
         }
 
-        public static ClientServiceBuilder ForMode(ServiceConnectionType serviceConnectionType)
+        public static ClientServiceBuilder ForServiceConnectionType(ServiceConnectionType serviceConnectionType)
         {
             switch (serviceConnectionType)
             {

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -10,7 +10,6 @@ using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.TestServices;
 using NUnit.Framework;
-using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests
 {
@@ -21,7 +20,7 @@ namespace Halibut.Tests
         public async Task ClientCanSendMessagesToOldTentacle_WithEchoService(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientAndPreviousServiceVersionBuilder
-                       .WithService(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithServiceVersion(PreviousVersions.v5_0_429)
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
                        .Build())

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -41,7 +41,7 @@ namespace Halibut.Tests
         public async Task OctopusCanSendMessagesToTentacle_WithEchoService(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .Build())
             {
@@ -60,7 +60,7 @@ namespace Halibut.Tests
         public async Task OctopusCanSendMessagesToTentacle_WithSupportedServices(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .WithSupportedServices()
                        .Build())
@@ -101,7 +101,7 @@ namespace Halibut.Tests
         public async Task StreamsCanBeSent(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .Build())
             {
@@ -123,7 +123,7 @@ namespace Halibut.Tests
         public async Task StreamsCanBeSentWithLatency(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .WithPortForwarding(octopusPort => PortForwarderUtil.ForwardingToLocalPort(octopusPort).WithSendDelay(TimeSpan.FromMilliseconds(20)).Build())
                        .Build())
@@ -150,7 +150,7 @@ namespace Halibut.Tests
         public async Task StreamsCanBeSentWithLatencyAndTheLastNBytesArriveLate(ServiceConnectionType serviceConnectionType, int numberOfBytesToDelaySending)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .WithPortForwarding(octopusPort => PortForwarderUtil.ForwardingToLocalPort(octopusPort)
                            .WithSendDelay(TimeSpan.FromMilliseconds(20))
@@ -176,7 +176,7 @@ namespace Halibut.Tests
         public async Task SupportsDifferentServiceContractMethods(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                     .ForMode(serviceConnectionType)
+                     .ForServiceConnectionType(serviceConnectionType)
                      .WithEchoService()
                      .WithSupportedServices()
                      .Build())
@@ -216,7 +216,7 @@ namespace Halibut.Tests
         public async Task StreamsCanBeSentWithProgressReporting(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .Build())
             {

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests
             var services = new SingleServiceFactory(new object(), typeof(EchoService));
 
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithServiceFactory(services)
                        .Build())
             {

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests
         public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -15,7 +15,7 @@ namespace Halibut.Tests
         public async Task AResponseShouldBeQuicklyReturned(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForMode(serviceConnectionType)
+                       .ForServiceConnectionType(serviceConnectionType)
                        .WithPortForwarding(out var portForwarder)
                        .WithDoSomeActionService(() => portForwarder.Value.Dispose())
                        .Build())


### PR DESCRIPTION
Rename the `ForMode` method to `ForServiceType`, for consistency.