### PR TITLE
Create a Standard set of test services, which will make it easier to align all client service builders.

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
@@ -46,9 +46,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 Console.WriteLine($"Will poll: {addressToPoll}");
             }
 
-            var services = new DelegateServiceFactory();
-            services.Register<IEchoService>(() => new EchoService());
-            services.Register<ICachingService>(() => new CachingService());
+            var services = ServiceFactoryFactory.CreateServiceFactory();
 
             using (var tentaclePolling = new HalibutRuntimeBuilder()
                        .WithServiceFactory(services)

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -107,7 +107,5 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
             return 1;
         }
-
-        
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -76,11 +76,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
                 var realServiceEndpoint = new ServiceEndPoint(realServiceUri, serviceCert.Thumbprint);
 
-                var forwardingEchoService = client.CreateClient<IEchoService>(realServiceEndpoint);
-
-                // Connects as service to the client.
-                var services = new DelegateServiceFactory();
-                services.Register<IEchoService>(() => new DelegateEchoService(forwardingEchoService));
+                var services = ServiceFactoryFactory.CreateProxyingServicesServiceFactory(client, realServiceEndpoint);
                 using (var proxyService = new HalibutRuntimeBuilder()
                            .WithServiceFactory(services)
                            .WithServerCertificate(serviceCert)
@@ -111,5 +107,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
             return 1;
         }
+
+        
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -1,0 +1,37 @@
+using Halibut.ServiceModel;
+using Halibut.TestUtils.SampleProgram.Base.Services;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class ServiceFactoryFactory
+    {
+        /// <summary>
+        /// Used when this external binary has the service.
+        /// ie Old/Previous Service.
+        /// </summary>
+        /// <returns></returns>
+        public static DelegateServiceFactory CreateServiceFactory()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            services.Register<ICachingService>(() => new CachingService());
+            services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
+            return services;
+        }
+        
+        /// <summary>
+        /// Used when the test CLR has the services
+        /// ie Old/Previous Client calling latest services.
+        /// </summary>
+        /// <param name="clientWhichTalksToLatestHalibut"></param>
+        /// <param name="realServiceEndpoint"></param>
+        /// <returns></returns>
+        public static DelegateServiceFactory CreateProxyingServicesServiceFactory(HalibutRuntime clientWhichTalksToLatestHalibut, ServiceEndPoint realServiceEndpoint)
+        {
+            var forwardingEchoService = clientWhichTalksToLatestHalibut.CreateClient<IEchoService>(realServiceEndpoint);
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new DelegateEchoService(forwardingEchoService));
+            return services;
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/IMultipleParametersTestService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/IMultipleParametersTestService.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Halibut.TestUtils.SampleProgram.Base.Services
+{
+    public class MapLocation
+    {
+        public int Latitude { get; set; }
+        
+        public int Longitude { get; set; }
+    }
+    
+    public interface IMultipleParametersTestService
+    {
+        void MethodReturningVoid(long a, long b);
+
+        long Add(long a, long b);
+        double Add(double a, double b);
+        decimal Add(decimal a, decimal b);
+
+        string Hello();
+        string Hello(string a);
+        string Hello(string a, string b);
+        string Hello(string a, string b, string c);
+        string Hello(string a, string b, string c, string d);
+        string Hello(string a, string b, string c, string d, string e);
+        string Hello(string a, string b, string c, string d, string e, string f);
+        string Hello(string a, string b, string c, string d, string e, string f, string g);
+        string Hello(string a, string b, string c, string d, string e, string f, string g, string h);
+        string Hello(string a, string b, string c, string d, string e, string f, string g, string h, string i);
+        string Hello(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j);
+        string Hello(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k);
+
+        string Ambiguous(string a, string b);
+        string Ambiguous(string a, Tuple<string, string> b);
+
+        MapLocation GetLocation(MapLocation loc);
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/MultipleParametersTestService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/MultipleParametersTestService.cs
@@ -1,0 +1,102 @@
+using System;
+
+namespace Halibut.TestUtils.SampleProgram.Base.Services
+{
+    public class MultipleParametersTestService : IMultipleParametersTestService
+    {
+        public void MethodReturningVoid(long a, long b)
+        {
+        }
+
+        public long Add(long a, long b)
+        {
+            return a + b;
+        }
+
+        public double Add(double a, double b)
+        {
+            return a + b;
+        }
+
+        public decimal Add(decimal a, decimal b)
+        {
+            return a + b;
+        }
+
+        public string Hello()
+        {
+            return "Hello";
+        }
+
+        public string Hello(string a)
+        {
+            return "Hello " + a;
+        }
+
+        public string Hello(string a, string b)
+        {
+            return "Hello " + string.Join(" ", a, b);
+        }
+
+        public string Hello(string a, string b, string c)
+        {
+            return "Hello " + string.Join(" ", a, b, c);
+        }
+
+        public string Hello(string a, string b, string c, string d)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e, string f)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e, f);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e, string f, string g)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e, f, g);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e, string f, string g, string h)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e, string f, string g, string h, string i)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h, i);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h, i, j);
+        }
+
+        public string Hello(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k)
+        {
+            return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h, i, j, k);
+        }
+
+        public string Ambiguous(string a, string b)
+        {
+            return "Hello string";
+        }
+
+        public string Ambiguous(string a, Tuple<string, string> b)
+        {
+            return "Hello tuple";
+        }
+
+        public MapLocation GetLocation(MapLocation loc)
+        {
+            // Swap the latitude and longitude for the round trip verification... never know where you will end up! 
+            return new MapLocation { Latitude = loc.Longitude, Longitude = loc.Latitude };
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
@@ -62,6 +62,14 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        public ClientAndPreviousServiceVersionBuilder WithStandardServices()
+        {
+            // TODO: EchoService is registered by default, so we don't need to do anything else here.
+            // It would be better to be able to configure the Tentacle binary to register/not register
+            // specific services, but we'll do that later.
+            return this;
+        }
+
         public async Task<IClientAndService> Build()
         {
             if (version == null)

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -82,6 +82,7 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
             client.Trust(serviceCertAndThumbprint.Thumbprint);
 
             var tentacle = new HalibutRuntimeBuilder()
+                // TODO register the other
                 .WithServiceFactory(new DelegateServiceFactory().Register<IEchoService>(() => echoService))
                 .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                 .WithLogFactory(new TestContextLogFactory("Tentacle"))

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -94,7 +94,6 @@ namespace Halibut.Tests.BackwardsCompatibility.Util
             client.Trust(serviceCertAndThumbprint.Thumbprint);
 
             var tentacle = new HalibutRuntimeBuilder()
-                // TODO register the other
                 .WithServiceFactory(new DelegateServiceFactory()
                     .Register(() => echoService)
                     .Register(() => cachingService)

--- a/source/Halibut.Tests/Support/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/ClientServiceBuilder.cs
@@ -89,6 +89,10 @@ namespace Halibut.Tests.Support
             return WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port).Build());
         }
 
+        public ClientServiceBuilder WithStandardServices()
+        {
+            return this.WithEchoService().WithMultipleParametersTestService().WithCachingService();
+        }
         public ClientServiceBuilder WithPortForwarding(out Reference<PortForwarder> portForwarder)
         {
             this.WithPortForwarding();

--- a/source/Halibut.Tests/Support/ClientServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/ClientServiceBuilderExtensionMethods.cs
@@ -10,9 +10,9 @@ namespace Halibut.Tests.Support
             return builder.WithService<IEchoService>(() => new EchoService());
         }
 
-        public static ClientServiceBuilder WithSupportedServices(this ClientServiceBuilder builder)
+        public static ClientServiceBuilder WithMultipleParametersTestService(this ClientServiceBuilder builder)
         {
-            return builder.WithService<ISupportedServices>(() => new SupportedServices());
+            return builder.WithService<IMultipleParametersTestService>(() => new MultipleParametersTestService());
         }
 
         public static ClientServiceBuilder WithDoSomeActionService(this ClientServiceBuilder builder, Action action)

--- a/source/Halibut.Tests/TestServices/IMultipleParametersTestService.cs
+++ b/source/Halibut.Tests/TestServices/IMultipleParametersTestService.cs
@@ -10,7 +10,7 @@ namespace Halibut.Tests.TestServices
         public int Longitude { get; set; }
     }
     
-    public interface ISupportedServices
+    public interface IMultipleParametersTestService
     {
         void MethodReturningVoid(long a, long b);
 

--- a/source/Halibut.Tests/TestServices/MultipleParametersTestService.cs
+++ b/source/Halibut.Tests/TestServices/MultipleParametersTestService.cs
@@ -2,7 +2,7 @@
 
 namespace Halibut.Tests.TestServices
 {
-    public class SupportedServices : ISupportedServices
+    public class MultipleParametersTestService : IMultipleParametersTestService
     {
         public void MethodReturningVoid(long a, long b)
         {

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -81,7 +81,6 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                        .Polling()
                        .WithStandardServices()
-                       //WithSupportedServices()
                        .Build()){
 
                 // This is here to exercise the path where the Listener's (web socket) handle loop has the protocol (with type serializer) built before the type is registered
@@ -100,9 +99,9 @@ namespace Halibut.Tests
         public async Task StreamsCanBeSent(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                                              .ForServiceConnectionType(serviceConnectionType)
-                                              .WithStandardServices()
-                                              .Build())
+                      .ForServiceConnectionType(serviceConnectionType)
+                      .WithStandardServices()
+                      .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
 

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -62,10 +62,10 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
-                       .WithSupportedServices()
+                       .WithMultipleParametersTestService()
                        .Build())
             {
-                var svc = clientAndService.CreateClient<ISupportedServices>();
+                var svc = clientAndService.CreateClient<IMultipleParametersTestService>();
                 for (var i = 1; i < 100; i++)
                 {
                     {
@@ -82,7 +82,7 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                        .Polling()
                        .WithEchoService()
-                       .WithSupportedServices()
+                       .WithMultipleParametersTestService()
                        .Build()){
 
                 // This is here to exercise the path where the Listener's (web socket) handle loop has the protocol (with type serializer) built before the type is registered
@@ -90,7 +90,7 @@ namespace Halibut.Tests
                 // This must come before CreateClient<ISupportedServices> for the situation to occur
                 echo.SayHello("Deploy package A").Should().Be("Deploy package A" + "...");
 
-                var svc = clientAndService.CreateClient<ISupportedServices>();
+                var svc = clientAndService.CreateClient<IMultipleParametersTestService>();
                 // This must happen before the message loop in MessageExchangeProtocol restarts (timeout, exception, or end) for the error to occur
                 svc.GetLocation(new MapLocation { Latitude = -27, Longitude = 153 }).Should().Match<MapLocation>(x => x.Latitude == 153 && x.Longitude == -27);
             }
@@ -178,10 +178,10 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                      .ForServiceConnectionType(serviceConnectionType)
                      .WithEchoService()
-                     .WithSupportedServices()
+                     .WithMultipleParametersTestService()
                      .Build())
             {
-                var echo = clientAndService.CreateClient<ISupportedServices>();
+                var echo = clientAndService.CreateClient<IMultipleParametersTestService>();
                 echo.MethodReturningVoid(12, 14);
 
                 echo.Hello().Should().Be("Hello");

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -42,7 +42,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
-                       .WithEchoService()
+                       .WithStandardServices()
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -61,8 +61,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
-                       .WithEchoService()
-                       .WithMultipleParametersTestService()
+                       .WithStandardServices()
                        .Build())
             {
                 var svc = clientAndService.CreateClient<IMultipleParametersTestService>();
@@ -81,8 +80,8 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await ClientServiceBuilder
                        .Polling()
-                       .WithEchoService()
-                       .WithMultipleParametersTestService()
+                       .WithStandardServices()
+                       //WithSupportedServices()
                        .Build()){
 
                 // This is here to exercise the path where the Listener's (web socket) handle loop has the protocol (with type serializer) built before the type is registered
@@ -101,9 +100,9 @@ namespace Halibut.Tests
         public async Task StreamsCanBeSent(ServiceConnectionType serviceConnectionType)
         {
             using (var clientAndService = await ClientServiceBuilder
-                       .ForServiceConnectionType(serviceConnectionType)
-                       .WithEchoService()
-                       .Build())
+                                              .ForServiceConnectionType(serviceConnectionType)
+                                              .WithStandardServices()
+                                              .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
 
@@ -177,8 +176,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await ClientServiceBuilder
                      .ForServiceConnectionType(serviceConnectionType)
-                     .WithEchoService()
-                     .WithMultipleParametersTestService()
+                     .WithStandardServices()
                      .Build())
             {
                 var echo = clientAndService.CreateClient<IMultipleParametersTestService>();
@@ -217,7 +215,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
-                       .WithEchoService()
+                       .WithStandardServices()
                        .Build())
             {
                 var progressReported = new List<int>();

--- a/source/Halibut.Tests/WebSocketUsageFixture.cs
+++ b/source/Halibut.Tests/WebSocketUsageFixture.cs
@@ -17,15 +17,14 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await ClientServiceBuilder
                        .PollingOverWebSocket()
-                       .WithService<IEchoService>(() => new EchoService())
-                       .WithService<ISupportedServices>(() => new SupportedServices())
+                       .WithStandardServices()
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
                 // This must come before CreateClient<ISupportedServices> for the situation to occur
                 echo.SayHello("Deploy package A").Should().Be("Deploy package A" + "...");
 
-                var svc = clientAndService.CreateClient<ISupportedServices>();
+                var svc = clientAndService.CreateClient<IMultipleParametersTestService>();
                 // This must happen before the message loop in MessageExchangeProtocol restarts (timeout, exception, or end) for the error to occur
                 svc.GetLocation(new MapLocation { Latitude = -27, Longitude = 153 }).Should().Match<MapLocation>(x => x.Latitude == 153 && x.Longitude == -27);
             }
@@ -37,11 +36,11 @@ namespace Halibut.Tests
 
             using (var clientAndService = await ClientServiceBuilder
                        .PollingOverWebSocket()
-                       .WithService<ISupportedServices>(() => new SupportedServices())
+                       .WithStandardServices()
                        .Build())
             {
 
-                var svc = clientAndService.CreateClient<ISupportedServices>();
+                var svc = clientAndService.CreateClient<IMultipleParametersTestService>();
                 for (var i = 1; i < 100; i++)
                 {
                     var i1 = i;


### PR DESCRIPTION
# Background

We would like to be able to have a single interface for all three of our Client Service builders. To simplify the compatibility bins this PR adds a concept of a standard set of services available to all Client Service builders. The result is that tests can just ask for the standard set of services which will just work no matter what Client Service builder is being used.

[SC-53455]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
