### PR TITLE
Add Proxy support to the Previous Client Version and Previous Service Version Builders

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Halibut.TestUtils.SampleProgram.Base.LogUtils;
 
@@ -9,46 +8,38 @@ namespace Halibut.TestUtils.SampleProgram.Base
     /// <summary>
     /// Creates a Proxy Service which forwards requests to another halibut client, which itself
     /// makes requests to a service such as one running in the test CLR.
-    /// 
+    ///
     /// This is used when testing the compatibility of a old client with latest service, since this
     /// has the old client which is making requests to the new service in the test CLR.
-    /// The Proxy 
+    /// The Proxy
     /// </summary>
     public class ProxyServiceForwardingRequestToClient
     {
-        public static int Run(string[] args)
+        public static async Task Run()
         {
-            var tentacleCertPath = Environment.GetEnvironmentVariable("tentaclecertpath");
-            Console.WriteLine($"Using tentacle cert path: {tentacleCertPath}");
-            var serviceCert = new X509Certificate2(tentacleCertPath);
-            
-            Console.WriteLine("Tentacle/service cert details " + serviceCert);
+            var serviceCert = SettingsHelper.GetServiceCertificate();
+            var clientCert = SettingsHelper.GetClientCertificate();
+            Console.WriteLine($"This should be bob: {clientCert}");
 
-            
-            var octopusCertPath = Environment.GetEnvironmentVariable("octopuscertpath");
-            Console.WriteLine($"Using octopus cert path: {octopusCertPath}");
-            var clientCert = new X509Certificate2(octopusCertPath);
-            Console.WriteLine("Octopus/Client cert details " + clientCert);
-            
+            var serviceConnectionType = SettingsHelper.GetServiceConnectionType();
+            var proxyDetails = SettingsHelper.GetProxyDetails();
 
-            ServiceConnectionType serviceConnectionType = BackwardsCompatProgramBase.ServiceConnectionTypeFromString(Environment.GetEnvironmentVariable("ServiceConnectionType"));
             string addressToPoll = null;
             if (serviceConnectionType == ServiceConnectionType.Polling)
             {
-                addressToPoll = Environment.GetEnvironmentVariable("octopusservercommsport");
+                addressToPoll = SettingsHelper.GetSetting("octopusservercommsport");
                 Console.WriteLine($"Will poll: {addressToPoll}");
             }
 
-            string serivceAddressToConnectTo = null; 
+            string serviceAddressToConnectTo = null;
             if (serviceConnectionType == ServiceConnectionType.Listening)
             {
-                serivceAddressToConnectTo = Environment.GetEnvironmentVariable("realServiceListenAddress");
-                Console.WriteLine($"Will forward request to: {serivceAddressToConnectTo}");
+                serviceAddressToConnectTo = SettingsHelper.GetSetting("realServiceListenAddress");
+                Console.WriteLine($"Will forward request to: {serviceAddressToConnectTo}");
             }
-            
-            // Create a client which will send RPC calls to the service in the Test CLR.
-            Console.WriteLine("This should be bob:");
-            Console.WriteLine(clientCert.ToString());
+
+            // A Halibut Runtime which is the previous version of Halibut the Test is trying to test.
+            // This will communicate with the Halibut Service created in the Test Process (the Tentacle were trying to test against)
             using (var client = new HalibutRuntimeBuilder()
                        .WithServerCertificate(clientCert)
                        .WithLogFactory(new TestContextLogFactory("ProxyClient"))
@@ -58,8 +49,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 Console.WriteLine("Client will trust: " + serviceCert.Thumbprint);
                 client.Trust(serviceCert.Thumbprint);
 
-                
-                Uri realServiceUri = null;
+                Uri realServiceUri;
                 switch (serviceConnectionType)
                 {
                     case ServiceConnectionType.Polling:
@@ -68,13 +58,13 @@ namespace Halibut.TestUtils.SampleProgram.Base
                         realServiceUri = new Uri("poll://SQ-TENTAPOLL");
                         break;
                     case ServiceConnectionType.Listening:
-                        realServiceUri = new Uri(serivceAddressToConnectTo);
+                        realServiceUri = new Uri(serviceAddressToConnectTo!);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
 
-                var realServiceEndpoint = new ServiceEndPoint(realServiceUri, serviceCert.Thumbprint);
+                var realServiceEndpoint = new ServiceEndPoint(realServiceUri, serviceCert.Thumbprint, proxyDetails);
 
                 var services = ServiceFactoryFactory.CreateProxyingServicesServiceFactory(client, realServiceEndpoint);
                 using (var proxyService = new HalibutRuntimeBuilder()
@@ -86,7 +76,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     switch (serviceConnectionType)
                     {
                         case ServiceConnectionType.Polling:
-                            proxyService.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll), clientCert.Thumbprint));
+                            proxyService.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll!), clientCert.Thumbprint));
                             break;
                         case ServiceConnectionType.Listening:
                             var port = proxyService.Listen();
@@ -99,13 +89,13 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
                     Console.WriteLine("RunningAndReady");
                     Console.WriteLine("Will Now sleep");
-                    Console.Out.Flush();
-                    // Now sleep until the processes is killed externally.
-                    Thread.Sleep(1000000);
+
+                    await Console.Out.FlushAsync();
+
+                    // Run until the Program is terminated
+                    await Task.Delay(-1);
                 }
             }
-
-            return 1;
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceConnectionType.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceConnectionType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public enum ServiceConnectionType
+    {
+        Polling,
+        PollingOverWebSocket,
+        Listening
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using Halibut.Transport.Proxy;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    static class SettingsHelper
+    {
+        public static ProxyDetails GetProxyDetails()
+        {
+            var host = GetSetting("proxydetails_host");
+
+            if (!string.IsNullOrWhiteSpace(host))
+            {
+                var password = GetSetting("proxydetails_password");
+                var userName = GetSetting("proxydetails_username");
+                var port = GetSetting("proxydetails_port");
+                var type = GetSetting("proxydetails_type");
+
+                Console.WriteLine($"Using Proxy Details Hot:{host} Port:{port} Type:{type} Username:{userName} Password:{password}");
+
+                return new ProxyDetails(host, AsInt(port), AsPortType(type), userName, password);
+
+                ProxyType AsPortType(string s)
+                {
+                    return (ProxyType)Enum.Parse(typeof(ProxyType), s);
+                }
+
+                int AsInt(string s)
+                {
+                    return int.Parse(s);
+                }
+            }
+
+            Console.WriteLine("Not using a Proxy");
+            return null;
+        }
+
+        public static string GetSetting(string name)
+        {
+            return Environment.GetEnvironmentVariable(name);
+        }
+
+        public static ServiceConnectionType GetServiceConnectionType()
+        {
+            return AsServiceConnectionType(GetSetting("ServiceConnectionType"));
+        }
+
+        public static X509Certificate2 GetClientCertificate()
+        {
+            var octopusCertPath = GetSetting("octopuscertpath");
+            Console.WriteLine($"Using octopus cert path: {octopusCertPath}");
+            var clientCert = new X509Certificate2(octopusCertPath);
+            Console.WriteLine("Octopus/Client cert details " + clientCert);
+
+            return clientCert;
+        }
+
+        public static string GetClientThumbprint()
+        {
+            var thumbprint = GetSetting("octopusthumbprint");
+            Console.WriteLine($"Using octopus thumbprint: {thumbprint}");
+
+            return thumbprint;
+        }
+
+        public static X509Certificate2 GetServiceCertificate()
+        {
+            var tentacleCertPath = GetSetting("tentaclecertpath");
+            Console.WriteLine($"Using tentacle cert path: {tentacleCertPath}");
+            var serviceCert = new X509Certificate2(tentacleCertPath);
+            Console.WriteLine("Tentacle/service cert details " + serviceCert);
+
+            return serviceCert;
+        }
+
+        static ServiceConnectionType AsServiceConnectionType(string s)
+        {
+            if (Enum.TryParse(s, out ServiceConnectionType serviceConnectionType))
+            {
+                return serviceConnectionType;
+            }
+
+            throw new Exception($"Unknown service type '{s}'");
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_236/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_236/Program.cs
@@ -1,13 +1,13 @@
-﻿using System;
+﻿using System.Threading.Tasks;
 using Halibut.TestUtils.SampleProgram.Base;
 
 namespace Halibut.TestUtils.SampleProgram.v5_0_237
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main()
         {
-           return BackwardsCompatProgramBase.Main(args);
+           return await BackwardsCompatProgramBase.Main();
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_429/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_429/Program.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using Halibut.Diagnostics;
+﻿using System.Threading.Tasks;
 using Halibut.TestUtils.SampleProgram.Base;
 
 namespace Halibut.TestUtils.SampleProgram.v5_0_429
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main()
         {
-            return BackwardsCompatProgramBase.Main(args);
+            return await BackwardsCompatProgramBase.Main();
         }
     }
 }

--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Tests.BackwardsCompatibility.Util;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestAttributes;
@@ -22,7 +21,7 @@ namespace Halibut.Tests.BackwardsCompatibility
                        .WithEchoServiceService(echoService)
                        .Build())
             {
-                
+
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("hello");
             }

--- a/source/Halibut.Tests/Support/IClientAndService.cs
+++ b/source/Halibut.Tests/Support/IClientAndService.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Threading;
+using Halibut.TestProxy;
 using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests.Support
@@ -9,6 +10,7 @@ namespace Halibut.Tests.Support
     {
         HalibutRuntime Octopus { get; }
         PortForwarder? PortForwarder { get; }
+        HttpProxyService? Proxy { get; }
         TService CreateClient<TService>(CancellationToken? cancellationToken = null, string? remoteThumbprint = null);
         TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint);
         TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken, string? remoteThumbprint = null);


### PR DESCRIPTION
# Background

Added support for using a Proxy to the ClientAndPreviousServiceVersionBuilder and PreviousClientVersionAndServiceBuilder

.... and a little bit of code clean-up as well!!

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
