### PR TITLE
Add portforwarder to PreviousClientVersionAndServiceBuilder

### DIFF
--- a/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/TestOldClientWithNewService.cs
@@ -29,5 +29,24 @@ namespace Halibut.Tests.BackwardsCompatibility
 
             echoService.SayHelloCallCount.Should().Be(1);
         }
+        
+        [Test]
+        [TestCaseSource(typeof(ServiceConnectionTypesToTestExcludingWebSockets))]
+        public async Task SimplePreviousClientTestWithLatency(ServiceConnectionType serviceConnectionType)
+        {
+            var echoService = new CallRecordingEchoServiceDecorator(new EchoService());
+            using (var clientAndService = await PreviousClientVersionAndServiceBuilder.ForServiceConnectionType(serviceConnectionType)
+                       .WithClientVersion(PreviousVersions.v5_0_429)
+                       .WithEchoServiceService(echoService)
+                       .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port).WithSendDelay(TimeSpan.FromMilliseconds(20)).Build())
+                       .Build())
+            {
+                
+                var echo = clientAndService.CreateClient<IEchoService>();
+                echo.SayHello("hello");
+            }
+
+            echoService.SayHelloCallCount.Should().Be(1);
+        }
     }
 }


### PR DESCRIPTION
# Background

This will allow changing the network conditions in this backwards compatibility testing.

This brings us one step closer to aligning all the Client Service builders. 

[SC-53455]

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
