### PR TITLE
Adds a receive message timeout test

### DIFF
--- a/source/Halibut.Tests/TimeoutsFixture.cs
+++ b/source/Halibut.Tests/TimeoutsFixture.cs
@@ -6,9 +6,7 @@ using Halibut.Diagnostics;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.TestServices;
-using Halibut.Tests.Util;
 using NUnit.Framework;
-using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests
 {
@@ -16,9 +14,8 @@ namespace Halibut.Tests
     {
         [Test]
         [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
-        public async Task ReadingARequestMes(ServiceConnectionType serviceConnectionType)
+        public async Task ReadingARequestMessage(ServiceConnectionType serviceConnectionType)
         {
-            
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithPortForwarding(out var portForwarderRef)
@@ -29,20 +26,19 @@ namespace Halibut.Tests
                 portForwarderRef.Value = clientAndService.PortForwarder;
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
-                
+
                 var pauseConnections = clientAndService.CreateClient<IDoSomeActionService>(point =>
                 {
                     // We don't want to measure the polling queue timeouts.
                     point.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromMinutes(10);
                     point.PollingRequestQueueTimeout = TimeSpan.FromMinutes(10);
                 });
-                
+
                 var sw = Stopwatch.StartNew();
                 var e = Assert.Throws<HalibutClientException>(() => pauseConnections.Action());
                 sw.Stop();
                 new SerilogLoggerBuilder().Build().Error(e, "msg");
                 sw.Elapsed.Should().BeCloseTo(HalibutLimits.TcpClientReceiveTimeout, TimeSpan.FromSeconds(5));
-
             }
         }
     }

--- a/source/Halibut.Tests/TimeoutsFixture.cs
+++ b/source/Halibut.Tests/TimeoutsFixture.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.Util;
+using NUnit.Framework;
+using Octopus.TestPortForwarder;
+
+namespace Halibut.Tests
+{
+    public class TimeoutsFixture
+    {
+        [Test]
+        [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
+        public async Task ReadingARequestMes(ServiceConnectionType serviceConnectionType)
+        {
+            
+            using (var clientAndService = await ClientServiceBuilder
+                       .ForServiceConnectionType(serviceConnectionType)
+                       .WithPortForwarding(out var portForwarderRef)
+                       .WithEchoService()
+                       .WithDoSomeActionService(() => portForwarderRef.Value.PauseExistingConnections())
+                       .Build())
+            {
+                portForwarderRef.Value = clientAndService.PortForwarder;
+                var echo = clientAndService.CreateClient<IEchoService>();
+                echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
+                
+                var pauseConnections = clientAndService.CreateClient<IDoSomeActionService>(point =>
+                {
+                    // We don't want to measure the polling queue timeouts.
+                    point.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromMinutes(10);
+                    point.PollingRequestQueueTimeout = TimeSpan.FromMinutes(10);
+                });
+                
+                var sw = Stopwatch.StartNew();
+                var e = Assert.Throws<HalibutClientException>(() => pauseConnections.Action());
+                sw.Stop();
+                new SerilogLoggerBuilder().Build().Error(e, "msg");
+                sw.Elapsed.Should().BeCloseTo(HalibutLimits.TcpClientReceiveTimeout, TimeSpan.FromSeconds(5));
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

We need tests around timeout before making everything async, since async method on streams behave differently with timeouts.

[SC-53157]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
