### PR TITLE
Fix HttpProxyService Disposal and Logs Causing Teamcity to Hang

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -33,6 +33,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -84,6 +85,7 @@
               "CopyToLocalPackages",
               "Default",
               "Pack",
+              "PackTestPortForwarder",
               "Restore",
               "TestLinux",
               "TestWindows"
@@ -105,6 +107,7 @@
               "CopyToLocalPackages",
               "Default",
               "Pack",
+              "PackTestPortForwarder",
               "Restore",
               "TestLinux",
               "TestWindows"

--- a/source/Halibut.TestProxy/ProxyConnection.cs
+++ b/source/Halibut.TestProxy/ProxyConnection.cs
@@ -18,7 +18,7 @@ namespace Halibut.TestProxy
     {
         readonly ProxyEndpoint destinationEndpoint;
         readonly ILogger<ProxyConnection> logger;
-        readonly List<TcpTunnel> tunnels = new();
+        List<TcpTunnel>? tunnels = new();
         readonly SemaphoreSlim sync = new(1);
 
         public ProxyConnection(ProxyEndpoint destinationEndpoint, ILogger<ProxyConnection> logger)
@@ -33,13 +33,16 @@ namespace Halibut.TestProxy
 
             try
             {
-                if (source.Client.RemoteEndPoint is not IPEndPoint sourceRemoteEndpoint) throw new InvalidOperationException($"{source.Client.RemoteEndPoint} is not an {nameof(IPEndPoint)}");
+                if (source.Client.RemoteEndPoint is not IPEndPoint sourceRemoteEndpoint)
+                {
+                    throw new InvalidOperationException($"{source.Client.RemoteEndPoint} is not an {nameof(IPEndPoint)}");
+                }
 
                 var sourceEndpoint = new ProxyEndpoint(sourceRemoteEndpoint.Address.ToString(), sourceRemoteEndpoint.Port);
                 var destination = new TcpClient(destinationEndpoint.Hostname, destinationEndpoint.Port);
                 var tunnel = new TcpTunnel(source, destination);
 
-                tunnels.Add(tunnel);
+                tunnels!.Add(tunnel);
 
                 // We kick the tunneling to a background task so that we can await for it close and cleanup
                 _ = Task.Run<Task>(async () =>
@@ -55,9 +58,6 @@ namespace Halibut.TestProxy
                     catch (Exception ex)
                     {
                         logger.LogWarning(ex, "An error has occurred in proxy connection - {SourceEndpoint} <-> {DestinationEndpoint}", sourceEndpoint, destinationEndpoint);
-                    }
-                    finally
-                    {
                         tunnels.Remove(tunnel);
                         tunnel.Dispose();
                     }
@@ -71,13 +71,13 @@ namespace Halibut.TestProxy
 
         public void Dispose()
         {
-            var allTunnels = tunnels.ToList();
-
-            foreach (var tunnel in allTunnels)
+            foreach (var tunnel in tunnels!)
             {
                 tunnels.Remove(tunnel);
                 tunnel.Dispose();
             }
+
+            tunnels = null;
 
             sync.Dispose();
         }

--- a/source/Halibut.TestProxy/ProxyEndpoint.cs
+++ b/source/Halibut.TestProxy/ProxyEndpoint.cs
@@ -3,26 +3,5 @@ using System.Text.RegularExpressions;
 
 namespace Halibut.TestProxy
 {
-    record ProxyEndpoint(string Hostname, int Port)
-    {
-        static Regex ParseRegex = new Regex("(?<hostname>[\\S]+):(?<port>\\d+)", RegexOptions.Compiled);
-
-        public override string ToString()
-        {
-            return $"{Hostname}:{Port}";
-        }
-
-        public static ProxyEndpoint Parse(string endpoint)
-        {
-            var match = ParseRegex.Match(endpoint);
-            if (match.Success)
-            {
-                var hostname = match.Groups["hostname"].Value;
-
-                return new ProxyEndpoint(match.Groups["hostname"].Value, int.Parse(match.Groups["port"].Value));
-            }
-
-            throw new ArgumentException($"Endpoint '{endpoint}' could not be parsed");
-        }
-    }
+    record ProxyEndpoint(string Hostname, int Port);
 }

--- a/source/Halibut.TestProxy/TcpListenerHelpers.cs
+++ b/source/Halibut.TestProxy/TcpListenerHelpers.cs
@@ -10,7 +10,7 @@ namespace Halibut.TestProxy
 {
     public static class TcpListenerHelpers
     {
-        static Regex ListenParseRegex = new Regex("(?<hostname>[\\S]+):(?<port>\\d+)", RegexOptions.Compiled);
+        static readonly Regex ListenParseRegex = new("(?<hostname>[\\S]+):(?<port>\\d+)", RegexOptions.Compiled);
 
         public static async Task<TcpListener> GetTcpListener(string listenEndpoint)
         {

--- a/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
@@ -49,7 +49,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             using (var tentaclePolling = new HalibutRuntimeBuilder()
                        .WithServiceFactory(services)
                        .WithServerCertificate(serviceCert)
-                       .WithLogFactory(new TestContextLogFactory("ExternalService"))
+                       .WithLogFactory(new TestContextLogFactory("ExternalService", SettingsHelper.GetHalibutLogLevel()))
                        .Build())
             {
                 switch (serviceConnectionType)

--- a/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextConnectionLog.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextConnectionLog.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Halibut.Diagnostics;
-
+using Halibut.Logging;
 
 namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
 {
@@ -10,11 +10,13 @@ namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
     {
         readonly string endpoint;
         readonly string name;
+        readonly LogLevel logLevel;
 
-        public TestContextConnectionLog(string endpoint, string name)
+        public TestContextConnectionLog(string endpoint, string name, LogLevel logLevel)
         {
             this.endpoint = endpoint;
             this.name = name;
+            this.logLevel = logLevel;
         }
 
         public void Write(EventType type, string message, params object[] args)
@@ -34,8 +36,30 @@ namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
 
         void WriteInternal(LogEvent logEvent)
         {
-            var logMessage = string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEvent.Type, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name);
-            Console.WriteLine(logMessage);
+            var logEventLogLevel = GetLogLevel(logEvent);
+
+            if (logEventLogLevel >= logLevel)
+            {
+                var logMessage = string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEvent.Type, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name);
+                Console.WriteLine(logMessage);
+            }
+        }
+
+        static LogLevel GetLogLevel(LogEvent logEvent)
+        {
+            switch (logEvent.Type)
+            {
+                case EventType.Error:
+                    return LogLevel.Error;
+                case EventType.Diagnostic:
+                case EventType.SecurityNegotiation:
+                case EventType.MessageExchange:
+                    return LogLevel.Trace;
+                case EventType.OpeningNewConnection:
+                    return LogLevel.Debug;
+                default:
+                    return LogLevel.Info;
+            }
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextLogFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/LogUtils/TestContextLogFactory.cs
@@ -3,20 +3,22 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Halibut.Diagnostics;
-
+using Halibut.Logging;
 
 namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
 {
     public class TestContextLogFactory : ILogFactory
     {
         readonly string name;
-        readonly ConcurrentDictionary<string, TestContextConnectionLog> events = new ConcurrentDictionary<string, TestContextConnectionLog>();
-        readonly HashSet<Uri> endpoints = new HashSet<Uri>();
-        readonly HashSet<string> prefixes = new HashSet<string>();
+        readonly LogLevel logLevel;
+        readonly ConcurrentDictionary<string, TestContextConnectionLog> events = new();
+        readonly HashSet<Uri> endpoints = new();
+        readonly HashSet<string> prefixes = new();
 
-        public TestContextLogFactory(string name)
+        public TestContextLogFactory(string name, LogLevel logLevel)
         {
             this.name = name;
+            this.logLevel = logLevel;
         }
 
         public Uri[] GetEndpoints()
@@ -36,14 +38,14 @@ namespace Halibut.TestUtils.SampleProgram.Base.LogUtils
             endpoint = NormalizeEndpoint(endpoint);
             lock (endpoints)
                 endpoints.Add(endpoint);
-            return events.GetOrAdd(endpoint.ToString(), e => new TestContextConnectionLog(endpoint.ToString(), name));
+            return events.GetOrAdd(endpoint.ToString(), e => new TestContextConnectionLog(endpoint.ToString(), name, logLevel));
         }
 
         public ILog ForPrefix(string prefix)
         {
             lock (prefixes)
                 prefixes.Add(prefix);
-            return events.GetOrAdd(prefix, e => new TestContextConnectionLog(prefix, name));
+            return events.GetOrAdd(prefix, e => new TestContextConnectionLog(prefix, name, logLevel));
         }
 
         static Uri NormalizeEndpoint(Uri endpoint)

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -42,7 +42,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             // This will communicate with the Halibut Service created in the Test Process (the Tentacle were trying to test against)
             using (var client = new HalibutRuntimeBuilder()
                        .WithServerCertificate(clientCert)
-                       .WithLogFactory(new TestContextLogFactory("ProxyClient"))
+                       .WithLogFactory(new TestContextLogFactory("ProxyClient", SettingsHelper.GetHalibutLogLevel()))
                        .Build())
             {
                 Console.WriteLine("Next line should be: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D");
@@ -70,7 +70,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 using (var proxyService = new HalibutRuntimeBuilder()
                            .WithServiceFactory(services)
                            .WithServerCertificate(serviceCert)
-                           .WithLogFactory(new TestContextLogFactory("ProxyService"))
+                           .WithLogFactory(new TestContextLogFactory("ProxyService", SettingsHelper.GetHalibutLogLevel()))
                            .Build())
                 {
                     switch (serviceConnectionType)

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -60,9 +60,9 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public static X509Certificate2 GetClientCertificate()
         {
             var octopusCertPath = GetSetting("octopuscertpath");
-            Console.WriteLine($"Using octopus cert path: {octopusCertPath}");
+            //Console.WriteLine($"Using octopus cert path: {octopusCertPath}");
             var clientCert = new X509Certificate2(octopusCertPath);
-            Console.WriteLine("Octopus/Client cert details " + clientCert);
+            //Console.WriteLine("Octopus/Client cert details " + clientCert);
 
             return clientCert;
         }
@@ -70,7 +70,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public static string GetClientThumbprint()
         {
             var thumbprint = GetSetting("octopusthumbprint");
-            Console.WriteLine($"Using octopus thumbprint: {thumbprint}");
+            //Console.WriteLine($"Using octopus thumbprint: {thumbprint}");
 
             return thumbprint;
         }
@@ -78,9 +78,9 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public static X509Certificate2 GetServiceCertificate()
         {
             var tentacleCertPath = GetSetting("tentaclecertpath");
-            Console.WriteLine($"Using tentacle cert path: {tentacleCertPath}");
+            //Console.WriteLine($"Using tentacle cert path: {tentacleCertPath}");
             var serviceCert = new X509Certificate2(tentacleCertPath);
-            Console.WriteLine("Tentacle/service cert details " + serviceCert);
+            //Console.WriteLine("Tentacle/service cert details " + serviceCert);
 
             return serviceCert;
         }

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
+using Halibut.Logging;
 using Halibut.Transport.Proxy;
 
 namespace Halibut.TestUtils.SampleProgram.Base
@@ -44,6 +45,16 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public static ServiceConnectionType GetServiceConnectionType()
         {
             return AsServiceConnectionType(GetSetting("ServiceConnectionType"));
+        }
+
+        public static LogLevel GetHalibutLogLevel()
+        {
+            return AsLogLevel(GetSetting("halibutloglevel"));
+
+            LogLevel AsLogLevel(string s)
+            {
+                return (LogLevel)Enum.Parse(typeof(LogLevel), s);
+            }
         }
 
         public static X509Certificate2 GetClientCertificate()

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
+using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
@@ -138,6 +139,8 @@ namespace Halibut.Tests
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithReadDataStreamService()
                        .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
+                       // This test is very noisy for the test logs
+                       .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .Build())
             {
                 var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
@@ -21,6 +22,7 @@ namespace Halibut.Tests
 
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .WithServiceFactory(services).Build())
             {
                 var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
@@ -75,18 +75,18 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
-        //public ClientAndPreviousServiceVersionBuilder WithProxy()
-        //{
-        //    this.proxyFactory = () =>
-        //    {
-        //        var options = new HttpProxyOptions();
-        //        var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
+        public ClientAndPreviousServiceVersionBuilder WithProxy()
+        {
+            this.proxyFactory = () =>
+            {
+                var options = new HttpProxyOptions();
+                var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
 
-        //        return new HttpProxyService(options, loggerFactory);
-        //    };
+                return new HttpProxyService(options, loggerFactory);
+            };
 
-        //    return this;
-        //}
+            return this;
+        }
 
         public async Task<IClientAndService> Build()
         {
@@ -247,11 +247,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public void Dispose()
             {
                 cancellationTokenSource?.Cancel();
-                cancellationTokenSource?.Dispose();
                 Octopus.Dispose();
                 Proxy?.Dispose();
                 runningOldHalibutBinary.Dispose();
                 disposableCollection.Dispose();
+                cancellationTokenSource?.Dispose();
             }
         }
     }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ClientAndPreviousServiceVersionBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Logging;
 using Halibut.TestProxy;
 using Halibut.Transport.Proxy;
 using Octopus.TestPortForwarder;
@@ -18,6 +19,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         Func<int, PortForwarder> portForwarderFactory;
         Func<HttpProxyService>? proxyFactory;
         CancellationTokenSource cancellationTokenSource = new();
+        LogLevel halibutLogLevel;
 
         ClientAndPreviousServiceVersionBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -88,6 +90,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        public ClientAndPreviousServiceVersionBuilder WithHalibutLoggingLevel(LogLevel halibutLogLevel)
+        {
+            this.halibutLogLevel = halibutLogLevel;
+
+            return this;
+        }
+
         public async Task<IClientAndService> Build()
         {
             if (version == null)
@@ -130,7 +139,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     clientCertAndThumbprint,
                     serviceCertAndThumbprint,
                     version,
-                    proxyDetails).Run();
+                    proxyDetails,
+                    halibutLogLevel).Run();
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
@@ -158,7 +168,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     clientCertAndThumbprint,
                     serviceCertAndThumbprint,
                     version,
-                    proxyDetails).Run();
+                    proxyDetails,
+                    halibutLogLevel).Run();
             }
             else if (serviceConnectionType == ServiceConnectionType.Listening)
             {
@@ -167,7 +178,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     clientCertAndThumbprint,
                     serviceCertAndThumbprint,
                     version,
-                    proxyDetails).Run();
+                    proxyDetails,
+                    halibutLogLevel).Run();
 
                 int listenPort = (int)runningOldHalibutBinary.ServiceListenPort!;
                 if (portForwarder != null) listenPort = portForwarder.ListeningPort;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Logging;
 using Octopus.Shellfish;
 using Serilog;
 
@@ -17,25 +18,27 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly CertAndThumbprint serviceCertAndThumbprint;
         readonly string version;
         readonly ProxyDetails? proxyDetails;
+        readonly LogLevel halibutLogLevel;
         readonly ILogger logger = new SerilogLoggerBuilder().Build().ForContext<HalibutRuntimeBuilder>();
         readonly Uri webSocketServiceEndpointUri;
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails)
+        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails, LogLevel halibutLogLevel)
         {
             this.serviceConnectionType = serviceConnectionType;
             this.clientCertAndThumbprint = clientCertAndThumbprint;
             this.serviceCertAndThumbprint = serviceCertAndThumbprint;
             this.version = version;
             this.proxyDetails = proxyDetails;
+            this.halibutLogLevel = halibutLogLevel;
         }
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails)
+        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails proxyDetails, LogLevel halibutLoggingLevel) :
+            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel)
         {
             this.clientServicePort = clientServicePort;
         }
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, Uri webSocketServiceEndpointUri, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails)
+        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, Uri webSocketServiceEndpointUri, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails, LogLevel halibutLoggingLevel) :
+            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel)
         {
             this.webSocketServiceEndpointUri = webSocketServiceEndpointUri;
         }
@@ -46,7 +49,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             {
                 { "mode", "serviceonly" },
                 { "tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath },
-                { "octopusthumbprint", clientCertAndThumbprint.Thumbprint }
+                { "octopusthumbprint", clientCertAndThumbprint.Thumbprint },
+                { "halibutloglevel", halibutLogLevel.ToString() }
             };
 
             if (proxyDetails != null)

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
 using Halibut.Tests.TestServices;
@@ -28,6 +29,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         ICachingService cachingService = new CachingService();
         IMultipleParametersTestService multipleParametersTestService = new MultipleParametersTestService();
         Func<int, PortForwarder>? portForwarderFactory;
+        LogLevel halibutLogLevel;
 
         PreviousClientVersionAndServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -101,6 +103,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        public PreviousClientVersionAndServiceBuilder WithHalibutLoggingLevel(LogLevel halibutLogLevel)
+        {
+            this.halibutLogLevel = halibutLogLevel;
+
+            return this;
+        }
+
         public async Task<ClientAndService> Build()
         {
             if (version == null)
@@ -120,7 +129,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     .Register(() => cachingService)
                     .Register(() => multipleParametersTestService))
                 .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
-                .WithLogFactory(new TestContextLogFactory("Tentacle"))
+                .WithLogFactory(new TestContextLogFactory("Tentacle", halibutLogLevel))
                 .Build();
 
             PortForwarder? portForwarder = null;
@@ -148,7 +157,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     serviceCertAndThumbprint,
                     new Uri("poll://SQ-TENTAPOLL"),
                     version,
-                    proxyDetails).Run();
+                    proxyDetails,
+                    halibutLogLevel).Run();
 
                 proxyServiceUri = new Uri("poll://SQ-TENTAPOLL");
 
@@ -170,7 +180,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     serviceCertAndThumbprint,
                     new Uri("https://localhost:" + listenPort),
                     version,
-                    proxyDetails).Run();
+                    proxyDetails,
+                    halibutLogLevel).Run();
 
                 proxyServiceUri = new Uri("https://localhost:" + runningOldHalibutBinary.ServiceListenPort);
             }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndServiceBuilder.cs
@@ -88,18 +88,18 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
-        //public PreviousClientVersionAndServiceBuilder WithProxy()
-        //{
-        //    this.proxyFactory = () =>
-        //    {
-        //        var options = new HttpProxyOptions();
-        //        var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
+        public PreviousClientVersionAndServiceBuilder WithProxy()
+        {
+            this.proxyFactory = () =>
+            {
+                var options = new HttpProxyOptions();
+                var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
 
-        //        return new HttpProxyService(options, loggerFactory);
-        //    };
+                return new HttpProxyService(options, loggerFactory);
+            };
 
-        //    return this;
-        //}
+            return this;
+        }
 
         public async Task<ClientAndService> Build()
         {
@@ -267,13 +267,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public void Dispose()
             {
                 cancellationTokenSource?.Cancel();
-                cancellationTokenSource?.Dispose();
                 Octopus.Dispose();
                 runningOldHalibutBinary.Dispose();
                 tentacle.Dispose();
                 disposableCollection.Dispose();
                 Proxy?.Dispose();
                 PortForwarder?.Dispose();
+                cancellationTokenSource?.Dispose();
             }
         }
     }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Logging;
 using Octopus.Shellfish;
 
 namespace Halibut.Tests.Support.BackwardsCompatibility
@@ -15,16 +16,17 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly CertAndThumbprint serviceCertAndThumbprint;
         readonly string version;
         readonly ProxyDetails proxyDetails;
+        readonly LogLevel halibutLogLevel;
         readonly Uri realServiceListenAddress;
 
-        public ProxyHalibutTestBinaryRunner(
-            ServiceConnectionType serviceConnectionType,
+        public ProxyHalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType,
             int? clientServicePort,
             CertAndThumbprint clientCertAndThumbprint,
             CertAndThumbprint serviceCertAndThumbprint,
             Uri realServiceListenAddress,
             string version,
-            ProxyDetails proxyDetails)
+            ProxyDetails proxyDetails,
+            LogLevel halibutLogLevel)
         {
             this.serviceConnectionType = serviceConnectionType;
             this.clientServicePort = clientServicePort;
@@ -32,9 +34,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.serviceCertAndThumbprint = serviceCertAndThumbprint;
             this.version = version;
             this.proxyDetails = proxyDetails;
+            this.halibutLogLevel = halibutLogLevel;
             this.realServiceListenAddress = realServiceListenAddress;
         }
-
 
         public async Task<RoundTripRunningOldHalibutBinary> Run()
         {
@@ -42,7 +44,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             {
                 { "mode", "proxy" },
                 { "tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath },
-                { "octopuscertpath", clientCertAndThumbprint.CertificatePfxPath }
+                { "octopuscertpath", clientCertAndThumbprint.CertificatePfxPath },
+                { "halibutloglevel", halibutLogLevel.ToString() }
             };
 
             if (proxyDetails != null)

--- a/source/Halibut.Tests/Support/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/ClientServiceBuilder.cs
@@ -114,18 +114,18 @@ namespace Halibut.Tests.Support
             return this;
         }
 
-        //public ClientServiceBuilder WithProxy()
-        //{
-        //    this.proxyFactory = () =>
-        //    {
-        //        var options = new HttpProxyOptions();
-        //        var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
+        public ClientServiceBuilder WithProxy()
+        {
+            this.proxyFactory = () =>
+            {
+                var options = new HttpProxyOptions();
+                var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
 
-        //        return new HttpProxyService(options, loggerFactory);
-        //    };
+                return new HttpProxyService(options, loggerFactory);
+            };
 
-        //    return this;
-        //}
+            return this;
+        }
 
         public ClientServiceBuilder WithPendingRequestQueueFactory(Func<ILogFactory, IPendingRequestQueueFactory> pendingRequestQueueFactory)
         {
@@ -320,12 +320,12 @@ namespace Halibut.Tests.Support
             public void Dispose()
             {
                 cancellationTokenSource?.Cancel();
-                cancellationTokenSource?.Dispose();
                 Octopus.Dispose();
                 Tentacle?.Dispose();
                 Proxy?.Dispose();
                 PortForwarder?.Dispose();
                 disposableCollection.Dispose();
+                cancellationTokenSource?.Dispose();
             }
         }
     }

--- a/source/Halibut.Tests/Support/ClientServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/ClientServiceBuilder.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
+using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
 using Halibut.Transport.Proxy;
@@ -25,6 +26,7 @@ namespace Halibut.Tests.Support
         Func<RetryPolicy>? pollingReconnectRetryPolicy;
         Func<HttpProxyService>? proxyFactory;
         readonly CancellationTokenSource cancellationTokenSource = new();
+        LogLevel halibutLogLevel = LogLevel.Trace;
 
         public ClientServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -139,12 +141,19 @@ namespace Halibut.Tests.Support
             return this;
         }
 
+        public ClientServiceBuilder WithHalibutLoggingLevel(LogLevel halibutLogLevel)
+        {
+            this.halibutLogLevel = halibutLogLevel;
+
+            return this;
+        }
+
         public async Task<ClientAndService> Build()
         {
             await Task.CompletedTask;
             serviceFactory ??= new DelegateServiceFactory();
 
-            var octopusLogFactory = new TestContextLogFactory("Client");
+            var octopusLogFactory = new TestContextLogFactory("Client", halibutLogLevel);
             var octopusBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(clientCertAndThumbprint.Certificate2)
                 .WithLogFactory(octopusLogFactory);
@@ -163,7 +172,7 @@ namespace Halibut.Tests.Support
                 var tentacleBuilder = new HalibutRuntimeBuilder()
                     .WithServiceFactory(serviceFactory)
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
-                    .WithLogFactory(new TestContextLogFactory("Service"));
+                    .WithLogFactory(new TestContextLogFactory("Service", halibutLogLevel));
 
                 if(pollingReconnectRetryPolicy != null) tentacleBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);
                 tentacle = tentacleBuilder.Build();

--- a/source/Halibut.Tests/Support/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests/Support/TestContextConnectionLog.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Halibut.Diagnostics;
 using Halibut.Logging;
-using NUnit.Framework;
 using ILog = Halibut.Diagnostics.ILog;
 
 namespace Halibut.Tests.Support
@@ -12,11 +11,13 @@ namespace Halibut.Tests.Support
     {
         readonly string endpoint;
         readonly string name;
+        readonly LogLevel logLevel;
 
-        public TestContextConnectionLog(string endpoint, string name)
+        public TestContextConnectionLog(string endpoint, string name, LogLevel logLevel)
         {
             this.endpoint = endpoint;
             this.name = name;
+            this.logLevel = logLevel;
         }
 
         public void Write(EventType type, string message, params object[] args)
@@ -36,11 +37,14 @@ namespace Halibut.Tests.Support
 
         void WriteInternal(LogEvent logEvent)
         {
-            var logLevel = GetLogLevel(logEvent);
+            var logEventLogLevel = GetLogLevel(logEvent);
 
-            new SerilogLoggerBuilder().Build()
-                .ForContext<TestContextConnectionLog>()
-                .Information(string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name));
+            if (logEventLogLevel >= logLevel)
+            {
+                new SerilogLoggerBuilder().Build()
+                    .ForContext<TestContextConnectionLog>()
+                    .Information(string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEventLogLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name));
+            }
         }
 
         static LogLevel GetLogLevel(LogEvent logEvent)

--- a/source/Halibut.Tests/Support/TestContextLogFactory.cs
+++ b/source/Halibut.Tests/Support/TestContextLogFactory.cs
@@ -3,19 +3,23 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Halibut.Diagnostics;
+using Halibut.Logging;
+using ILog = Halibut.Diagnostics.ILog;
 
 namespace Halibut.Tests.Support
 {
     public class TestContextLogFactory : ILogFactory
     {
         readonly string name;
-        readonly ConcurrentDictionary<string, TestContextConnectionLog> events = new ConcurrentDictionary<string, TestContextConnectionLog>();
-        readonly HashSet<Uri> endpoints = new HashSet<Uri>();
-        readonly HashSet<string> prefixes = new HashSet<string>();
+        readonly LogLevel logLevel;
+        readonly ConcurrentDictionary<string, TestContextConnectionLog> events = new();
+        readonly HashSet<Uri> endpoints = new();
+        readonly HashSet<string> prefixes = new();
 
-        public TestContextLogFactory(string name)
+        public TestContextLogFactory(string name, LogLevel logLevel)
         {
             this.name = name;
+            this.logLevel = logLevel;
         }
 
         public Uri[] GetEndpoints()
@@ -35,14 +39,14 @@ namespace Halibut.Tests.Support
             endpoint = NormalizeEndpoint(endpoint);
             lock (endpoints)
                 endpoints.Add(endpoint);
-            return events.GetOrAdd(endpoint.ToString(), e => new TestContextConnectionLog(endpoint.ToString(), name));
+            return events.GetOrAdd(endpoint.ToString(), e => new TestContextConnectionLog(endpoint.ToString(), name, logLevel));
         }
 
         public ILog ForPrefix(string prefix)
         {
             lock (prefixes)
                 prefixes.Add(prefix);
-            return events.GetOrAdd(prefix, e => new TestContextConnectionLog(prefix, name));
+            return events.GetOrAdd(prefix, e => new TestContextConnectionLog(prefix, name, logLevel));
         }
 
         static Uri NormalizeEndpoint(Uri endpoint)

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
+using Halibut.Logging;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestAttributes;
@@ -25,6 +26,7 @@ namespace Halibut.Tests
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithServiceVersion(PreviousVersions.v5_0_429)
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -44,6 +46,7 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithStandardServices()
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -70,23 +73,26 @@ namespace Halibut.Tests
                        await PreviousClientVersionAndServiceBuilder
                            .ForServiceConnectionType(serviceConnectionType)
                            .WithClientVersion(clientVersion)
+                           .WithHalibutLoggingLevel(LogLevel.Info)
                            .WithProxy()
                            .Build() : serviceVersion != null ?
                        await ClientAndPreviousServiceVersionBuilder
                            .ForServiceConnectionType(serviceConnectionType)
                            .WithServiceVersion(serviceVersion)
+                           .WithHalibutLoggingLevel(LogLevel.Info)
                            .WithProxy()
                            .Build()
                        : await ClientServiceBuilder
                            .ForServiceConnectionType(serviceConnectionType)
-                           .WithProxy()
                            .WithEchoService()
+                           .WithHalibutLoggingLevel(LogLevel.Info)
+                           .WithProxy()
                            .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Deploy package A").Should().Be("Deploy package A...");
 
-                for (var i = 0; i < StandardIterationCount.ForServiceType(serviceConnectionType); i++)
+                for (var i = 0; i < 10; i++)
                 {
                     echo.SayHello($"Deploy package A {i}").Should().Be($"Deploy package A {i}...");
                 }
@@ -107,17 +113,20 @@ namespace Halibut.Tests
                        await PreviousClientVersionAndServiceBuilder
                            .ForServiceConnectionType(serviceConnectionType)
                            .WithClientVersion(clientVersion)
+                           .WithHalibutLoggingLevel(LogLevel.Info)
                            .WithProxy()
                            .Build() : serviceVersion != null ?
                        await ClientAndPreviousServiceVersionBuilder
                            .ForServiceConnectionType(serviceConnectionType)
                            .WithServiceVersion(serviceVersion)
+                           .WithHalibutLoggingLevel(LogLevel.Info)
                            .WithProxy()
                            .Build()
                        : await ClientServiceBuilder
                            .ForServiceConnectionType(serviceConnectionType)
-                           .WithProxy()
                            .WithEchoService()
+                           .WithHalibutLoggingLevel(LogLevel.Info)
+                           .WithProxy()
                            .Build())
             {
                 await clientAndService.Proxy!.StopAsync(CancellationToken.None);
@@ -135,6 +144,7 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithStandardServices()
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
             {
                 var svc = clientAndService.CreateClient<IMultipleParametersTestService>();
@@ -174,6 +184,7 @@ namespace Halibut.Tests
             using (var clientAndService = await ClientServiceBuilder
                       .ForServiceConnectionType(serviceConnectionType)
                       .WithStandardServices()
+                      .WithHalibutLoggingLevel(LogLevel.Info)
                       .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -197,6 +208,7 @@ namespace Halibut.Tests
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithEchoService()
                        .WithPortForwarding(octopusPort => PortForwarderUtil.ForwardingToLocalPort(octopusPort).WithSendDelay(TimeSpan.FromMilliseconds(20)).Build())
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -227,6 +239,7 @@ namespace Halibut.Tests
                            .WithSendDelay(TimeSpan.FromMilliseconds(20))
                            .WithNumberOfBytesToDelaySending(numberOfBytesToDelaySending)
                            .Build())
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -56,77 +56,77 @@ namespace Halibut.Tests
             }
         }
 
-        //[Test]
-        //[TestCase(ServiceConnectionType.Polling, null, null)]
-        //[TestCase(ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        //[TestCase(ServiceConnectionType.Polling, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
-        //[TestCase(ServiceConnectionType.Listening, null, null)]
-        //[TestCase(ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        //[TestCase(ServiceConnectionType.Listening, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
-        //// PollingOverWebSockets does not support (or use) ProxyDetails if provided. If support is added, test variations should be added
-        //public async Task OctopusCanSendMessagesToTentacle_WithEchoService_AndAProxy(ServiceConnectionType serviceConnectionType, string clientVersion, string serviceVersion)
-        //{
-        //    using (var clientAndService = clientVersion != null ?
-        //               await PreviousClientVersionAndServiceBuilder
-        //                   .ForServiceConnectionType(serviceConnectionType)
-        //                   .WithClientVersion(clientVersion)
-        //                   .WithProxy()
-        //                   .Build() : serviceVersion != null ?
-        //               await ClientAndPreviousServiceVersionBuilder
-        //                   .ForServiceConnectionType(serviceConnectionType)
-        //                   .WithServiceVersion(serviceVersion)
-        //                   .WithProxy()
-        //                   .Build()
-        //               : await ClientServiceBuilder
-        //                   .ForServiceConnectionType(serviceConnectionType)
-        //                   .WithProxy()
-        //                   .WithEchoService()
-        //                   .Build())
-        //    {
-        //        var echo = clientAndService.CreateClient<IEchoService>();
-        //        echo.SayHello("Deploy package A").Should().Be("Deploy package A...");
+        [Test]
+        [TestCase(ServiceConnectionType.Polling, null, null)]
+        [TestCase(ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
+        [TestCase(ServiceConnectionType.Polling, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
+        [TestCase(ServiceConnectionType.Listening, null, null)]
+        [TestCase(ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
+        [TestCase(ServiceConnectionType.Listening, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
+        // PollingOverWebSockets does not support (or use) ProxyDetails if provided. If support is added, test variations should be added
+        public async Task OctopusCanSendMessagesToTentacle_WithEchoService_AndAProxy(ServiceConnectionType serviceConnectionType, string clientVersion, string serviceVersion)
+        {
+            using (var clientAndService = clientVersion != null ?
+                       await PreviousClientVersionAndServiceBuilder
+                           .ForServiceConnectionType(serviceConnectionType)
+                           .WithClientVersion(clientVersion)
+                           .WithProxy()
+                           .Build() : serviceVersion != null ?
+                       await ClientAndPreviousServiceVersionBuilder
+                           .ForServiceConnectionType(serviceConnectionType)
+                           .WithServiceVersion(serviceVersion)
+                           .WithProxy()
+                           .Build()
+                       : await ClientServiceBuilder
+                           .ForServiceConnectionType(serviceConnectionType)
+                           .WithProxy()
+                           .WithEchoService()
+                           .Build())
+            {
+                var echo = clientAndService.CreateClient<IEchoService>();
+                echo.SayHello("Deploy package A").Should().Be("Deploy package A...");
 
-        //        for (var i = 0; i < StandardIterationCount.ForServiceType(serviceConnectionType); i++)
-        //        {
-        //            echo.SayHello($"Deploy package A {i}").Should().Be($"Deploy package A {i}...");
-        //        }
-        //    }
-        //}
+                for (var i = 0; i < StandardIterationCount.ForServiceType(serviceConnectionType); i++)
+                {
+                    echo.SayHello($"Deploy package A {i}").Should().Be($"Deploy package A {i}...");
+                }
+            }
+        }
 
-        //[Test]
-        //[TestCase(ServiceConnectionType.Polling, null, null)]
-        //[TestCase(ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        //[TestCase(ServiceConnectionType.Polling, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
-        //[TestCase(ServiceConnectionType.Listening, null, null)]
-        //[TestCase(ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        //[TestCase(ServiceConnectionType.Listening, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
-        //// PollingOverWebSockets does not support (or use) ProxyDetails if provided. If support is added, test variations should be added
-        //public async Task OctopusCanNotSendMessagesToTentacle_WithEchoService_AndABrokenProxy(ServiceConnectionType serviceConnectionType, string clientVersion, string serviceVersion)
-        //{
-        //    using (var clientAndService = clientVersion != null ?
-        //               await PreviousClientVersionAndServiceBuilder
-        //                   .ForServiceConnectionType(serviceConnectionType)
-        //                   .WithClientVersion(clientVersion)
-        //                   .WithProxy()
-        //                   .Build() : serviceVersion != null ?
-        //               await ClientAndPreviousServiceVersionBuilder
-        //                   .ForServiceConnectionType(serviceConnectionType)
-        //                   .WithServiceVersion(serviceVersion)
-        //                   .WithProxy()
-        //                   .Build()
-        //               : await ClientServiceBuilder
-        //                   .ForServiceConnectionType(serviceConnectionType)
-        //                   .WithProxy()
-        //                   .WithEchoService()
-        //                   .Build())
-        //    {
-        //        await clientAndService.Proxy!.StopAsync(CancellationToken.None);
+        [Test]
+        [TestCase(ServiceConnectionType.Polling, null, null)]
+        [TestCase(ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
+        [TestCase(ServiceConnectionType.Polling, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
+        [TestCase(ServiceConnectionType.Listening, null, null)]
+        [TestCase(ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
+        [TestCase(ServiceConnectionType.Listening, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
+        // PollingOverWebSockets does not support (or use) ProxyDetails if provided. If support is added, test variations should be added
+        public async Task OctopusCanNotSendMessagesToTentacle_WithEchoService_AndABrokenProxy(ServiceConnectionType serviceConnectionType, string clientVersion, string serviceVersion)
+        {
+            using (var clientAndService = clientVersion != null ?
+                       await PreviousClientVersionAndServiceBuilder
+                           .ForServiceConnectionType(serviceConnectionType)
+                           .WithClientVersion(clientVersion)
+                           .WithProxy()
+                           .Build() : serviceVersion != null ?
+                       await ClientAndPreviousServiceVersionBuilder
+                           .ForServiceConnectionType(serviceConnectionType)
+                           .WithServiceVersion(serviceVersion)
+                           .WithProxy()
+                           .Build()
+                       : await ClientServiceBuilder
+                           .ForServiceConnectionType(serviceConnectionType)
+                           .WithProxy()
+                           .WithEchoService()
+                           .Build())
+            {
+                await clientAndService.Proxy!.StopAsync(CancellationToken.None);
 
-        //        var echo = clientAndService.CreateClient<IEchoService>();
-        //        Func<string> action = () => echo.SayHello("Deploy package A");
-        //        action.Should().Throw<HalibutClientException>();
-        //    }
-        //}
+                var echo = clientAndService.CreateClient<IEchoService>();
+                Func<string> action = () => echo.SayHello("Deploy package A");
+                action.Should().Throw<HalibutClientException>();
+            }
+        }
 
         [Test]
         [TestCaseSource(typeof(ServiceConnectionTypesToTest))]


### PR DESCRIPTION
# Background

Fix HttpProxyService Disposal
Reduced logging level for Halibut is some noisy tests as this was causing the Windows Test Build to hang

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
