### PR TITLE
Fixing Flaky Test by Updating Shellfish

### DIFF
--- a/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
+++ b/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
@@ -40,7 +40,7 @@
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-        <PackageReference Include="Octopus.Shellfish" Version="0.2.1098" />
+        <PackageReference Include="Octopus.Shellfish" Version="0.2.1180" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-    <PackageReference Include="Octopus.Shellfish" Version="0.2.1098" />
+    <PackageReference Include="Octopus.Shellfish" Version="0.2.1180" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">


### PR DESCRIPTION
[sc-53693]

# Background
A Halibut integration test was failing (details in linked Shortcut story). 

# Results


## Before
A `Process was not started by this object, so requested information cannot be determined.` exception was being thrown from `System.Process` when Shellfish was accessing the exit code of the process.

Shellfish already wraps this property in a try/catch, but it doesn't listen for this error.

## After
[Shellfish was updated](https://github.com/OctopusDeploy/Shellfish/pull/77) with the fix. All we had to do was use that update.

# How to review this PR


Quality :heavy_check_mark: