### PR TITLE
Ensure the child compat test binary will always exits if the parent dies.

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
@@ -78,7 +78,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 await Console.Out.FlushAsync();
 
                 // Run until the Program is terminated
-                StayAliveUntilHelper.WaitUntilSignaledToDie();
+                await StayAliveUntilHelper.WaitUntilSignaledToDie();
             }
         }
     }

--- a/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Halibut.TestUtils.SampleProgram.Base.LogUtils;
+using Halibut.TestUtils.SampleProgram.Base.Services;
 
 namespace Halibut.TestUtils.SampleProgram.Base
 {
@@ -77,7 +78,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 await Console.Out.FlushAsync();
 
                 // Run until the Program is terminated
-                await Task.Delay(-1);
+                StayAliveUntilHelper.WaitUntilSignaledToDie();
             }
         }
     }

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Halibut.TestUtils.SampleProgram.Base.LogUtils;
+using Halibut.TestUtils.SampleProgram.Base.Services;
 
 namespace Halibut.TestUtils.SampleProgram.Base
 {
@@ -93,7 +94,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     await Console.Out.FlushAsync();
 
                     // Run until the Program is terminated
-                    await Task.Delay(-1);
+                    StayAliveUntilHelper.WaitUntilSignaledToDie();
                 }
             }
         }

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -94,7 +94,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     await Console.Out.FlushAsync();
 
                     // Run until the Program is terminated
-                    StayAliveUntilHelper.WaitUntilSignaledToDie();
+                    await StayAliveUntilHelper.WaitUntilSignaledToDie();
                 }
             }
         }

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.TestUtils.SampleProgram.Base.Services
+{
+    public class StayAliveUntilHelper
+    {
+        public static void WaitUntilSignaledToDie()
+        {
+            var stayAliveFile = SettingsHelper.CompatBinaryStayAliveLockFile();
+            while (true)
+            {
+                try
+                {
+                    Console.WriteLine("Waiting to lock");
+                    var fileStreamLock = new FileStream(stayAliveFile, FileMode.Open, FileAccess.Read, FileShare.None);
+                    Console.WriteLine("Got a lock, going to die now");
+                    fileStreamLock.Dispose();
+                    File.Delete(stayAliveFile);
+                    Environment.Exit(0);
+                }
+                catch (Exception e)
+                {
+                
+                }
+
+                if (!File.Exists(stayAliveFile))
+                {
+                    Environment.Exit(0);
+                }
+                
+                Thread.Sleep(2000);
+            }
+            
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
@@ -8,7 +8,7 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
 {
     public class StayAliveUntilHelper
     {
-        public static void WaitUntilSignaledToDie()
+        public static async Task WaitUntilSignaledToDie()
         {
             var stayAliveFile = SettingsHelper.CompatBinaryStayAliveLockFile();
             while (true)
@@ -16,11 +16,20 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
                 try
                 {
                     Console.WriteLine("Waiting to lock");
-                    var fileStreamLock = new FileStream(stayAliveFile, FileMode.Open, FileAccess.Read, FileShare.None);
-                    Console.WriteLine("Got a lock, going to die now");
-                    fileStreamLock.Dispose();
-                    File.Delete(stayAliveFile);
-                    Environment.Exit(0);
+                    using (var fileStreamLock = new FileStream(stayAliveFile, FileMode.Open, FileAccess.Read, FileShare.None))
+                    {
+                        Console.WriteLine("Got a lock, going to die now");
+                        fileStreamLock.Dispose();    
+                    }
+
+                    try
+                    {
+                        File.Delete(stayAliveFile);
+                    }
+                    finally
+                    {
+                        Environment.Exit(0);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -86,14 +86,14 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         public static string CompatBinaryStayAliveLockFile()
         {
-            var tentacleCertPath = GetSetting("CompatBinaryStayAliveFilePath");
-            if (tentacleCertPath == null || tentacleCertPath.Length == 0)
+            var stayAliveFilePath = GetSetting("CompatBinaryStayAliveFilePath");
+            if (string.IsNullOrEmpty(stayAliveFilePath))
             {
                 throw new Exception("Env var CompatBinaryStayAliveFilePath must be set");
             }
             
-            Console.WriteLine($"Will die when the following file can be locked or is deleted '{tentacleCertPath}'.");
-            return tentacleCertPath;
+            Console.WriteLine($"Will die when the following file can be locked or is deleted '{stayAliveFilePath}'.");
+            return stayAliveFilePath;
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -83,5 +83,17 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
             throw new Exception($"Unknown service type '{s}'");
         }
+
+        public static string CompatBinaryStayAliveLockFile()
+        {
+            var tentacleCertPath = GetSetting("CompatBinaryStayAliveFilePath");
+            if (tentacleCertPath == null || tentacleCertPath.Length == 0)
+            {
+                throw new Exception("Env var CompatBinaryStayAliveFilePath must be set");
+            }
+            
+            Console.WriteLine($"Will die when the following file can be locked or is deleted '{tentacleCertPath}'.");
+            return tentacleCertPath;
+        }
     }
 }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/CompatBinaryStayAlive.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/CompatBinaryStayAlive.cs
@@ -9,26 +9,27 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         public static string StayAliveFilePathEnvVarKey = "CompatBinaryStayAliveFilePath";
         
         readonly TmpDirectory tmpDirectory;
-        public readonly string lockFile;
+        public string LockFile { get; }
         readonly FileStream fileStreamLock;
         public CompatBinaryStayAlive()
         {
             tmpDirectory = new TmpDirectory();
-            lockFile = Path.Combine(tmpDirectory.FullPath, "compat-bin-lock");
+            LockFile = Path.Combine(tmpDirectory.FullPath, "compat-bin-lock");
             
-            fileStreamLock = new FileStream(lockFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            fileStreamLock = new FileStream(LockFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
 
         }
 
         public void Dispose()
         {
+            var logger = new SerilogLoggerBuilder().Build().ForContext<CompatBinaryStayAlive>();
             try
             {
                 fileStreamLock.Dispose();
             }
             catch (Exception e)
             {
-                new SerilogLoggerBuilder().Build().ForContext<CompatBinaryStayAlive>().Warning(e, "Could not release lock");
+                logger.Warning(e, "Could not release lock");
             }
 
             try
@@ -37,9 +38,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             }
             catch (Exception e)
             {
-                new SerilogLoggerBuilder().Build().ForContext<CompatBinaryStayAlive>().Warning(e, "Could not delete directory");
+                logger.Warning(e, "Could not delete directory");
             }
-            
         }
     }
 }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/CompatBinaryStayAlive.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/CompatBinaryStayAlive.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+
+namespace Halibut.Tests.Support.BackwardsCompatibility
+{
+    public class CompatBinaryStayAlive : IDisposable
+    {
+
+        public static string StayAliveFilePathEnvVarKey = "CompatBinaryStayAliveFilePath";
+        
+        readonly TmpDirectory tmpDirectory;
+        public readonly string lockFile;
+        readonly FileStream fileStreamLock;
+        public CompatBinaryStayAlive()
+        {
+            tmpDirectory = new TmpDirectory();
+            lockFile = Path.Combine(tmpDirectory.FullPath, "compat-bin-lock");
+            
+            fileStreamLock = new FileStream(lockFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                fileStreamLock.Dispose();
+            }
+            catch (Exception e)
+            {
+                new SerilogLoggerBuilder().Build().ForContext<CompatBinaryStayAlive>().Warning(e, "Could not release lock");
+            }
+
+            try
+            {
+                tmpDirectory.Dispose();
+            }
+            catch (Exception e)
+            {
+                new SerilogLoggerBuilder().Build().ForContext<CompatBinaryStayAlive>().Warning(e, "Could not delete directory");
+            }
+            
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -48,7 +48,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 { "mode", "serviceonly" },
                 { "tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath },
                 { "octopusthumbprint", clientCertAndThumbprint.Thumbprint },
-                {CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.lockFile}
+                { CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.LockFile }
             };
 
             if (proxyDetails != null)

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 { "mode", "proxy" },
                 { "tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath },
                 { "octopuscertpath", clientCertAndThumbprint.CertificatePfxPath },
-                {CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.lockFile}
+                {CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.LockFile}
             };
 
             if (proxyDetails != null)
@@ -157,7 +157,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 Task runningOldHalibutTask,
                 TmpDirectory tmpDirectory,
                 int? serviceListenPort,
-                int? proxyClientListenPort, CompatBinaryStayAlive compatBinaryStayAlive)
+                int? proxyClientListenPort,
+                CompatBinaryStayAlive compatBinaryStayAlive)
             {
                 this.cts = cts;
                 this.runningOldHalibutTask = runningOldHalibutTask;
@@ -172,7 +173,6 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public void Dispose()
             {
                 compatBinaryStayAlive.Dispose();
-                Thread.Sleep(10000);
                 cts.Cancel();
                 runningOldHalibutTask.GetAwaiter().GetResult();
                 tmpDirectory.Dispose();


### PR DESCRIPTION
# Background

Looking at a hung build, we found that a compatibility test binary was still running when the parent tests process was not. This resulted in the teamcity build being hung. Killing that binary resulted in the tests completing and going green.

The change here is to change compatibility test binary such that if the parent dies it also dies.

# How

This is done by the parent processes creating a file and holding a lock on that, released in the dispose method (when the running compatibility test binary is disposed).

The compatibility test binary is told the location of that file and will exit if either:
* It can get a lock on that file.
* the file no longer exists.

File locks are always released when the owning process dies, this means should the test host process die the lock is released. This will result in the compatibility test binary obtaining the lock and then exiting.

# Local Development Improvement

This change also helps local development since if the parent test process is killed in some way that doesn't kill the child, the child will detect that and die. Previously we found the compat bin would stay running, preventing future compilation.

# Helps when other bits of the test are in error

This is also handy in code that is not prepared for EVERYTHING and ANYTHING to throw an exception e.g.

```
SomeDisposable build() {
    var runningCompatBin = StartCompatBin();
    var foo = somethingThatCanThrowAnException(); // If this throws the compat bin wont be disposed, and so will stay running.
    return new SomeDisposable(runningCompatBin, foo);
}
```

with these changes, in that above example the compat bin will die when the test process completes.

# How to review this PR

Try it yourself, previously the compat binary would stay running if you forget to dispose of it now it will always be killed.


# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
