### PR TITLE
Background thread is background thread

### DIFF
--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -92,6 +92,7 @@ namespace Halibut.Transport
             {
                 Name = "Accept connections on " + listener.LocalEndpoint
             };
+            backgroundThread.IsBackground = true;
             backgroundThread.Start();
 
             return ((IPEndPoint)listener.LocalEndpoint).Port;


### PR DESCRIPTION
# Background

When a halibut runtime fails to be disposed, e.g. because some exception is thrown in the builder perhaps because:
- the compat binary can not be started
-  the proxy can not be started
- the port forwarder can not be started

The test process stays running waiting for the SecureListener thread to die, which it never does.

The change here is to make the `SecureListener` behave like other threads started in Halibut (such as the polling client thread) where it is marked as a background thread. The result is the CLR is allowed to finish even if the thread is still running.

The result should hopefully be that we are less likely to keep test CLRs running when a test fails in an unexpected way.

Tentacle itself, expects this behaviour since polling tentacles work and the source code has a concept of waiting for the user to exit tentacle see [here](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Commands/RunAgentCommand.cs#L119).


## Async alignment

This behaviour is not something that is aligned with converting everything to async, since async contexts don't have a concept of keeping the CLR running while they still have work todo.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
