### PR TITLE
Increase heart beat duration

### DIFF
--- a/source/Halibut.Tests/LowerHalibutLimitsForAllTests.cs
+++ b/source/Halibut.Tests/LowerHalibutLimitsForAllTests.cs
@@ -22,8 +22,8 @@ namespace Halibut.Tests
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientSendTimeout), TimeSpan.FromSeconds(45));
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientReceiveTimeout), TimeSpan.FromSeconds(45));
 
-            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientHeartbeatSendTimeout), TimeSpan.FromSeconds(10));
-            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientHeartbeatReceiveTimeout), TimeSpan.FromSeconds(10));
+            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientHeartbeatSendTimeout), TimeSpan.FromSeconds(15));
+            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientHeartbeatReceiveTimeout), TimeSpan.FromSeconds(15));
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientConnectTimeout), TimeSpan.FromSeconds(20));
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.PollingQueueWaitTimeout), TimeSpan.FromSeconds(20));
         }

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -32,11 +32,12 @@ namespace Halibut.Tests
 
                 // The test knows that Halibut should be using the shorter TcpClientHeartbeatReceiveTimeout when checking
                 // the TCP connection pulled out of the pool. Doing this reduces the test time in the failure case.
-                await Task.WhenAny(sayHelloTask, Task.Delay(HalibutLimits.TcpClientHeartbeatReceiveTimeout + HalibutLimits.TcpClientHeartbeatReceiveTimeout));
+                var moreThanTheTimeWeExpectToWait = HalibutLimits.TcpClientHeartbeatReceiveTimeout + TimeSpan.FromSeconds(10);
+                await Task.WhenAny(sayHelloTask, Task.Delay(moreThanTheTimeWeExpectToWait));
 
                 sayHelloTask.IsCompleted.Should().BeTrue("We should be able to detect dead TCP connections and retry requests with a new TCP connection.");
 
-                (HalibutLimits.TcpClientHeartbeatReceiveTimeout + TimeSpan.FromSeconds(10)).Should().BeLessThan(HalibutLimits.TcpClientReceiveTimeout, 
+                (moreThanTheTimeWeExpectToWait).Should().BeLessThan(HalibutLimits.TcpClientReceiveTimeout, 
                     "This depend on the heart beat timeouts being less than the regular TCP timeouts, if that is not true this test isn't testing the correct timeout.");
             }
         }

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -11,7 +11,7 @@ namespace Halibut.Tests
     public class WhenTheTcpConnectionStopsSendingData
     {
         [Test]
-        public async Task HalibutCanRecoverFromIdleTcpDisconnect2()
+        public async Task HalibutCanRecoverFromIdleTcpDisconnect()
         {
             using (var clientAndService = await ClientServiceBuilder
                        .Listening()


### PR DESCRIPTION
# Background

Since it is too low and sometimes causes test failures. see [here](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_TestWindows/8846670?buildTab=tests&expandedTest=build%3A%28id%3A8846670%29%2Cid%3A2000000286)

```
 ---> System.IO.IOException: Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond..
 ---> System.Net.Sockets.SocketException (10060): A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
   at System.Net.Sockets.NetworkStream.Read(Span`1 buffer)
   --- End of inner exception stack trace ---
   at System.Net.Sockets.NetworkStream.Read(Span`1 buffer)
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](TIOAdapter adapter)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](TIOAdapter adapter, Memory`1 buffer)
   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.RewindableBufferStream.Read(Byte[] buffer, Int32 offset, Int32 count) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\RewindableBufferStream.cs:line 94
   at System.IO.Stream.ReadByte()
   at Halibut.Transport.Protocol.ControlMessageReader.ReadControlMessage(Stream stream) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\ControlMessageReader.cs:line 24
   at Halibut.Transport.Protocol.ControlMessageReader.ReadUntilNonEmptyControlMessage(Stream stream) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\ControlMessageReader.cs:line 14
   at Halibut.Transport.Protocol.MessageExchangeStream.ExpectProceeed() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\MessageExchangeStream.cs:line 131
   at Halibut.Transport.Protocol.MessageExchangeProtocol.PrepareExchangeAsClient() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\MessageExchangeProtocol.cs:line 66
   --- End of inner exception stack trace ---
```


Also fix up the delay for `HalibutCanRecoverFromIdleTcpDisconnect` it was using the wrong one.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
