### PR TITLE
Add Proxy support to IClientAndServiceBuilder

### DIFF
--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -87,6 +87,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
+        {
+            return WithProxy();
+        }
+
         public LatestClientAndPreviousServiceVersionBuilder WithProxy()
         {
             this.proxyFactory = () =>

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -107,6 +107,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return WithEchoServiceService(new EchoService()).WithCachingService(new CachingService()).WithMultipleParametersTestService(new MultipleParametersTestService());
         }
         
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
+        {
+            return WithProxy();
+        }
+
         public PreviousClientVersionAndLatestServiceBuilder WithProxy()
         {
             this.proxyFactory = () =>

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -9,6 +9,7 @@ namespace Halibut.Tests.Support
     {
         Task<IClientAndService> Build();
         IClientAndServiceBuilder WithPortForwarding(Func<int, PortForwarder> func);
+        IClientAndServiceBuilder WithProxy();
         IClientAndServiceBuilder WithStandardServices();
         IClientAndServiceBuilder WithHalibutLoggingLevel(LogLevel info);
     }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -127,6 +127,11 @@ namespace Halibut.Tests.Support
             return this.WithEchoService().WithMultipleParametersTestService().WithCachingService();
         }
         
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
+        {
+            return WithProxy();
+        }
+
         public LatestClientAndLatestServiceBuilder WithProxy()
         {
             this.proxyFactory = () =>

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCase.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCase.cs
@@ -24,7 +24,7 @@ namespace Halibut.Tests.Support.TestCases
             this.clientAndServiceTestVersion = clientAndServiceTestVersion;
         }
 
-        public IClientAndServiceBuilder CreateBaseTestCaseBuilder()
+        public IClientAndServiceBuilder CreateTestCaseBuilder()
         {
             var logger = new SerilogLoggerBuilder().Build();
             var builder = ClientAndServiceBuilderFactory.ForVersion(clientAndServiceTestVersion)(ServiceConnectionType);

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -8,10 +8,8 @@ using FluentAssertions;
 using Halibut.Exceptions;
 using Halibut.Logging;
 using Halibut.Tests.Support;
-using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
-using Halibut.Tests.Util;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
@@ -23,7 +21,7 @@ namespace Halibut.Tests
         [TestCaseSource(typeof(LatestAndPreviousClientAndServiceVersionsTestCases))]
         public async Task OctopusCanSendMessagesToTentacle_WithEchoService(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateBaseTestCaseBuilder()
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
@@ -38,35 +36,16 @@ namespace Halibut.Tests
             }
         }
 
-[Test]
-        [TestCase(ServiceConnectionType.Polling, null, null)]
-        [TestCase(ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        [TestCase(ServiceConnectionType.Polling, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
-        [TestCase(ServiceConnectionType.Listening, null, null)]
-        [TestCase(ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        [TestCase(ServiceConnectionType.Listening, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
+        [Test]
+        [TestCaseSource(typeof(LatestAndPreviousClientAndServiceVersionsTestCases))]
         // PollingOverWebSockets does not support (or use) ProxyDetails if provided. If support is added, test variations should be added
-        public async Task OctopusCanSendMessagesToTentacle_WithEchoService_AndAProxy(ServiceConnectionType serviceConnectionType, string clientVersion, string serviceVersion)
+        public async Task OctopusCanSendMessagesToTentacle_WithEchoService_AndAProxy(ClientAndServiceTestCase testCase)
         {
-            using (IClientAndService clientAndService = clientVersion != null ?
-                       await PreviousClientVersionAndLatestServiceBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithClientVersion(clientVersion)
-                           .WithHalibutLoggingLevel(LogLevel.Info)
-                           .WithProxy()
-                           .Build() : serviceVersion != null ?
-                       await LatestClientAndPreviousServiceVersionBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithServiceVersion(serviceVersion)
-                           .WithHalibutLoggingLevel(LogLevel.Info)
-                           .WithProxy()
-                           .Build()
-                       : await LatestClientAndLatestServiceBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithEchoService()
-                           .WithHalibutLoggingLevel(LogLevel.Info)
-                           .WithProxy()
-                           .Build())
+            using (IClientAndService clientAndService = await testCase.CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .WithProxy()
+                       .WithHalibutLoggingLevel(LogLevel.Info)
+                       .Build())
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Deploy package A").Should().Be("Deploy package A...");
@@ -79,34 +58,15 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [TestCase(ServiceConnectionType.Polling, null, null)]
-        [TestCase(ServiceConnectionType.Polling, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        [TestCase(ServiceConnectionType.Polling, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
-        [TestCase(ServiceConnectionType.Listening, null, null)]
-        [TestCase(ServiceConnectionType.Listening, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417, null)]
-        [TestCase(ServiceConnectionType.Listening, null, PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417)]
+        [TestCaseSource(typeof(LatestAndPreviousClientAndServiceVersionsTestCases))]
         // PollingOverWebSockets does not support (or use) ProxyDetails if provided. If support is added, test variations should be added
-        public async Task OctopusCanNotSendMessagesToTentacle_WithEchoService_AndABrokenProxy(ServiceConnectionType serviceConnectionType, string clientVersion, string serviceVersion)
+        public async Task OctopusCanNotSendMessagesToTentacle_WithEchoService_AndABrokenProxy(ClientAndServiceTestCase testCase)
         {
-            using (IClientAndService clientAndService = clientVersion != null ?
-                       await PreviousClientVersionAndLatestServiceBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithClientVersion(clientVersion)
-                           .WithHalibutLoggingLevel(LogLevel.Info)
-                           .WithProxy()
-                           .Build() : serviceVersion != null ?
-                       await LatestClientAndPreviousServiceVersionBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithServiceVersion(serviceVersion)
-                           .WithHalibutLoggingLevel(LogLevel.Info)
-                           .WithProxy()
-                           .Build()
-                       : await LatestClientAndLatestServiceBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithEchoService()
-                           .WithHalibutLoggingLevel(LogLevel.Info)
-                           .WithProxy()
-                           .Build())
+            using (IClientAndService clientAndService = await testCase.CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .WithProxy()
+                       .WithHalibutLoggingLevel(LogLevel.Info)
+                       .Build())
             {
                 await clientAndService.Proxy!.StopAsync(CancellationToken.None);
 
@@ -117,10 +77,11 @@ namespace Halibut.Tests
         }
 
         
+        [Test]
         [TestCaseSource(typeof(LatestAndPreviousClientAndServiceVersionsTestCases))]
         public async Task OctopusCanSendMessagesToTentacle_WithSupportedServices(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateBaseTestCaseBuilder()
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build())
@@ -159,7 +120,7 @@ namespace Halibut.Tests
         [TestCaseSource(typeof(LatestAndPreviousClientAndServiceVersionsTestCases))]
         public async Task StreamsCanBeSent(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateBaseTestCaseBuilder()
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                       .WithStandardServices()
                       .WithHalibutLoggingLevel(LogLevel.Info)
                       .Build())
@@ -181,7 +142,7 @@ namespace Halibut.Tests
         [TestCaseSource(typeof(LatestAndPreviousClientAndServiceVersionsTestCases))]
         public async Task SupportsDifferentServiceContractMethods(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateBaseTestCaseBuilder()
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build())
             {
@@ -219,7 +180,7 @@ namespace Halibut.Tests
         [TestCaseSource(typeof(LatestClientAndLatestServiceTestCases))]
         public async Task StreamsCanBeSentWithProgressReporting(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateBaseTestCaseBuilder()
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build())
             {


### PR DESCRIPTION
Adds proxy support to `IClientAndTestBuilder`, which allows the use of the new "test pretty much everything" test case source in proxy-related tests.

Implemented as part of [sc-53455]