### PR TITLE
Don't make available the caching service when it does not make sense

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -28,13 +28,15 @@ namespace Halibut.TestUtils.SampleProgram.Base
         /// <returns></returns>
         public static DelegateServiceFactory CreateProxyingServicesServiceFactory(HalibutRuntime clientWhichTalksToLatestHalibut, ServiceEndPoint realServiceEndpoint)
         {
-            var forwardingEchoService = clientWhichTalksToLatestHalibut.CreateClient<IEchoService>(realServiceEndpoint);
-            var forwardingCachingService = clientWhichTalksToLatestHalibut.CreateClient<ICachingService>(realServiceEndpoint);
-            var forwardingMultipleParametersTestService = clientWhichTalksToLatestHalibut.CreateClient<IMultipleParametersTestService>(realServiceEndpoint);
             var services = new DelegateServiceFactory();
+            
+            var forwardingEchoService = clientWhichTalksToLatestHalibut.CreateClient<IEchoService>(realServiceEndpoint);
             services.Register<IEchoService>(() => new DelegateEchoService(forwardingEchoService));
-            services.Register<ICachingService>(() => new DelegateCachingService(forwardingCachingService));
+            
+            var forwardingMultipleParametersTestService = clientWhichTalksToLatestHalibut.CreateClient<IMultipleParametersTestService>(realServiceEndpoint);
             services.Register<IMultipleParametersTestService>(() => new DelegateMultipleParametersTestService(forwardingMultipleParametersTestService));
+            
+            // The ICachingService is not supported since, the new attributes are not available in the versions of Halibut in the compat library.
             return services;
         }
     }

--- a/source/Halibut.Tests/Properties/AssemblyInfo.cs
+++ b/source/Halibut.Tests/Properties/AssemblyInfo.cs
@@ -10,4 +10,3 @@ using NUnit.Framework;
 [assembly: Parallelizable(ParallelScope.All)]
 [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [assembly: TestTimeout]
-[assembly: LevelOfParallelism(256)]

--- a/source/Halibut.Tests/Properties/AssemblyInfo.cs
+++ b/source/Halibut.Tests/Properties/AssemblyInfo.cs
@@ -10,3 +10,4 @@ using NUnit.Framework;
 [assembly: Parallelizable(ParallelScope.All)]
 [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [assembly: TestTimeout]
+[assembly: LevelOfParallelism(256)]

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -87,6 +87,14 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithCachingService() => WithCachingService();
+        
+        public IClientAndServiceBuilder WithCachingService()
+        {
+            // TODO actually make the old service only have caching service if this is called.
+            return this;
+        }
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
         {
             return WithProxy();
@@ -109,7 +117,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return WithHalibutLoggingLevel(halibutLogLevel);
         }
-        
+
         public LatestClientAndPreviousServiceVersionBuilder WithHalibutLoggingLevel(LogLevel halibutLogLevel)
         {
             this.halibutLogLevel = halibutLogLevel;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -90,10 +90,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
-        public PreviousClientVersionAndLatestServiceBuilder WithCachingService(Halibut.TestUtils.Contracts.ICachingService cachingService)
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithCachingService()
         {
-            this.cachingService = cachingService;
-            return this;
+            throw new Exception("Caching service is not supported, when testing on the old Client. Since the old client is on external CLR which does not have the new caching attributes which this service is used to test.");
         }
 
         public PreviousClientVersionAndLatestServiceBuilder WithMultipleParametersTestService(IMultipleParametersTestService multipleParametersTestService)
@@ -109,7 +108,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
         public PreviousClientVersionAndLatestServiceBuilder WithStandardServices()
         {
-            return WithEchoServiceService(new EchoService()).WithCachingService(new CachingService()).WithMultipleParametersTestService(new MultipleParametersTestService());
+            return WithEchoServiceService(new EchoService()).WithMultipleParametersTestService(new MultipleParametersTestService());
         }
         
         IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
@@ -134,7 +133,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return WithHalibutLoggingLevel(halibutLogLevel);
         }
-        
+
         public PreviousClientVersionAndLatestServiceBuilder WithHalibutLoggingLevel(LogLevel halibutLogLevel)
         {
             this.halibutLogLevel = halibutLogLevel;

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -13,5 +13,6 @@ namespace Halibut.Tests.Support
         IClientAndServiceBuilder WithProxy();
         IClientAndServiceBuilder WithStandardServices();
         IClientAndServiceBuilder WithHalibutLoggingLevel(LogLevel info);
+        IClientAndServiceBuilder WithCachingService();
     }
 }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -6,6 +6,7 @@ using Halibut.Diagnostics;
 using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
+using Halibut.TestUtils.Contracts;
 using Halibut.Transport.Proxy;
 using Halibut.Util;
 using Octopus.TestPortForwarder;
@@ -126,7 +127,14 @@ namespace Halibut.Tests.Support
         {
             return this.WithEchoService().WithMultipleParametersTestService().WithCachingService();
         }
+
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithCachingService() => WithCachingService();
         
+        public LatestClientAndLatestServiceBuilder WithCachingService()
+        {
+            return this.WithService<ICachingService>(() => new CachingService());
+        }
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
         {
             return WithProxy();

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
@@ -26,10 +26,5 @@ namespace Halibut.Tests.Support
         {
             return builder.WithService<IReadDataStreamService>(() => new ReadDataStreamService());
         }
-
-        public static LatestClientAndLatestServiceBuilder WithCachingService(this LatestClientAndLatestServiceBuilder builder)
-        {
-            return builder.WithService<ICachingService>(() => new CachingService());
-        }
     }
 }


### PR DESCRIPTION
# Background

The `ICachingService` doesn't make sense to be tested with when the client is an old client, since that old client wont have the new caching attributes we are trying to test.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
