### PR TITLE
Improve localdev by making more tests run in parallel

### DIFF
--- a/source/Halibut.Tests/Properties/AssemblyInfo.cs
+++ b/source/Halibut.Tests/Properties/AssemblyInfo.cs
@@ -10,3 +10,4 @@ using NUnit.Framework;
 [assembly: Parallelizable(ParallelScope.All)]
 [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [assembly: TestTimeout]
+[assembly: CustomLevelOfParallelismAttribute(10)]

--- a/source/Halibut.Tests/Properties/AssemblyInfo.cs
+++ b/source/Halibut.Tests/Properties/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using NUnit.Framework;
 [assembly: Parallelizable(ParallelScope.All)]
 [assembly: FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [assembly: TestTimeout]
-[assembly: CustomLevelOfParallelismAttribute(10)]
+[assembly: CustomLevelOfParallelism]

--- a/source/Halibut.Tests/Support/TestAttributes/CustomLevelOfParallelismAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/CustomLevelOfParallelismAttribute.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.Support.TestAttributes
     [AttributeUsage( AttributeTargets.Assembly, AllowMultiple=false, Inherited=false )]
     public class CustomLevelOfParallelismAttribute : PropertyAttribute
     {
-        public CustomLevelOfParallelismAttribute(int level) : base(LevelOfParallelismAttributePropertyName(), NumberOfCpusToUse())
+        public CustomLevelOfParallelismAttribute() : base(LevelOfParallelismAttributePropertyName(), NumberOfCpusToUse())
         {
         }
         

--- a/source/Halibut.Tests/Support/TestAttributes/CustomLevelOfParallelismAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/CustomLevelOfParallelismAttribute.cs
@@ -1,0 +1,53 @@
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Api;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    /// <summary>
+    /// Halibut tests take time but don't use lots of CPU.
+    ///
+    /// For local development by default increase the level of parallelism to 2x the number of Cores.
+    ///
+    /// This can be overriden with the environment variable "CustomLevelOfParallelism" e.g.
+    /// CustomLevelOfParallelism=256
+    ///
+    /// When run in the build the default level is always used.
+    /// </summary>
+    [AttributeUsage( AttributeTargets.Assembly, AllowMultiple=false, Inherited=false )]
+    public class CustomLevelOfParallelismAttribute : PropertyAttribute
+    {
+        public CustomLevelOfParallelismAttribute(int level) : base(LevelOfParallelismAttributePropertyName(), NumberOfCpusToUse())
+        {
+        }
+        
+        public static int NumberOfCpusToUse()
+        {
+            if (TeamCityDetection.IsRunningInTeamCity()) return NUnitTestAssemblyRunner.DefaultLevelOfParallelism;
+            
+            return LevelOfParallelismFromEnvVar()??NUnitTestAssemblyRunner.DefaultLevelOfParallelism * 2;
+        }
+        
+        static int? LevelOfParallelismFromEnvVar()
+        {
+            var nunitLevelOfParallelismSetting = Environment.GetEnvironmentVariable("CustomLevelOfParallelism");
+            if (!string.IsNullOrEmpty(nunitLevelOfParallelismSetting))
+            {
+                if (int.TryParse(nunitLevelOfParallelismSetting, out var level))
+                {
+                    return level;
+                }
+            }
+
+            return null;
+        }
+
+        static string LevelOfParallelismAttributePropertyName()
+        {
+            string propertyName = typeof(LevelOfParallelismAttribute).Name;
+            if ( propertyName.EndsWith( "Attribute" ) )
+                propertyName = propertyName.Substring( 0, propertyName.Length - 9 );
+            return propertyName;
+        }
+    }
+}


### PR DESCRIPTION
# Background

Improve local dev experience by increasing the level of Parallelism of tests locally (by 2x). On Teamcity the level is kept the same.

See `CustomLevelOfParallelismAttribute` for more details on the change.

[SC-53968]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
