### PR TITLE
Don't register services unless asked to

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -12,10 +12,19 @@ namespace Halibut.TestUtils.SampleProgram.Base
         /// <returns></returns>
         public static DelegateServiceFactory CreateServiceFactory()
         {
+            
             var services = new DelegateServiceFactory();
-            services.Register<IEchoService>(() => new EchoService());
-            services.Register<ICachingService>(() => new CachingService());
-            services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
+            if (SettingsHelper.IsWithStandardServices())
+            {
+                services.Register<IEchoService>(() => new EchoService());
+                services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
+            }
+
+            if (SettingsHelper.IsWithCachingService())
+            {
+                services.Register<ICachingService>(() => new CachingService());
+            }
+
             return services;
         }
 
@@ -29,7 +38,8 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public static DelegateServiceFactory CreateProxyingServicesServiceFactory(HalibutRuntime clientWhichTalksToLatestHalibut, ServiceEndPoint realServiceEndpoint)
         {
             var services = new DelegateServiceFactory();
-            
+            // No need to check if is with standard services since, the Test itself has the service and so controls that.
+
             var forwardingEchoService = clientWhichTalksToLatestHalibut.CreateClient<IEchoService>(realServiceEndpoint);
             services.Register<IEchoService>(() => new DelegateEchoService(forwardingEchoService));
             

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -38,7 +38,8 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public static DelegateServiceFactory CreateProxyingServicesServiceFactory(HalibutRuntime clientWhichTalksToLatestHalibut, ServiceEndPoint realServiceEndpoint)
         {
             var services = new DelegateServiceFactory();
-            // No need to check if is with standard services since, the Test itself has the service and so controls that.
+            // No need to check if is with standard services since, the Test itself has the service and so controls what is available
+            // or not. This will just pass on the request to the service that may or may not exist.
 
             var forwardingEchoService = clientWhichTalksToLatestHalibut.CreateClient<IEchoService>(realServiceEndpoint);
             services.Register<IEchoService>(() => new DelegateEchoService(forwardingEchoService));

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
@@ -15,7 +15,6 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
             {
                 try
                 {
-                    Console.WriteLine("Waiting to lock");
                     using (var fileStreamLock = new FileStream(stayAliveFile, FileMode.Open, FileAccess.Read, FileShare.None))
                     {
                         Console.WriteLine("Got a lock, going to die now");

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -42,7 +42,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             return Environment.GetEnvironmentVariable(name);
         }
         
-        public static bool GetMandatoryBool(string name)
+        static bool GetMandatoryBool(string name)
         {
             var boolAsString = GetSetting(name);
             if (string.IsNullOrEmpty(boolAsString))

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -41,6 +41,21 @@ namespace Halibut.TestUtils.SampleProgram.Base
         {
             return Environment.GetEnvironmentVariable(name);
         }
+        
+        public static bool GetMandatoryBool(string name)
+        {
+            var boolAsString = GetSetting(name);
+            if (string.IsNullOrEmpty(boolAsString))
+            {
+                throw new Exception($"Env var {name} must be set");
+            }
+
+            if (bool.TryParse(boolAsString, out var boolValue))
+            {
+                return boolValue;
+            }
+            throw new Exception($"Env var {name} must be a bool it was: {boolAsString}");
+        }
 
         public static ServiceConnectionType GetServiceConnectionType()
         {
@@ -105,6 +120,16 @@ namespace Halibut.TestUtils.SampleProgram.Base
             
             Console.WriteLine($"Will die when the following file can be locked or is deleted '{stayAliveFilePath}'.");
             return stayAliveFilePath;
+        }
+
+        public static bool IsWithStandardServices()
+        {
+            return GetMandatoryBool("WithStandardServices");
+        }
+
+        public static bool IsWithCachingService()
+        {
+            return GetMandatoryBool("WithCachingService");
         }
     }
 }

--- a/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
@@ -19,6 +19,7 @@ namespace Halibut.Tests.BackwardsCompatibility
             using (var clientAndService = await LatestClientAndPreviousServiceVersionBuilder
                        .ForServiceConnectionType(serviceConnectionType)
                        .WithServiceVersion(PreviousVersions.v5_0_429)
+                       .WithStandardServices()
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService>(se =>

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -55,7 +55,7 @@ namespace Halibut.Tests
         [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
         public async Task CanTalkToOldServicesWhichDontKnowAboutHalibutProxyRequestOptions(ServiceConnectionType serviceConnectionType)
         {
-            using (var clientAndService = await LatestClientAndPreviousServiceVersionBuilder.ForServiceConnectionType(serviceConnectionType).WithServiceVersion("5.0.429").Build(CancellationToken))
+            using (var clientAndService = await LatestClientAndPreviousServiceVersionBuilder.ForServiceConnectionType(serviceConnectionType).WithServiceVersion("5.0.429").WithStandardServices().Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
                     {

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -215,6 +215,7 @@ namespace Halibut.Tests
                 await LatestClientAndPreviousServiceVersionBuilder
                     .ForServiceConnectionType(serviceConnectionType)
                     .WithServiceVersion(halibutServiceVersion)
+                    .WithCachingService()
                     .Build(CancellationToken);
         }
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -21,8 +21,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly LogLevel halibutLogLevel;
         readonly ILogger logger = new SerilogLoggerBuilder().Build().ForContext<HalibutRuntimeBuilder>();
         readonly Uri webSocketServiceEndpointUri;
+        readonly OldServiceAvailableServices availableServices;
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails, LogLevel halibutLogLevel)
+        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails, LogLevel halibutLogLevel, OldServiceAvailableServices availableServices)
         {
             this.serviceConnectionType = serviceConnectionType;
             this.clientCertAndThumbprint = clientCertAndThumbprint;
@@ -30,15 +31,16 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.version = version;
             this.proxyDetails = proxyDetails;
             this.halibutLogLevel = halibutLogLevel;
+            this.availableServices = availableServices;
         }
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails proxyDetails, LogLevel halibutLoggingLevel) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel)
+        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails proxyDetails, LogLevel halibutLoggingLevel, OldServiceAvailableServices availableServices) :
+            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel, availableServices)
         {
             this.clientServicePort = clientServicePort;
         }
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, Uri webSocketServiceEndpointUri, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails, LogLevel halibutLoggingLevel) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel)
+        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, Uri webSocketServiceEndpointUri, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string version, ProxyDetails? proxyDetails, LogLevel halibutLoggingLevel, OldServiceAvailableServices availableServices) :
+            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel, availableServices)
         {
             this.webSocketServiceEndpointUri = webSocketServiceEndpointUri;
         }
@@ -52,7 +54,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 { "tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath },
                 { "octopusthumbprint", clientCertAndThumbprint.Thumbprint },
                 { "halibutloglevel", halibutLogLevel.ToString() },
-                { CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.LockFile }
+                { CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.LockFile },
+                { "WithStandardServices", availableServices.HasStandardServices.ToString() },
+                { "WithCachingService", availableServices.HasCachingService.ToString() },
             };
 
             if (proxyDetails != null)

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -20,6 +20,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         Func<HttpProxyService>? proxyFactory;
         CancellationTokenSource cancellationTokenSource = new();
         LogLevel halibutLogLevel;
+        OldServiceAvailableServices availableServices = new(false, false);
 
         LatestClientAndPreviousServiceVersionBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -81,9 +82,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
         public LatestClientAndPreviousServiceVersionBuilder WithStandardServices()
         {
-            // TODO: EchoService is registered by default, so we don't need to do anything else here.
-            // It would be better to be able to configure the Tentacle binary to register/not register
-            // specific services, but we'll do that later.
+            availableServices.HasStandardServices = true;
             return this;
         }
 
@@ -91,7 +90,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         
         public IClientAndServiceBuilder WithCachingService()
         {
-            // TODO actually make the old service only have caching service if this is called.
+            availableServices.HasCachingService = true;
             return this;
         }
 
@@ -173,7 +172,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     serviceCertAndThumbprint,
                     version,
                     proxyDetails,
-                    halibutLogLevel).Run();
+                    halibutLogLevel,
+                    availableServices).Run();
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
@@ -203,7 +203,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     serviceCertAndThumbprint,
                     version,
                     proxyDetails,
-                    halibutLogLevel).Run();
+                    halibutLogLevel,
+                    availableServices).Run();
             }
             else if (serviceConnectionType == ServiceConnectionType.Listening)
             {
@@ -213,7 +214,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     serviceCertAndThumbprint,
                     version,
                     proxyDetails,
-                    halibutLogLevel).Run();
+                    halibutLogLevel,
+                    availableServices).Run();
 
                 var listenPort = (int)runningOldHalibutBinary.ServiceListenPort!;
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/OldServiceAvailableServices.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/OldServiceAvailableServices.cs
@@ -1,0 +1,14 @@
+namespace Halibut.Tests.Support.BackwardsCompatibility
+{
+    public class OldServiceAvailableServices
+    {
+        public OldServiceAvailableServices(bool hasStandardServices, bool hasCachingService)
+        {
+            HasStandardServices = hasStandardServices;
+            HasCachingService = hasCachingService;
+        }
+
+        public bool HasStandardServices { get; set; }
+        public bool HasCachingService { get; set; }
+    }
+}


### PR DESCRIPTION
# Background

Some client service builders would always register services, this PR changes that so that by default they all give no services and must be explicitly registered.

Also removes a log message in the external binary that logs every 2 seconds.

[SC-53455]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
