### PR TITLE
Document the two ICachingService interface

### DIFF
--- a/source/Halibut.TestUtils.Contracts/ICachingService.cs
+++ b/source/Halibut.TestUtils.Contracts/ICachingService.cs
@@ -2,6 +2,11 @@ using System;
 
 namespace Halibut.TestUtils.Contracts
 {
+    /// <summary>
+    /// Don't use this interface to resolve a client proxy within a test since it does not have the cache attributes.
+    ///
+    /// This should only be used as the implemented interface.
+    /// </summary>
     public interface ICachingService
     {
         Guid NonCachableCall();

--- a/source/Halibut.Tests/TestServices/ICachingService.cs
+++ b/source/Halibut.Tests/TestServices/ICachingService.cs
@@ -3,6 +3,9 @@ using Halibut.Transport.Caching;
 
 namespace Halibut.Tests.TestServices
 {
+    /// <summary>
+    /// Use this interface when generating the proxy client in tests.
+    /// </summary>
     public interface ICachingService
     {
         Guid NonCachableCall();


### PR DESCRIPTION
# Background

We have two ICachingService interface since the contracts project needs one but has the an old Halibut which does not have the cache attributes required in tests.

This PR just documents when to use each.

[SC-53455]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
