### PR TITLE
Increase test timeout

### DIFF
--- a/source/Halibut.Tests/Support/TestAttributes/TestTimeoutAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/TestTimeoutAttribute.cs
@@ -13,7 +13,7 @@ namespace Halibut.Tests.Support.TestAttributes
         public static int TestTimeout()
         {
             if (Debugger.IsAttached) return (int) TimeSpan.FromHours(1).TotalMilliseconds;
-            return (int) TimeSpan.FromMinutes(3).TotalMilliseconds;
+            return (int) TimeSpan.FromMinutes(6).TotalMilliseconds;
         }
     }
 }


### PR DESCRIPTION
# Background

A few times tests have timed out in teamcity for running for longer than 3 minutes, this PR increases the timeout to 6.

Opting for increasing the test timeout since I want to see if a bug exists or if it is windows just being slow before reducing the number of iterations.

```
Halibut.Tests.UsageFixture.StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)
[UsageFixture] 04:31:38.094 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)] Test started
[TestContextConnectionLog] 04:31:38.098 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)]          Service: Info: listen://[::]:51058/  42 Listener started
[TestContextConnectionLog] 04:31:38.109 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)]          Service: Info: listen://[::]:51058/  237 Accepted TCP client: [::1]:51059
[TestContextConnectionLog] 04:31:38.116 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)]           Client: Info: https://localhost:51058/  42 Secure connection established. Server at [::1]:51058 identified by thumbprint: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D, using protocol Tls12
[TestContextConnectionLog] 04:31:38.116 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)]          Service: Info: listen://[::]:51058/  74 Client at [::1]:51059 authenticated as 76225C0717A16C1D0BA4A7FFA76519D286D8A248
[UsageFixture] 04:34:33.097 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)] The test timed out.
[TestContextConnectionLog] 04:34:38.140 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)]           Client: Error:System.IO.IOException: The read operation failed, see inner exception. ---> System.Threading.ThreadAbortException: Thread was being aborted.
   at System.Net.UnsafeNclNativeMethods.OSSOCK.recv(IntPtr socketHandle, Byte* pinnedBuffer, Int32 len, SocketFlags socketFlags)
   at System.Net.Sockets.Socket.Receive(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags, SocketError& errorCode)
   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)
   at System.Net.FixedSizeReader.ReadPacket(Byte[] buffer, Int32 offset, Int32 count)
   at System.Net.Security._SslStream.StartFrameHeader(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security._SslStream.StartReading(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security._SslStream.ProcessRead(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   --- End of inner exception stack trace ---
   at System.Net.Security._SslStream.ProcessRead(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Observability.ByteCountingStream.Read(Byte[] buffer, Int32 offset, Int32 count) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Observability\ByteCountingStream.cs:line 101
   at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
   at Halibut.Transport.Observability.ByteCountingStream.Read(Byte[] buffer, Int32 offset, Int32 count) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Observability\ByteCountingStream.cs:line 101
   at System.IO.BinaryReader.FillBuffer(Int32 numBytes)
   at System.IO.BinaryReader.ReadInt32()
   at Newtonsoft.Json.Bson.BsonDataReader.ReadNormal()
   at Newtonsoft.Json.Bson.BsonDataReader.Read()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Halibut.Transport.Protocol.MessageSerializer.DeserializeMessage[T](JsonReader reader) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 124
   at Halibut.Transport.Protocol.MessageSerializer.ReadCompressedMessage[T](Stream stream) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\MessageSerializer.cs:line 80
   at Halibut.Transport.Protocol.MessageExchangeStream.Receive[T]() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\Protocol\MessageExchangeStream.cs:line 198
   at Halibut.HalibutRuntime.<>c__DisplayClass53_0.<SendOutgoingHttpsRequest>b__0(MessageExchangeProtocol protocol) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\HalibutRuntime.cs:line 274
   at Halibut.Transport.SecureListeningClient.ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken) in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Transport\SecureListeningClient.cs:line 74 https://localhost:51058/  42 Unexpected exception executing transaction.
[TestContextConnectionLog] 04:34:38.142 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)]          Service: Info: listen://[::]:51058/  42 Listener stopped
[UsageFixture] 04:34:38.144 +00:00 [StreamsCanBeSent(Listening, v:Latest, Network Condition: 'Perfect', Iters: 1000)] Tearing down
```


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
