### PR TITLE
Add tests for sending/receiving complex objects

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -29,7 +29,10 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         static ComplexResponse FixResponseDataStreams(ComplexResponse response)
         {
-            response.Payloads = response.Payloads.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            foreach (var pair in response.Payloads)
+            {
+                response.Payloads[pair.Key] = pair.Value.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            }
             response.Child.First = response.Child.First.ConfigureWriterOnReceivedDataStream();
             response.Child.Second = response.Child.Second.ConfigureWriterOnReceivedDataStream();
             return response;

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Halibut.TestUtils.Contracts;
+using Halibut.TestUtils.SampleProgram.Base.Utils;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class DelegateComplexObjectService: IComplexObjectService
+    {
+        readonly IComplexObjectService service;
+
+        public DelegateComplexObjectService(IComplexObjectService service)
+        {
+            this.service = service;
+        }
+
+        public ComplexResponse Process(ComplexRequest request)
+        {
+            var response = service.Process(FixRequestDataStreams(request));
+            return FixResponseDataStreams(response);
+        }
+
+        static ComplexRequest FixRequestDataStreams(ComplexRequest request)
+        {
+            request.Payload = request.Payload.ConfigureWriterOnReceivedDataStream();
+            request.Child.First = request.Child.First.ConfigureWriterOnReceivedDataStream();
+            request.Child.Second = request.Child.Second.ConfigureWriterOnReceivedDataStream();
+            return request;
+        }
+
+        static ComplexResponse FixResponseDataStreams(ComplexResponse response)
+        {
+            response.Payloads = response.Payloads.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            response.Child.First = response.Child.First.ConfigureWriterOnReceivedDataStream();
+            response.Child.Second = response.Child.Second.ConfigureWriterOnReceivedDataStream();
+            return response;
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.SampleProgram.Base.Utils;
 
@@ -29,10 +31,13 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         static ComplexResponse FixResponseDataStreams(ComplexResponse response)
         {
+            var newPayloads = new Dictionary<Guid, IList<DataStream>>();
             foreach (var pair in response.Payloads)
             {
-                response.Payloads[pair.Key] = pair.Value.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+                newPayloads[pair.Key] = pair.Value.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
             }
+
+            response.Payloads = newPayloads;
             response.Child.First = response.Child.First.ConfigureWriterOnReceivedDataStream();
             response.Child.Second = response.Child.Second.ConfigureWriterOnReceivedDataStream();
             return response;

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -18,6 +18,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             {
                 services.Register<IEchoService>(() => new EchoService());
                 services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
+                services.Register<IComplexObjectService>(() => new ComplexObjectService());
             }
 
             if (SettingsHelper.IsWithCachingService())
@@ -46,6 +47,9 @@ namespace Halibut.TestUtils.SampleProgram.Base
             
             var forwardingMultipleParametersTestService = clientWhichTalksToLatestHalibut.CreateClient<IMultipleParametersTestService>(realServiceEndpoint);
             services.Register<IMultipleParametersTestService>(() => new DelegateMultipleParametersTestService(forwardingMultipleParametersTestService));
+
+            var forwardingComplexObjectTestService = clientWhichTalksToLatestHalibut.CreateClient<IComplexObjectService>(realServiceEndpoint);
+            services.Register<IComplexObjectService>(() => new DelegateComplexObjectService(forwardingComplexObjectTestService));
             
             // The ICachingService is not supported since, the new attributes are not available in the versions of Halibut in the compat library.
             return services;

--- a/source/Halibut.TestUtils.Contracts/DataStreamExtensionMethods.cs
+++ b/source/Halibut.TestUtils.Contracts/DataStreamExtensionMethods.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.IO;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public static class DataStreamExtensionMethods
+    {
+        public static string ReadAsString(this DataStream stream)
+        {
+            string result = null;
+            stream.Receiver().Read(s =>
+            {
+                using (var reader = new StreamReader(s))
+                {
+                    result = reader.ReadToEnd();
+                }
+            });
+            return result;
+        }
+    }
+}

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -19,7 +20,7 @@ namespace Halibut.TestUtils.Contracts
     public class ComplexResponse
     {
         public string RequestId;
-        public IList<DataStream> Payloads;
+        public IDictionary<Guid, IList<DataStream>> Payloads;
 
         public ComplexObjectChild Child;
     }
@@ -38,35 +39,22 @@ namespace Halibut.TestUtils.Contracts
             string payload = request.Payload.ReadAsString();
             for (int i = 1; i <= request.NumberOfCopies; i++)
             {
-                dataStreams.Add(ProcessPayload(i, payload));
+                dataStreams.Add(DataStream.FromString(i + ": " + payload));
             }
 
             return new ComplexResponse
             {
                 RequestId = request.RequestId,
-                Payloads = dataStreams,
+                Payloads = new Dictionary<Guid, IList<DataStream>>
+                {
+                    {Guid.NewGuid(), dataStreams}
+                },
                 Child = new ComplexObjectChild
                 {
-                    First = ProcessFirst(request.Child.First),
-                    Second = ProcessSecond(request.Child.Second),
+                    First = DataStream.FromString("First: " + request.Child.First.ReadAsString()),
+                    Second = DataStream.FromString("Second: " + request.Child.Second.ReadAsString()),
                 }
-                
             };
-        }
-
-        public static DataStream ProcessPayload(int copyNumber, string payload)
-        {
-            return DataStream.FromString(copyNumber + ": " + payload);
-        }
-
-        public static DataStream ProcessFirst(DataStream payload)
-        {
-            return DataStream.FromString("First: " + payload.ReadAsString());
-        }
-
-        public static DataStream ProcessSecond(DataStream payload)
-        {
-            return DataStream.FromString("Second: " + payload.ReadAsString());
         }
     }
 }

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public interface IComplexObjectService
+    {
+        ComplexResponse Process(ComplexRequest request);
+    }
+
+    public class ComplexRequest
+    {
+        public string RequestId;
+        public DataStream Payload;
+        public int NumberOfCopies;
+
+        public ComplexObjectChild Child;
+    }
+
+    public class ComplexResponse
+    {
+        public string RequestId;
+        public IList<DataStream> Payloads;
+
+        public ComplexObjectChild Child;
+    }
+
+    public class ComplexObjectChild
+    {
+        public DataStream First;
+        public DataStream Second;
+    }
+
+    public class ComplexObjectService : IComplexObjectService
+    {
+        public ComplexResponse Process(ComplexRequest request)
+        {
+            IList<DataStream> dataStreams = new List<DataStream>();
+            string payload = request.Payload.ReadAsString();
+            for (int i = 1; i <= request.NumberOfCopies; i++)
+            {
+                dataStreams.Add(ProcessPayload(i, payload));
+            }
+
+            return new ComplexResponse
+            {
+                RequestId = request.RequestId,
+                Payloads = dataStreams,
+                Child = new ComplexObjectChild
+                {
+                    First = ProcessFirst(request.Child.First),
+                    Second = ProcessSecond(request.Child.Second),
+                }
+                
+            };
+        }
+
+        public static DataStream ProcessPayload(int copyNumber, string payload)
+        {
+            return DataStream.FromString(copyNumber + ": " + payload);
+        }
+
+        public static DataStream ProcessFirst(DataStream payload)
+        {
+            return DataStream.FromString("First: " + payload.ReadAsString());
+        }
+
+        public static DataStream ProcessSecond(DataStream payload)
+        {
+            return DataStream.FromString("Second: " + payload.ReadAsString());
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -28,6 +28,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         IEchoService echoService = new EchoService();
         ICachingService cachingService = new CachingService();
         IMultipleParametersTestService multipleParametersTestService = new MultipleParametersTestService();
+        IComplexObjectService complexObjectService = new ComplexObjectService();
         Func<int, PortForwarder>? portForwarderFactory;
         LogLevel halibutLogLevel;
         
@@ -106,6 +107,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        public PreviousClientVersionAndLatestServiceBuilder WithComplexObjectService(IComplexObjectService complexObjectService)
+        {
+            this.complexObjectService = complexObjectService;
+            return this;
+        }
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithStandardServices()
         {
             return WithStandardServices();
@@ -113,7 +120,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
         public PreviousClientVersionAndLatestServiceBuilder WithStandardServices()
         {
-            return WithEchoServiceService(new EchoService()).WithMultipleParametersTestService(new MultipleParametersTestService());
+            return WithEchoServiceService(new EchoService())
+                .WithMultipleParametersTestService(new MultipleParametersTestService())
+                .WithComplexObjectService(new ComplexObjectService());
         }
         
         IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
@@ -168,7 +177,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 .WithServiceFactory(new DelegateServiceFactory()
                     .Register(() => echoService)
                     .Register(() => cachingService)
-                    .Register(() => multipleParametersTestService))
+                    .Register(() => multipleParametersTestService)
+                    .Register(() => complexObjectService))
                 .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                 .WithLogFactory(new TestContextLogFactory("Tentacle", halibutLogLevel))
                 .Build();

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -130,7 +130,11 @@ namespace Halibut.Tests.Support
         
         public LatestClientAndLatestServiceBuilder WithStandardServices()
         {
-            return this.WithEchoService().WithMultipleParametersTestService().WithCachingService();
+            return this
+                .WithEchoService()
+                .WithMultipleParametersTestService()
+                .WithCachingService()
+                .WithComplexObjectService();
         }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithCachingService() => WithCachingService();

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
@@ -17,6 +17,11 @@ namespace Halibut.Tests.Support
             return builder.WithService<IMultipleParametersTestService>(() => new MultipleParametersTestService());
         }
 
+        public static LatestClientAndLatestServiceBuilder WithComplexObjectService(this LatestClientAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<IComplexObjectService>(() => new ComplexObjectService());
+        }
+
         public static LatestClientAndLatestServiceBuilder WithDoSomeActionService(this LatestClientAndLatestServiceBuilder builder, Action action)
         {
             return builder.WithService<IDoSomeActionService>(() => new DoSomeActionService(action));

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -171,9 +171,16 @@ namespace Halibut.Tests
             {
                 var service = clientAndService.CreateClient<IComplexObjectService>();
                 var requestId = "TestRequestIdentifier";
+                
                 var payload = "ThisIsMyTestString";
+                var resultPayload1 = "1: ThisIsMyTestString";
+                var resultPayload2 = "2: ThisIsMyTestString";
+                var resultPayload3 = "3: ThisIsMyTestString";
+                
                 var childPayload1 = "ChildPayload1";
                 var childPayload2 = "ChildPayload2";
+                var resultChildPayload1 = "First: ChildPayload1";
+                var resultChildPayload2 = "Second: ChildPayload2";
 
                 for (int i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
                 {
@@ -190,14 +197,14 @@ namespace Halibut.Tests
                     });
                     result.RequestId.Should().Be(requestId);
 
-                    var payloads = result.Payloads.ToArray();
-                    payloads.Length.Should().Be(3);
-                    payloads[0].ReadAsString().Should().Be(ComplexObjectService.ProcessPayload(1, payload).ReadAsString());
-                    payloads[1].ReadAsString().Should().Be(ComplexObjectService.ProcessPayload(2, payload).ReadAsString());
-                    payloads[2].ReadAsString().Should().Be(ComplexObjectService.ProcessPayload(3, payload).ReadAsString());
+                    result.Payloads.Count.Should().Be(1);
+                    var payloads = result.Payloads.First().Value.ToArray();
+                    payloads[0].ReadAsString().Should().Be(resultPayload1);
+                    payloads[1].ReadAsString().Should().Be(resultPayload2);
+                    payloads[2].ReadAsString().Should().Be(resultPayload3);
 
-                    result.Child.First.ReadAsString().Should().Be(ComplexObjectService.ProcessFirst(DataStream.FromString(childPayload1)).ReadAsString());
-                    result.Child.Second.ReadAsString().Should().Be(ComplexObjectService.ProcessSecond(DataStream.FromString(childPayload2)).ReadAsString());
+                    result.Child.First.ReadAsString().Should().Be(resultChildPayload1);
+                    result.Child.Second.ReadAsString().Should().Be(resultChildPayload2);
                 }
             }
         }


### PR DESCRIPTION
Adds a test which sends and receives complex objects containing multiple DataStreams via Halibut.

Part of [sc-53157]