### PR TITLE
Fix buffer overread on net48

### DIFF
--- a/source/Halibut.Tests/Transport/Protocol/DeflateStreamInputBufferReflectorFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/DeflateStreamInputBufferReflectorFixture.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using Halibut.Diagnostics;
+using Halibut.Transport;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
@@ -9,19 +11,6 @@ namespace Halibut.Tests.Transport.Protocol
 {
     public class DeflateStreamInputBufferReflectorFixture
     {
-        #if NETFRAMEWORK
-        [Test]
-        public void TryGetAvailableInputBufferSizeShouldThrow()
-        {
-            var sut = new DeflateStreamInputBufferReflector();
-
-            using (var ms = new MemoryStream())
-            using (var deflate = new DeflateStream(ms, CompressionMode.Decompress))
-            {
-                Assert.Throws<PlatformNotSupportedException>(() => sut.TryGetAvailableInputBufferSize(deflate, out _));
-            }
-        }
-        #else
         [Test]
         public void TryGetAvailableInputBufferSizeShouldReadSize()
         {
@@ -30,19 +19,20 @@ namespace Halibut.Tests.Transport.Protocol
             // Write both compressed and uncompressed data to the stream.
             using (var inputDeflate = new DeflateStream(stream, CompressionMode.Compress, true))
             {
-                inputDeflate.Write(Encoding.ASCII.GetBytes("Compressed")); // length = 10
+                var bytes = Encoding.ASCII.GetBytes("Compressed");
+                inputDeflate.Write(bytes, 0, bytes.Length); // length = 10
             }
-            stream.Write(Encoding.ASCII.GetBytes("Not Compressed")); // length = 14
+            var notCompressedBytes = Encoding.ASCII.GetBytes("Not Compressed");
+            stream.Write(notCompressedBytes, 0, notCompressedBytes.Length); // length = 14
             stream.Position = 0;
 
             // Now decompress, filling the DeflateStream buffer
             using var deflate = new DeflateStream(stream, CompressionMode.Decompress);
             _ = deflate.Read(new byte[10], 0, 10);
 
-            var sut = new DeflateStreamInputBufferReflector();
+            var sut = new DeflateStreamInputBufferReflector(new InMemoryConnectionLog("poll://foo/"));
             Assert.IsTrue(sut.TryGetAvailableInputBufferSize(deflate, out var result));
             Assert.AreEqual(14, result);
         }
-        #endif
     }
 }

--- a/source/Halibut/Transport/Observability/ByteCountingStream.cs
+++ b/source/Halibut/Transport/Observability/ByteCountingStream.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/source/Halibut/Transport/Observability/ByteCountingStream.cs
+++ b/source/Halibut/Transport/Observability/ByteCountingStream.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/source/Halibut/Transport/Protocol/IMessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/IMessageSerializer.cs
@@ -6,6 +6,6 @@ namespace Halibut.Transport.Protocol
     {
         void WriteMessage<T>(Stream stream, T message);
 
-        T ReadMessage<T>(Stream stream);
+        T ReadMessage<T>(RewindableBufferStream stream);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -19,7 +19,7 @@ namespace Halibut.Transport.Protocol
         const string MxSubscriber = "MX-SUBSCRIBER";
         const string MxServer = "MX-SERVER";
 
-        readonly Stream stream;
+        readonly RewindableBufferStream stream;
         readonly ILog log;
         readonly StreamWriter streamWriter;
         readonly IMessageSerializer serializer;
@@ -28,11 +28,7 @@ namespace Halibut.Transport.Protocol
 
         public MessageExchangeStream(Stream stream, IMessageSerializer serializer, ILog log)
         {
-            #if NETFRAMEWORK
-            this.stream = stream;
-            #else
             this.stream = new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
-            #endif
             this.log = log;
             streamWriter = new StreamWriter(this.stream, new UTF8Encoding(false)) { NewLine = "\r\n" };
             this.serializer = serializer;

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
-using Halibut.Transport.Observability;
-using System.Linq;
 using Halibut.Diagnostics;
+using Halibut.Transport.Observability;
 using Halibut.Transport.Streams;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
@@ -27,7 +26,7 @@ namespace Halibut.Transport.Protocol
                 settings.SerializationBinder = binder;
                 return JsonSerializer.Create(settings);
             };
-            deflateReflector = new DeflateStreamInputBufferReflector();
+            deflateReflector = new DeflateStreamInputBufferReflector(new InMemoryConnectionLog("poll://foo/"));
             observer = new NoMessageSerializerObserver();
         }
 
@@ -39,7 +38,7 @@ namespace Halibut.Transport.Protocol
             this.typeRegistry = typeRegistry;
             this.createSerializer = createSerializer;
             this.observer = observer;
-            deflateReflector = new DeflateStreamInputBufferReflector();
+            deflateReflector = new DeflateStreamInputBufferReflector(new InMemoryConnectionLog("poll://foo/"));
         }
 
         public void AddToMessageContract(params Type[] types) // kept for backwards compatibility
@@ -63,15 +62,14 @@ namespace Halibut.Transport.Protocol
             observer.MessageWritten(compressedByteCountingStream.BytesWritten);
         }
 
-        public T ReadMessage<T>(Stream stream)
+        public T ReadMessage<T>(RewindableBufferStream stream)
         {
-            var messageReader = MessageReaderStrategyFromStream<T>(stream);
             using (var errorRecordingStream = new ErrorRecordingStream(stream, closeInner: false))
             {
                 Exception exceptionFromDeserialisation = null;
                 try
                 {
-                    return messageReader(errorRecordingStream);
+                    return ReadCompressedMessage<T>(errorRecordingStream, stream);
                 }
                 catch (Exception e)
                 {
@@ -99,34 +97,9 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        Func<Stream, T> MessageReaderStrategyFromStream<T>(Stream stream)
+        T ReadCompressedMessage<T>(Stream stream, IRewindableBuffer rewindableBuffer)
         {
-            if (stream is IRewindableBuffer rewindable)
-            {
-                return (s) => ReadCompressedMessageRewindable<T>(s, rewindable);
-            }
-
-            return (s) => ReadCompressedMessage<T>(s);
-        }
-
-        T ReadCompressedMessage<T>(Stream stream)
-        {
-            using (var compressedByteCountingStream = new ByteCountingStream(stream, OnDispose.LeaveInputStreamOpen))
-            using (var zip = new DeflateStream(compressedByteCountingStream, CompressionMode.Decompress, true))
-            using (var decompressedByteCountingStream = new ByteCountingStream(zip, OnDispose.LeaveInputStreamOpen))
-            using (var bson = new BsonDataReader(decompressedByteCountingStream) { CloseInput = false })
-            {
-                var messageEnvelope = DeserializeMessage<T>(bson);
-
-                observer.MessageRead(compressedByteCountingStream.BytesRead, decompressedByteCountingStream.BytesRead);
-
-                return messageEnvelope.Message;
-            }
-        }
-
-        T ReadCompressedMessageRewindable<T>(Stream stream, IRewindableBuffer rewindable)
-        {
-            rewindable.StartBuffer();
+            rewindableBuffer.StartBuffer();
             try
             {
                 using (var compressedByteCountingStream = new ByteCountingStream(stream, OnDispose.LeaveInputStreamOpen))
@@ -139,11 +112,11 @@ namespace Halibut.Transport.Protocol
                     // Find the unused bytes in the DeflateStream input buffer
                     if (deflateReflector.TryGetAvailableInputBufferSize(zip, out var unusedBytesCount))
                     {
-                        rewindable.FinishAndRewind(unusedBytesCount);
+                        rewindableBuffer.FinishAndRewind(unusedBytesCount);
                     }
                     else
                     {
-                        rewindable.CancelBuffer();
+                        rewindableBuffer.CancelBuffer();
                     }
 
                     observer.MessageRead(compressedByteCountingStream.BytesRead - unusedBytesCount, decompressedObservableStream.BytesRead);
@@ -153,7 +126,7 @@ namespace Halibut.Transport.Protocol
             }
             catch
             {
-                rewindable.CancelBuffer();
+                rewindableBuffer.CancelBuffer();
                 throw;
             }
         }

--- a/source/Halibut/Transport/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/RewindableBufferStream.cs
@@ -9,7 +9,7 @@ namespace Halibut.Transport
     /// Only supports rewinding the last read of the underlying stream. Which appears to be all
     /// that is required when rewinding from a Deflate stream over read.
     /// </summary>
-    class RewindableBufferStream : Stream, IRewindableBuffer
+    public class RewindableBufferStream : Stream, IRewindableBuffer
     {
         readonly Stream baseStream;
         readonly byte[] rewindBuffer;


### PR DESCRIPTION
# Background

A message in the Halibut protocol is:
```
<DeflateStream><DataStreams with prefix and postix of size><Control Messages>
```

The protocol sends no indication of when the `DeflateStream` ends or its length. This means we must find the length of the deflate stream by decompressing the stream. The `DeflateStream` implmentation in both dotnet and netframework will both read in more bytes from the underlying stream if the compressed bytes do not end at 8KB (the buffer sized used by the deflate stream).  This can be a problem since the following `DataStreams` and/or `Control Messages` may be consumed and dropped by the deflate stream.

This was fixed for dotnet [here](https://github.com/OctopusDeploy/Halibut/pull/154) but was never fixed for netframework.

The issue of overeading bytes during normal Halibut operation in netframework could not be reproduced. It appears to be that so long as the sender makes distinct writes between the `<DeflateStream>` section and the following sections, when reading a stream in netframework it will always happen to read bytes such that bytes from distinct writes are never mixed. EXAMPLE:

Sender sends:
```
sslStream.write("hello");
sslStream.write(StringOf12Kb);
sslStream.write("cya");
sslStream.flush();
```


If in net48 after the flush has completed:
```
sslStream.read(byteArray, 0, 2); // reads "he"
sslStream.read(byteArray, 0, 99999999); // only reads "llo" despite more being available 
// and requesting lots of data. (This is why it appears to work in net48)
sslStream.read(byteArray, 0, 99999999); // Reads the 12kb string
sslStream.read(byteArray, 0, 99999999); // reads "cya"
```

This is different to net6 where the operations would be:
```
sslStream.read(byteArray, 0, 2); // reads "he"
sslStream.read(byteArray, 0, 99999999); // reads "llo" and the 12kb string and "cya"
```


This means that communications to net48 are very delicate and depend on however we happen to be creating encrypted frames of data. If For example writing of a message is changed to writing all of the data to a `MemoryStream` and then that is sent over the sslStream in one go net48 WILL overread.

[SC-53378]

# The change

The change here is to change net48 to be aligned with net6, such that it no longer depends on the chance that data is sent in a way that the sslStream which by chance happens to force distinct reads between the frames for communications to be successful.

This also add's a try catch in the reflector. Although never seen as something that is required should an underlying implementation of dotnet change halibut wont be immediately broken.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
