### PR TITLE
Fixes reading buffers larger than the rewindable stream buffer

### DIFF
--- a/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
@@ -176,6 +176,55 @@ namespace Halibut.Tests.Transport
                 Assert.AreEqual(0, sut.Read(rewoundOutputBuffer, 0, 1));
             }
         }
+        
+        [Test]
+        public void ReadingMoreThanTheBufferSizeShouldSupportRewindingA()
+        {
+            using (var baseStream = new MemoryStream(2))
+            using (var sut =  new RewindableBufferStream(baseStream, 2))
+            {
+                var inputBuffer = Encoding.ASCII.GetBytes("Test");
+                baseStream.Write(inputBuffer, 0, inputBuffer.Length);
+                baseStream.Position = 0;
+
+                sut.StartBuffer();
+                var outputBuffer = new byte[inputBuffer.Length];
+                while (sut.Read(outputBuffer, 0, inputBuffer.Length) > 0)
+                {
+                }
+                
+                sut.FinishAndRewind(2);
+
+                var rewoundOutputBuffer = new byte[8];
+                Assert.AreEqual(2, sut.Read(rewoundOutputBuffer, 0, 8));
+                var postRewindValue = Encoding.ASCII.GetString(rewoundOutputBuffer.AsSpan(0, 2).ToArray());
+                Assert.AreEqual("st", postRewindValue);
+            }
+        }
+        
+        [Test]
+        public async Task ReadingMoreThanTheBufferSizeShouldSupportRewindingAsync()
+        {
+            using (var baseStream = new MemoryStream(2))
+            using (var sut =  new RewindableBufferStream(baseStream, 2))
+            {
+                var inputBuffer = Encoding.ASCII.GetBytes("Test");
+                baseStream.Write(inputBuffer, 0, inputBuffer.Length);
+                baseStream.Position = 0;
+
+                sut.StartBuffer();
+                var outputBuffer = new byte[inputBuffer.Length];
+                while (await sut.ReadAsync(outputBuffer, 0, inputBuffer.Length) > 0)
+                {
+                }
+                sut.FinishAndRewind(2);
+
+                var rewoundOutputBuffer = new byte[8];
+                Assert.AreEqual(2, sut.Read(rewoundOutputBuffer, 0, 8));
+                var postRewindValue = Encoding.ASCII.GetString(rewoundOutputBuffer.AsSpan(0, 2).ToArray());
+                Assert.AreEqual("st", postRewindValue);
+            }
+        }
 
         static class RewindableBufferStreamBuilder
         {

--- a/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
@@ -178,7 +178,7 @@ namespace Halibut.Tests.Transport
         }
         
         [Test]
-        public void ReadingMoreThanTheBufferSizeShouldSupportRewindingA()
+        public void ReadingMoreThanTheBufferSizeShouldSupportRewinding()
         {
             using (var baseStream = new MemoryStream(2))
             using (var sut =  new RewindableBufferStream(baseStream, 2))


### PR DESCRIPTION
# Background

A bug in the `RewindableBufferStream` exists where asking for more bytes than the RewindableBufferStream's buffer would result in an out of bounds exception.

This happens to not cause problems in halibut right now since the Deflate stream default (const) buffer size is equal to the `RewindableBufferStream`'s buffer.

[SC-53460]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
