### PR TITLE
Adds timeout tests around sending/receiving messages.

### DIFF
--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
@@ -26,6 +26,11 @@ namespace Halibut.Tests.Support
         {
             return builder.WithService<IDoSomeActionService>(() => new DoSomeActionService(action));
         }
+        
+        public static LatestClientAndLatestServiceBuilder WithReturnSomeDataStreamService(this LatestClientAndLatestServiceBuilder builder, Func<DataStream> dataStreamCreator)
+        {
+            return builder.WithService<IReturnSomeDataStreamService>(() => new ReturnSomeDataStreamService(dataStreamCreator));
+        }
 
         public static LatestClientAndLatestServiceBuilder WithReadDataStreamService(this LatestClientAndLatestServiceBuilder builder)
         {

--- a/source/Halibut.Tests/TestServices/IReturnSomeDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/IReturnSomeDataStreamService.cs
@@ -1,0 +1,7 @@
+namespace Halibut.Tests.TestServices
+{
+    public interface IReturnSomeDataStreamService
+    {
+        public DataStream SomeDataStream();
+    }
+}

--- a/source/Halibut.Tests/TestServices/ReturnSomeDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/ReturnSomeDataStreamService.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Halibut.Tests.TestServices
+{
+    public class ReturnSomeDataStreamService : IReturnSomeDataStreamService
+    {
+        readonly Func<DataStream> createDataStream;
+
+        public ReturnSomeDataStreamService(Func<DataStream> createDataStream)
+        {
+            this.createDataStream = createDataStream;
+        }
+
+        public DataStream SomeDataStream()
+        {
+            return createDataStream();
+        }
+    }
+}

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -10,7 +10,7 @@ using Halibut.Tests.Util;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
-namespace Halibut.Tests
+namespace Halibut.Tests.Timeouts
 {
     public class SendingAndReceivingRequestMessagesTimeoutsFixture : BaseTest
     {

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -26,7 +26,6 @@ namespace Halibut.Tests.Timeouts
                        .WithDoSomeActionService(() => portForwarderRef.Value.PauseExistingConnections())
                        .Build(CancellationToken))
             {
-                portForwarderRef.Value = clientAndService.PortForwarder;
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
 
@@ -57,7 +56,6 @@ namespace Halibut.Tests.Timeouts
                            thenSend: "All done"))
                        .Build(CancellationToken))
             {
-                portForwarderRef.Value = clientAndService.PortForwarder;
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
 

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Diagnostics;
@@ -10,11 +9,10 @@ using Halibut.Tests.TestServices;
 using Halibut.Tests.Util;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
-using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests
 {
-    public class TimeoutsFixture : BaseTest
+    public class SendingAndReceivingRequestMessagesTimeoutsFixture : BaseTest
     {
         [Test]
         [TestCaseSource(typeof(ServiceConnectionTypesToTest))]

--- a/source/Halibut.Tests/TimeoutsFixture.cs
+++ b/source/Halibut.Tests/TimeoutsFixture.cs
@@ -108,7 +108,7 @@ namespace Halibut.Tests
                     addControlMessageTimeout += HalibutLimits.TcpClientHeartbeatSendTimeout;
                 }
 
-                sw.Elapsed.Should().BeCloseTo(HalibutLimits.TcpClientSendTimeout * 2 + addControlMessageTimeout, TimeSpan.FromSeconds(5),
+                sw.Elapsed.Should().BeCloseTo(HalibutLimits.TcpClientSendTimeout + HalibutLimits.TcpClientSendTimeout + addControlMessageTimeout, TimeSpan.FromSeconds(5),
                     "We 'should' wait the send timeout amount of time, however when an error occurs writing to the zip (deflate)" +
                     "stream we also call dispose which again attempts to write to the stream. Thus we wait 2 times the TcpClientSendTimeout.");
 

--- a/source/Halibut.Tests/Util/DataStreamUtil.cs
+++ b/source/Halibut.Tests/Util/DataStreamUtil.cs
@@ -6,8 +6,8 @@ namespace Halibut.Tests.Util
     {
         public static DataStream From(string firstSend, Action andThenRun, string thenSend)
         {
-            var helloBytes = "hello".GetBytesUtf8();
-            var allDoneBytes = "All done".GetBytesUtf8();
+            var helloBytes = firstSend.GetBytesUtf8();
+            var allDoneBytes = thenSend.GetBytesUtf8();
             return new DataStream(helloBytes.Length + allDoneBytes.Length, stream =>
             {
                 stream.Write(helloBytes);

--- a/source/Halibut.Tests/Util/DataStreamUtil.cs
+++ b/source/Halibut.Tests/Util/DataStreamUtil.cs
@@ -10,10 +10,10 @@ namespace Halibut.Tests.Util
             var allDoneBytes = thenSend.GetBytesUtf8();
             return new DataStream(helloBytes.Length + allDoneBytes.Length, stream =>
             {
-                stream.Write(helloBytes);
+                stream.Write(helloBytes, 0, helloBytes.Length);
                 stream.Flush();
                 andThenRun();
-                stream.Write(allDoneBytes);
+                stream.Write(allDoneBytes, 0, allDoneBytes.Length);
                 stream.Flush();
             });
         }

--- a/source/Halibut.Tests/Util/DataStreamUtil.cs
+++ b/source/Halibut.Tests/Util/DataStreamUtil.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Halibut.Tests.Util
+{
+    public class DataStreamUtil
+    {
+        public static DataStream From(string firstSend, Action andThenRun, string thenSend)
+        {
+            var helloBytes = "hello".GetBytesUtf8();
+            var allDoneBytes = "All done".GetBytesUtf8();
+            return new DataStream(helloBytes.Length + allDoneBytes.Length, stream =>
+            {
+                stream.Write(helloBytes);
+                stream.Flush();
+                andThenRun();
+                stream.Write(allDoneBytes);
+                stream.Flush();
+            });
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/PortForwarderBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/PortForwarderBuilderExtensionMethods.cs
@@ -6,7 +6,8 @@ namespace Halibut.Tests.Util
     public static class PortForwarderBuilderExtensionMethods
     {
         /// <summary>
-        /// 
+        ///  Pause port forwarder TCP streams after a number of bytes have been received on either end of the forwarder
+        /// TCP connection.
         /// </summary>
         /// <param name="portForwarderBuilder"></param>
         /// <param name="numberOfBytesBeforePausingAStream">When this many bytes have been received by a single port forwarder TCPPump

--- a/source/Halibut.Tests/Util/PortForwarderBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/PortForwarderBuilderExtensionMethods.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using Octopus.TestPortForwarder;
+
+namespace Halibut.Tests.Util
+{
+    public static class PortForwarderBuilderExtensionMethods
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="portForwarderBuilder"></param>
+        /// <param name="numberOfBytesBeforePausingAStream">When this many bytes have been received by a single port forwarder TCPPump
+        /// that TCP pump will be paused. Other pumps including new ones are not paused.</param>
+        /// <returns></returns>
+        public static PortForwarderBuilder PauseSingleStreamAfterANumberOfBytesHaveBeenSet(this PortForwarderBuilder portForwarderBuilder, int numberOfBytesBeforePausingAStream)
+        {
+            
+            return portForwarderBuilder.WithDataObserver(() =>
+            {
+                long count = 0;
+                var pauseTcpPumpOnceEnoughDataHasBeenPumped = new DataTransferObserverBuilder()
+                    .WithWritingDataObserver(((pump, stream) =>
+                    {
+                        var current = Interlocked.Add(ref count, stream.Length);
+                        if (current > numberOfBytesBeforePausingAStream)
+                        {
+                            pump.Pause();
+                        }
+                    }))
+                    .Build();
+                               
+                return new BiDirectionalDataTransferObserver(pauseTcpPumpOnceEnoughDataHasBeenPumped, pauseTcpPumpOnceEnoughDataHasBeenPumped);
+            });
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/Some.cs
+++ b/source/Halibut.Tests/Util/Some.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text;
+
+namespace Halibut.Tests.Util
+{
+    public static class Some
+    {
+        public static string RandomAsciiStringOfLength(int length)
+        {
+            var sb = new StringBuilder(length);
+            var random = new Random();
+            const int minPrintableCharacter = 32;
+            const int maxPrintableCharacter = 126;
+            const int availableChars = maxPrintableCharacter - minPrintableCharacter;
+            
+            for (int i = 0; i < length; i++)
+            {
+                var nextByte = (char) (random.Next(availableChars) + minPrintableCharacter);
+                sb.Append(nextByte);
+
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/StringExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/StringExtensionMethods.cs
@@ -1,0 +1,13 @@
+using System.IO;
+using System.Text;
+
+namespace Halibut.Tests.Util
+{
+    public static class StringExtensionMethods
+    {
+        public static byte[] GetBytesUtf8(this string s)
+        {
+            return Encoding.UTF8.GetBytes(s);
+        }
+    }
+}

--- a/source/Octopus.TestPortForwarder/TcpPump.cs
+++ b/source/Octopus.TestPortForwarder/TcpPump.cs
@@ -118,6 +118,7 @@ namespace Octopus.TestPortForwarder
                 {
 
                     var socketStatus = await socketPump.PumpBytes(readFrom, writeTo, cancellationToken).ConfigureAwait(false);
+                    await socketPump.PausePump(cancellationToken);
                     if(socketStatus == SocketPump.SocketStatus.SOCKET_CLOSED) break;
                 }
                 catch (SocketException socketException)
@@ -132,6 +133,7 @@ namespace Octopus.TestPortForwarder
                 {
                     logger.Warning(ex, "Received pump exception: {Message}.", ex.Message);
                 }
+                await socketPump.PausePump(cancellationToken);
             }
         }
 


### PR DESCRIPTION
# Background

Adds some tests around Timeouts we now test:
* Timeouts occur when sending a RequestMessage over a network that is paused.
    * After that timeout occurs further requests can be made.
* We already had a test for Timeouts occurring when receiving a `ResponseMessage`, 
    * this updated the test to ensure further requests can be made.
* Timeouts occur when receiving a DataStream
    * And further requests can occur after that timed out request.
* Timeouts occur when sending a DataStream
    * And further requests can occur after that timed out request.


Also updated the port forwardersuch that:
* When a TCP pump is paused  it really remains paused even if one end terminates the connection.
* When no send delay is sent data is passed along immediately, rather than trying to always read as much as possible before sending.

[SC-52821]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
