### PR TITLE
Add a test showing the polling queue keeps the connection alive

### DIFF
--- a/source/Halibut.Tests/Support/TestAttributes/PollingServiceConnectionTypesToTest.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/PollingServiceConnectionTypesToTest.cs
@@ -1,0 +1,28 @@
+﻿
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    public class PollingServiceConnectionTypesToTest : IEnumerable<ServiceConnectionType>
+    {
+        public IEnumerator<ServiceConnectionType> GetEnumerator()
+        {
+            var toTest = new List<ServiceConnectionType>()
+            {
+                ServiceConnectionType.Polling,
+// Disabled while these are causing flakey Team City Tests
+//#if SUPPORTS_WEB_SOCKET_CLIENT
+//             ServiceConnectionType.PollingOverWebSocket
+//#endif
+            };
+            return ((IEnumerable<ServiceConnectionType>)toTest).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/TestAttributes/PollingServiceConnectionTypesToTest.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/PollingServiceConnectionTypesToTest.cs
@@ -1,7 +1,6 @@
-﻿
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Halibut.Tests.Support.TestAttributes
 {
@@ -9,7 +8,7 @@ namespace Halibut.Tests.Support.TestAttributes
     {
         public IEnumerator<ServiceConnectionType> GetEnumerator()
         {
-            var toTest = new List<ServiceConnectionType>()
+            var toTest = new List<ServiceConnectionType>
             {
                 ServiceConnectionType.Polling,
 // Disabled while these are causing flakey Team City Tests
@@ -17,7 +16,7 @@ namespace Halibut.Tests.Support.TestAttributes
 //             ServiceConnectionType.PollingOverWebSocket
 //#endif
             };
-            return ((IEnumerable<ServiceConnectionType>)toTest).GetEnumerator();
+            return ((IEnumerable<ServiceConnectionType>) toTest).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
+++ b/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
@@ -19,7 +19,6 @@ namespace Halibut.Tests.Timeouts
         [TestCaseSource(typeof(PollingServiceConnectionTypesToTest))]
         public async Task WhenThenNetworkIsPaused_WhileReadingAResponseMessage_ATcpReadTimeoutOccurs_and_FurtherRequestsCanBeMade(ServiceConnectionType serviceConnectionType)
         {
-            
             var timeSpansBetweenDataFlowing = new ConcurrentBag<TimeSpan>();
             using (var clientAndService = await LatestClientAndLatestServiceBuilder
                        .ForServiceConnectionType(serviceConnectionType)
@@ -46,7 +45,6 @@ namespace Halibut.Tests.Timeouts
                 echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
 
                 timeSpansBetweenDataFlowing.Clear();
-
 
                 await Task.Delay(TimeSpan.FromSeconds(20));
 

--- a/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
+++ b/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.Timeouts
     {
         [Test]
         [TestCaseSource(typeof(PollingServiceConnectionTypesToTest))]
-        public async Task WhenThenNetworkIsPaused_WhileReadingAResponseMessage_ATcpReadTimeoutOccurs_and_FurtherRequestsCanBeMade(ServiceConnectionType serviceConnectionType)
+        public async Task WhenNoMessagesAreSentToAPollingTentacle_ThePollingRequestQueueCausesNullMessagesToBeSent_KeepingTheConnectionAlive(ServiceConnectionType serviceConnectionType)
         {
             var timeSpansBetweenDataFlowing = new ConcurrentBag<TimeSpan>();
             using (var clientAndService = await LatestClientAndLatestServiceBuilder

--- a/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
+++ b/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Util;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+using Octopus.TestPortForwarder;
+
+namespace Halibut.Tests.Timeouts
+{
+    public class PollingQueueTimeouts : BaseTest
+    {
+        [Test]
+        [TestCaseSource(typeof(PollingServiceConnectionTypesToTest))]
+        public async Task WhenThenNetworkIsPaused_WhileReadingAResponseMessage_ATcpReadTimeoutOccurs_and_FurtherRequestsCanBeMade(ServiceConnectionType serviceConnectionType)
+        {
+            
+            var timeSpansBetweenDataFlowing = new ConcurrentBag<TimeSpan>();
+            using (var clientAndService = await LatestClientAndLatestServiceBuilder
+                       .ForServiceConnectionType(serviceConnectionType)
+                       .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
+                           .WithDataObserver(() =>
+                           {
+                               var perTcpPumpStopwatch = Stopwatch.StartNew();
+                               return new BiDirectionalDataTransferObserver(
+                                   new DataTransferObserverBuilder()
+                                       .WithWritingDataObserver((tcpPump, Stream) =>
+                                       {
+                                           timeSpansBetweenDataFlowing.Add(perTcpPumpStopwatch.Elapsed);
+                                           perTcpPumpStopwatch.Reset();
+                                       })
+                                       .Build(),
+                                   new DataTransferObserverBuilder().Build());
+                           })
+                           .Build())
+                       .WithPendingRequestQueueFactory(logFactory => new FuncPendingRequestQueueFactory(uri => new PendingRequestQueue(logFactory.ForEndpoint(uri), TimeSpan.FromSeconds(1))))
+                       .WithEchoService()
+                       .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService>();
+                echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
+
+                timeSpansBetweenDataFlowing.Clear();
+
+
+                await Task.Delay(TimeSpan.FromSeconds(20));
+
+                timeSpansBetweenDataFlowing.Count.Should().BeGreaterThan(5, "Even though we are not sending messages over the wire, the polling queue should be sending null messages keeping the connection alive.");
+                foreach (var timeSpan in timeSpansBetweenDataFlowing)
+                {
+                    timeSpan.Should().BeLessThan(TimeSpan.FromSeconds(6), "The polling queue should be timing out causing messages to flow across the wire, this should be happen close to every 1 second.");
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
+++ b/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests.Timeouts
                 var echo = clientAndService.CreateClient<IEchoService>();
                 echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
 
-                timeSpansBetweenDataFlowing.Clear();
+                timeSpansBetweenDataFlowing = new ConcurrentBag<TimeSpan>();
 
                 await Task.Delay(TimeSpan.FromSeconds(20));
 

--- a/source/Halibut.Tests/Util/FuncPendingRequestQueueFactory.cs
+++ b/source/Halibut.Tests/Util/FuncPendingRequestQueueFactory.cs
@@ -1,0 +1,20 @@
+using System;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.Util
+{
+    public class FuncPendingRequestQueueFactory : IPendingRequestQueueFactory
+    {
+        Func<Uri, IPendingRequestQueue> createQueue;
+
+        public FuncPendingRequestQueueFactory(Func<Uri, IPendingRequestQueue> createQueue)
+        {
+            this.createQueue = createQueue;
+        }
+
+        public IPendingRequestQueue CreateQueue(Uri endpoint)
+        {
+            return createQueue(endpoint);
+        }
+    }
+}


### PR DESCRIPTION
# Background

Adds a test showing that the polling queue keeps the connection alive by sending data even when no messages are sent to a polling endpoint.

[SC-52821]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
