### PR TITLE
Reworked tests to cover more complex object use cases

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -27,11 +27,11 @@ namespace Halibut.TestUtils.SampleProgram.Base
             request.Child1.ChildPayload1 = request.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
             request.Child1.ChildPayload2 = request.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
             request.Child1.ListOfStreams = request.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            request.Child1.ComplexPayloadSet = request.Child1.ComplexPayloadSet.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            request.Child1.ComplexPayloadSet = request.Child1.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             request.Child2.ChildPayload1 = request.Child2.ChildPayload1.ConfigureWriterOnReceivedDataStream();
             request.Child2.ChildPayload2 = request.Child2.ChildPayload2.ConfigureWriterOnReceivedDataStream();
             request.Child2.ListOfStreams = request.Child2.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             return request;
         }
 
@@ -42,11 +42,11 @@ namespace Halibut.TestUtils.SampleProgram.Base
             response.Child1.ChildPayload1 = response.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
             response.Child1.ChildPayload2 = response.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
             response.Child1.ListOfStreams = response.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            response.Child1.ComplexPayloadSet = response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            response.Child1.ComplexPayloadSet = response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             response.Child2.ChildPayload1 = response.Child2.ChildPayload1.ConfigureWriterOnReceivedDataStream();
             response.Child2.ChildPayload2 = response.Child2.ChildPayload2.ConfigureWriterOnReceivedDataStream();
             response.Child2.ListOfStreams = response.Child2.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             return response;
         }
     }

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -13,40 +13,37 @@ namespace Halibut.TestUtils.SampleProgram.Base
         {
             this.service = service;
         }
-
-        public ComplexResponse Process(ComplexRequest request)
-        {
-            var response = service.Process(FixRequestDataStreams(request));
-            return FixResponseDataStreams(response);
-        }
-
-        static ComplexRequest FixRequestDataStreams(ComplexRequest request)
+        
+        public ComplexObjectMultipleDataStreams Process(ComplexObjectMultipleDataStreams request)
         {
             request.Payload1 = request.Payload1.ConfigureWriterOnReceivedDataStream();
             request.Payload2 = request.Payload2.ConfigureWriterOnReceivedDataStream();
+
+            var response = service.Process(request);
+            
+            response.Payload1 = response.Payload1.ConfigureWriterOnReceivedDataStream();
+            response.Payload2 = response.Payload2.ConfigureWriterOnReceivedDataStream();
+
+            return response;
+        }
+
+        public ComplexObjectMultipleChildren Process(ComplexObjectMultipleChildren request)
+        {
             request.Child1.ChildPayload1 = request.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
             request.Child1.ChildPayload2 = request.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
             request.Child1.ListOfStreams = request.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            request.Child1.ComplexPayloadSet = request.Child1.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
-            request.Child2.ChildPayload1 = request.Child2.ChildPayload1.ConfigureWriterOnReceivedDataStream();
-            request.Child2.ChildPayload2 = request.Child2.ChildPayload2.ConfigureWriterOnReceivedDataStream();
-            request.Child2.ListOfStreams = request.Child2.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
             request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
-            return request;
-        }
+            request.Child1.ListOfStreams = request.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
 
-        static ComplexResponse FixResponseDataStreams(ComplexResponse response)
-        {
-            response.Payload1 = response.Payload1.ConfigureWriterOnReceivedDataStream();
-            response.Payload2 = response.Payload2.ConfigureWriterOnReceivedDataStream();
+            var response = service.Process(request);
+            
             response.Child1.ChildPayload1 = response.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
             response.Child1.ChildPayload2 = response.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
             response.Child1.ListOfStreams = response.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            response.Child1.ComplexPayloadSet = response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
-            response.Child2.ChildPayload1 = response.Child2.ChildPayload1.ConfigureWriterOnReceivedDataStream();
-            response.Child2.ChildPayload2 = response.Child2.ChildPayload2.ConfigureWriterOnReceivedDataStream();
-            response.Child2.ListOfStreams = response.Child2.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
             response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+
             return response;
         }
     }

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -16,35 +16,29 @@ namespace Halibut.TestUtils.SampleProgram.Base
         
         public ComplexObjectMultipleDataStreams Process(ComplexObjectMultipleDataStreams request)
         {
-            request.Payload1 = request.Payload1.ConfigureWriterOnReceivedDataStream();
-            request.Payload2 = request.Payload2.ConfigureWriterOnReceivedDataStream();
+            return FixDataStreams(service.Process(FixDataStreams(request)));
+        }
 
-            var response = service.Process(request);
-            
-            response.Payload1 = response.Payload1.ConfigureWriterOnReceivedDataStream();
-            response.Payload2 = response.Payload2.ConfigureWriterOnReceivedDataStream();
-
-            return response;
+        ComplexObjectMultipleDataStreams FixDataStreams(ComplexObjectMultipleDataStreams complexObject)
+        {
+            complexObject.Payload1 = complexObject.Payload1.ConfigureWriterOnReceivedDataStream();
+            complexObject.Payload2 = complexObject.Payload2.ConfigureWriterOnReceivedDataStream();
+            return complexObject;
         }
 
         public ComplexObjectMultipleChildren Process(ComplexObjectMultipleChildren request)
         {
-            request.Child1.ChildPayload1 = request.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
-            request.Child1.ChildPayload2 = request.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
-            request.Child1.ListOfStreams = request.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
-            request.Child1.ListOfStreams = request.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            return FixDataStreams(service.Process(FixDataStreams(request)));
+        }
 
-            var response = service.Process(request);
-            
-            response.Child1.ChildPayload1 = response.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
-            response.Child1.ChildPayload2 = response.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
-            response.Child1.ListOfStreams = response.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
-            response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
-
-            return response;
+        ComplexObjectMultipleChildren FixDataStreams(ComplexObjectMultipleChildren complexObject)
+        {
+            complexObject.Child1.ChildPayload1 = complexObject.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
+            complexObject.Child1.ChildPayload2 = complexObject.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
+            complexObject.Child1.ListOfStreams = complexObject.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            complexObject.Child2.ComplexPayloadSet = complexObject.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            complexObject.Child2.ComplexPayloadSet = complexObject.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            return complexObject;
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.SampleProgram.Base.Utils;
@@ -23,23 +22,31 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         static ComplexRequest FixRequestDataStreams(ComplexRequest request)
         {
-            request.Payload = request.Payload.ConfigureWriterOnReceivedDataStream();
-            request.Child.First = request.Child.First.ConfigureWriterOnReceivedDataStream();
-            request.Child.Second = request.Child.Second.ConfigureWriterOnReceivedDataStream();
+            request.Payload1 = request.Payload1.ConfigureWriterOnReceivedDataStream();
+            request.Payload2 = request.Payload2.ConfigureWriterOnReceivedDataStream();
+            request.Child1.ChildPayload1 = request.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
+            request.Child1.ChildPayload2 = request.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
+            request.Child1.ListOfStreams = request.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            request.Child1.ComplexPayloadSet = request.Child1.ComplexPayloadSet.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            request.Child2.ChildPayload1 = request.Child2.ChildPayload1.ConfigureWriterOnReceivedDataStream();
+            request.Child2.ChildPayload2 = request.Child2.ChildPayload2.ConfigureWriterOnReceivedDataStream();
+            request.Child2.ListOfStreams = request.Child2.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            request.Child2.ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             return request;
         }
 
         static ComplexResponse FixResponseDataStreams(ComplexResponse response)
         {
-            var newPayloads = new Dictionary<Guid, IList<DataStream>>();
-            foreach (var pair in response.Payloads)
-            {
-                newPayloads[pair.Key] = pair.Value.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            }
-
-            response.Payloads = newPayloads;
-            response.Child.First = response.Child.First.ConfigureWriterOnReceivedDataStream();
-            response.Child.Second = response.Child.Second.ConfigureWriterOnReceivedDataStream();
+            response.Payload1 = response.Payload1.ConfigureWriterOnReceivedDataStream();
+            response.Payload2 = response.Payload2.ConfigureWriterOnReceivedDataStream();
+            response.Child1.ChildPayload1 = response.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
+            response.Child1.ChildPayload2 = response.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
+            response.Child1.ListOfStreams = response.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            response.Child1.ComplexPayloadSet = response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            response.Child2.ChildPayload1 = response.Child2.ChildPayload1.ConfigureWriterOnReceivedDataStream();
+            response.Child2.ChildPayload2 = response.Child2.ChildPayload2.ConfigureWriterOnReceivedDataStream();
+            response.Child2.ListOfStreams = response.Child2.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            response.Child2.ComplexPayloadSet = response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, DataStream>(x.Item1, x.Item2.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             return response;
         }
     }

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -11,50 +12,135 @@ namespace Halibut.TestUtils.Contracts
     public class ComplexRequest
     {
         public string RequestId;
-        public DataStream Payload;
-        public int NumberOfCopies;
 
-        public ComplexObjectChild Child;
+        public DataStream Payload1;
+        public DataStream Payload2;
+
+        public ComplexRequestChild Child1;
+        public ComplexRequestChild Child2;
     }
 
     public class ComplexResponse
     {
         public string RequestId;
-        public IDictionary<Guid, IList<DataStream>> Payloads;
 
-        public ComplexObjectChild Child;
+        public DataStream Payload1;
+        public DataStream Payload2;
+
+        public ComplexResponseChild Child1;
+        public ComplexResponseChild Child2;
     }
 
-    public class ComplexObjectChild
+    public abstract class ComplexChildBase<T>
     {
-        public DataStream First;
-        public DataStream Second;
+        public DataStream ChildPayload1;
+        public DataStream ChildPayload2;
+
+        public IList<DataStream> ListOfStreams;
+        public IDictionary<Guid, string> DictionaryPayload;
+        public T EnumPayload;
+        public ISet<ComplexPair<T, DataStream>> ComplexPayloadSet;
+    }
+
+    public class ComplexRequestChild : ComplexChildBase<ComplexRequestEnum>
+    {
+    }
+
+    public class ComplexResponseChild : ComplexChildBase<ComplexResponseEnum>
+    {
+    }
+
+    public enum ComplexRequestEnum
+    {
+        RequestValue1,
+        RequestValue2,
+        RequestValue3
+    }
+
+    public class ComplexPair<T1, T2>: IEquatable<ComplexPair<T1, T2>>
+    {
+        public ComplexPair(T1 item1, T2 item2)
+        {
+            Item1 = item1;
+            Item2 = item2;
+        }
+
+        public readonly T1 Item1;
+        public readonly T2 Item2;
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((ComplexPair<T1, T2>)obj);
+        }
+
+        public bool Equals(ComplexPair<T1, T2> other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Item1.Equals(other.Item1) && Item2.Equals(other.Item2);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (EqualityComparer<T1>.Default.GetHashCode(Item1) * 397) ^ EqualityComparer<T2>.Default.GetHashCode(Item2);
+            }
+        }
+    }
+
+    public enum ComplexResponseEnum
+    {
+        ResponseValue1,
+        ResponseValue2,
+        ResponseValue3
     }
 
     public class ComplexObjectService : IComplexObjectService
     {
         public ComplexResponse Process(ComplexRequest request)
         {
-            IList<DataStream> dataStreams = new List<DataStream>();
-            string payload = request.Payload.ReadAsString();
-            for (int i = 1; i <= request.NumberOfCopies; i++)
-            {
-                dataStreams.Add(DataStream.FromString(i + ": " + payload));
-            }
-
             return new ComplexResponse
             {
                 RequestId = request.RequestId,
-                Payloads = new Dictionary<Guid, IList<DataStream>>
-                {
-                    {Guid.NewGuid(), dataStreams}
-                },
-                Child = new ComplexObjectChild
-                {
-                    First = DataStream.FromString("First: " + request.Child.First.ReadAsString()),
-                    Second = DataStream.FromString("Second: " + request.Child.Second.ReadAsString()),
-                }
+                Payload1 = AddResponsePrefix(request.Payload1),
+                Payload2 = AddResponsePrefix(request.Payload2),
+                Child1 = MapToResponseChild(request.Child1),
+                Child2 = MapToResponseChild(request.Child2)
             };
         }
+
+        DataStream AddResponsePrefix(DataStream ds)
+        {
+            return DataStream.FromString(AddResponsePrefix(ds.ReadAsString()));
+        }
+
+        string AddResponsePrefix(string s)
+        {
+            return "Response: " + s;
+        }
+
+        ComplexResponseChild MapToResponseChild(ComplexRequestChild requestChild)
+        {
+            return new ComplexResponseChild
+            {
+                ChildPayload1 = AddResponsePrefix(requestChild.ChildPayload1),
+                ChildPayload2 = AddResponsePrefix(requestChild.ChildPayload2),
+                ListOfStreams = requestChild.ListOfStreams.Select(AddResponsePrefix).ToList(),
+                EnumPayload = EnumMap[requestChild.EnumPayload],
+                DictionaryPayload = requestChild.DictionaryPayload.ToDictionary(pair => pair.Key, pair => AddResponsePrefix(pair.Value)),
+                ComplexPayloadSet = requestChild.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, DataStream>(EnumMap[x.Item1], AddResponsePrefix(x.Item2))).ToHashSet()
+            };
+        }
+
+        static readonly Dictionary<ComplexRequestEnum, ComplexResponseEnum> EnumMap = new()
+        {
+            { ComplexRequestEnum.RequestValue1, ComplexResponseEnum.ResponseValue1 },
+            { ComplexRequestEnum.RequestValue2, ComplexResponseEnum.ResponseValue2 },
+            { ComplexRequestEnum.RequestValue3, ComplexResponseEnum.ResponseValue3 }
+        };
     }
 }

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -172,125 +172,111 @@ namespace Halibut.Tests
                 var service = clientAndService.CreateClient<IComplexObjectService>();
                 var requestId = "RequestIdentifier";
                 
-                var requestPayload1 = "Payload #1";
-                var responsePayload1 = "Response: Payload #1";
-                var requestPayload2 = "Payload #2";
-                var responsePayload2 = "Response: Payload #2";
+                var payload1 = "Payload #1";
+                var payload2 = "Payload #2";
                 
-                var requestChild1Payload1 = "Child #1, Payload #1";
-                var responseChild1Payload1 = "Response: Child #1, Payload #1";
-                var requestChild1Payload2 = "Child #1, Payload #2";
-                var responseChild1Payload2 = "Response: Child #1, Payload #2";
-                var requestChild2Payload1 = "Child #2, Payload #1";
-                var responseChild2Payload1 = "Response: Child #2, Payload #1";
-                var requestChild2Payload2 = "Child #2, Payload #2";
-                var responseChild2Payload2 = "Response: Child #2, Payload #2";
+                var child1Payload1 = "Child #1, Payload #1";
+                var child1Payload2 = "Child #1, Payload #2";
+                var child2Payload1 = "Child #2, Payload #1";
+                var child2Payload2 = "Child #2, Payload #2";
 
-                var requestList1 = new[] { "Child #1, List Item #1", "Child #1, List Item #2", "Child #1, List Item #3" };
-                var responseList1 = new[] { "Response: Child #1, List Item #1", "Response: Child #1, List Item #2", "Response: Child #1, List Item #3" };
-                
-                var requestList2 = new[] { "Child #2, List Item #1", "Child #2, List Item #2", "Child #2, List Item #3" };
-                var responseList2 = new[] { "Response: Child #2, List Item #1", "Response: Child #2, List Item #2", "Response: Child #2, List Item #3" };
+                var list1 = new[] { "Child #1, List Item #1", "Child #1, List Item #2", "Child #1, List Item #3" };
+                var list2 = new[] { "Child #2, List Item #1", "Child #2, List Item #2", "Child #2, List Item #3" };
 
-                var requestEnum1 = ComplexRequestEnum.RequestValue1;
-                var responseEnum1 = ComplexResponseEnum.ResponseValue1;
+                var enum1 = ComplexEnum.RequestValue1;
+                var enum2 = ComplexEnum.RequestValue2;
 
-                var requestEnum2 = ComplexRequestEnum.RequestValue2;
-                var responseEnum2 = ComplexResponseEnum.ResponseValue2;
+                var child1Guid1 = Guid.NewGuid();
+                var child1Guid2 = Guid.NewGuid();
+                var child2Guid1 = Guid.NewGuid();
+                var child2Guild2 = Guid.NewGuid();
 
-                var guid_1_1 = Guid.NewGuid();
-                var guid_1_2 = Guid.NewGuid();
-                var guid_2_1 = Guid.NewGuid();
-                var guid_2_2 = Guid.NewGuid();
-
-                var requestDictionary1 = new Dictionary<Guid, string>
+                var dictionary1 = new Dictionary<Guid, string>
                 {
-                    { guid_1_1, "Child #1, Dictionary #1" },
-                    { guid_1_2, "Child #1, Dictionary #2" },
-                };
-                var responseDictionary1 = new Dictionary<Guid, string>
-                {
-                    { guid_1_1, "Response: Child #1, Dictionary #1" },
-                    { guid_1_2, "Response: Child #1, Dictionary #2" },
+                    { child1Guid1, "Child #1, Dictionary #1" },
+                    { child1Guid2, "Child #1, Dictionary #2" },
                 };
                 
-                var requestDictionary2 = new Dictionary<Guid, string>
+                var dictionary2 = new Dictionary<Guid, string>
                 {
-                    { guid_2_1, "Child #2, Dictionary #1" },
-                    { guid_2_2, "Child #2, Dictionary #2" },
-                };
-                var responseDictionary2 = new Dictionary<Guid, string>
-                {
-                    { guid_2_1, "Response: Child #2, Dictionary #1" },
-                    { guid_2_2, "Response: Child #2, Dictionary #2" },
+                    { child2Guid1, "Child #2, Dictionary #1" },
+                    { child2Guild2, "Child #2, Dictionary #2" },
                 };
 
-                var requestSet1 = new HashSet<ComplexPair<ComplexRequestEnum, string>>
+                var set1 = new HashSet<ComplexPair<string>>
                 {
-                    new(ComplexRequestEnum.RequestValue1, "Child #1, ComplexSet #1"),
-                    new(ComplexRequestEnum.RequestValue3, "Child #1, ComplexSet #3"),
-                };
-                var responseSet1 = new HashSet<ComplexPair<ComplexResponseEnum, string>>
-                {
-                    new(ComplexResponseEnum.ResponseValue1, "Response: Child #1, ComplexSet #1"),
-                    new(ComplexResponseEnum.ResponseValue3, "Response: Child #1, ComplexSet #3"),
+                    new(ComplexEnum.RequestValue1, "Child #1, ComplexSet #1"),
+                    new(ComplexEnum.RequestValue3, "Child #1, ComplexSet #3"),
                 };
 
-                var requestSet2 = new HashSet<ComplexPair<ComplexRequestEnum, string>>
+                var set2 = new HashSet<ComplexPair<string>>
                 {
-                    new(ComplexRequestEnum.RequestValue1, "Child #2, ComplexSet #1"),
-                    new(ComplexRequestEnum.RequestValue3, "Child #2, ComplexSet #3"),
-                };
-                var responseSet2 = new HashSet<ComplexPair<ComplexResponseEnum, string>>
-                {
-                    new(ComplexResponseEnum.ResponseValue1, "Response: Child #2, ComplexSet #1"),
-                    new(ComplexResponseEnum.ResponseValue3, "Response: Child #2, ComplexSet #3"),
+                    new(ComplexEnum.RequestValue1, "Child #2, ComplexSet #1"),
+                    new(ComplexEnum.RequestValue3, "Child #2, ComplexSet #3"),
                 };
 
                 for (int i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
                 {
-                    var response = service.Process(new ComplexRequest
+                    var request = new ComplexRequest
                     {
                         RequestId = requestId,
-                        Payload1 = DataStream.FromString(requestPayload1),
-                        Payload2 = DataStream.FromString(requestPayload2),
-                        Child1 = new ComplexRequestChild
+                        Payload1 = DataStream.FromString(payload1),
+                        Payload2 = DataStream.FromString(payload2),
+                        Child1 = new ComplexChild
                         {
-                            ChildPayload1 = DataStream.FromString(requestChild1Payload1),
-                            ChildPayload2 = DataStream.FromString(requestChild1Payload2),
-                            ListOfStreams = requestList1.Select(DataStream.FromString).ToList(),
-                            EnumPayload = requestEnum1,
-                            DictionaryPayload = requestDictionary1,
-                            ComplexPayloadSet = requestSet1.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, DataStream.FromString(x.Item2))).ToHashSet()
+                            ChildPayload1 = DataStream.FromString(child1Payload1),
+                            ChildPayload2 = DataStream.FromString(child1Payload2),
+                            ListOfStreams = list1.Select(DataStream.FromString).ToList(),
+                            EnumPayload = enum1,
+                            DictionaryPayload = dictionary1,
+                            ComplexPayloadSet = set1.Select(x => new ComplexPair<DataStream>(x.EnumValue, DataStream.FromString(x.Payload))).ToHashSet()
                         },
-                        Child2 = new ComplexRequestChild
+                        Child2 = new ComplexChild
                         {
-                            ChildPayload1 = DataStream.FromString(requestChild2Payload1),
-                            ChildPayload2 = DataStream.FromString(requestChild2Payload2),
-                            ListOfStreams = requestList2.Select(DataStream.FromString).ToList(),
-                            EnumPayload = requestEnum2,
-                            DictionaryPayload = requestDictionary2,
-                            ComplexPayloadSet = requestSet2.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, DataStream.FromString(x.Item2))).ToHashSet()
+                            ChildPayload1 = DataStream.FromString(child2Payload1),
+                            ChildPayload2 = DataStream.FromString(child2Payload2),
+                            ListOfStreams = list2.Select(DataStream.FromString).ToList(),
+                            EnumPayload = enum2,
+                            DictionaryPayload = dictionary2,
+                            ComplexPayloadSet = set2.Select(x => new ComplexPair<DataStream>(x.EnumValue, DataStream.FromString(x.Payload))).ToHashSet()
                         },
-                    });
+                    };
+                    
+                    var response = service.Process(request);
 
                     response.RequestId.Should().Be(requestId);
 
-                    response.Payload1.ReadAsString().Should().Be(responsePayload1);
-                    response.Payload2.ReadAsString().Should().Be(responsePayload2);
-                    response.Child1.ChildPayload1.ReadAsString().Should().Be(responseChild1Payload1);
-                    response.Child1.ChildPayload2.ReadAsString().Should().Be(responseChild1Payload2);
-                    response.Child1.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(responseList1);
-                    response.Child1.EnumPayload.Should().Be(responseEnum1);
-                    response.Child1.DictionaryPayload.Should().BeEquivalentTo(responseDictionary1);
-                    response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, string>(x.Item1, x.Item2.ReadAsString())).ToHashSet().Should().BeEquivalentTo(responseSet1);
+                    response.Payload1.Should().NotBeSameAs(request.Payload1);
+                    response.Payload1.ReadAsString().Should().Be(payload1);
                     
-                    response.Child2.ChildPayload1.ReadAsString().Should().Be(responseChild2Payload1);
-                    response.Child2.ChildPayload2.ReadAsString().Should().Be(responseChild2Payload2);
-                    response.Child2.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(responseList2);
-                    response.Child2.EnumPayload.Should().Be(responseEnum2);
-                    response.Child2.DictionaryPayload.Should().BeEquivalentTo(responseDictionary2);
-                    response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, string>(x.Item1, x.Item2.ReadAsString())).ToHashSet().Should().BeEquivalentTo(responseSet2);
+                    response.Payload2.Should().NotBeSameAs(request.Payload2);
+                    response.Payload2.ReadAsString().Should().Be(payload2);
+
+                    response.Child1.Should().NotBeSameAs(request.Child1);
+                    response.Child1.ChildPayload1.Should().NotBeSameAs(request.Child1.ChildPayload1);
+                    response.Child1.ChildPayload1.ReadAsString().Should().Be(child1Payload1);
+                    response.Child1.ChildPayload2.Should().NotBeSameAs(request.Child1.ChildPayload2);
+                    response.Child1.ChildPayload2.ReadAsString().Should().Be(child1Payload2);
+                    response.Child1.ListOfStreams.Should().NotBeSameAs(request.Child1.ListOfStreams);
+                    response.Child1.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list1);
+                    response.Child1.EnumPayload.Should().Be(enum1);
+                    response.Child1.DictionaryPayload.Should().NotBeSameAs(request.Child1.DictionaryPayload);
+                    response.Child1.DictionaryPayload.Should().BeEquivalentTo(dictionary1);
+                    response.Child1.ComplexPayloadSet.Should().NotBeSameAs(request.Child1.ComplexPayloadSet);
+                    response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set1);
+
+                    response.Child2.Should().NotBeSameAs(request.Child2);
+                    response.Child2.ChildPayload1.Should().NotBeSameAs(request.Child2.ChildPayload1);
+                    response.Child2.ChildPayload1.ReadAsString().Should().Be(child2Payload1);
+                    response.Child2.ChildPayload2.Should().NotBeSameAs(request.Child2.ChildPayload2);
+                    response.Child2.ChildPayload2.ReadAsString().Should().Be(child2Payload2);
+                    response.Child2.ListOfStreams.Should().NotBeSameAs(request.Child2.ListOfStreams);
+                    response.Child2.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list2);
+                    response.Child2.EnumPayload.Should().Be(enum2);
+                    response.Child2.DictionaryPayload.Should().NotBeSameAs(request.Child2.DictionaryPayload);
+                    response.Child2.DictionaryPayload.Should().BeEquivalentTo(dictionary2);
+                    response.Child2.ComplexPayloadSet.Should().NotBeSameAs(request.Child2.ComplexPayloadSet);
+                    response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set2);
                 }
             }
         }

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -170,41 +170,127 @@ namespace Halibut.Tests
                        .Build(CancellationToken))
             {
                 var service = clientAndService.CreateClient<IComplexObjectService>();
-                var requestId = "TestRequestIdentifier";
+                var requestId = "RequestIdentifier";
                 
-                var payload = "ThisIsMyTestString";
-                var resultPayload1 = "1: ThisIsMyTestString";
-                var resultPayload2 = "2: ThisIsMyTestString";
-                var resultPayload3 = "3: ThisIsMyTestString";
+                var requestPayload1 = "Payload #1";
+                var responsePayload1 = "Response: Payload #1";
+                var requestPayload2 = "Payload #2";
+                var responsePayload2 = "Response: Payload #2";
                 
-                var childPayload1 = "ChildPayload1";
-                var childPayload2 = "ChildPayload2";
-                var resultChildPayload1 = "First: ChildPayload1";
-                var resultChildPayload2 = "Second: ChildPayload2";
+                var requestChild1Payload1 = "Child #1, Payload #1";
+                var responseChild1Payload1 = "Response: Child #1, Payload #1";
+                var requestChild1Payload2 = "Child #1, Payload #2";
+                var responseChild1Payload2 = "Response: Child #1, Payload #2";
+                var requestChild2Payload1 = "Child #2, Payload #1";
+                var responseChild2Payload1 = "Response: Child #2, Payload #1";
+                var requestChild2Payload2 = "Child #2, Payload #2";
+                var responseChild2Payload2 = "Response: Child #2, Payload #2";
+
+                var requestList1 = new[] { "Child #1, List Item #1", "Child #1, List Item #2", "Child #1, List Item #3" };
+                var responseList1 = new[] { "Response: Child #1, List Item #1", "Response: Child #1, List Item #2", "Response: Child #1, List Item #3" };
+                
+                var requestList2 = new[] { "Child #2, List Item #1", "Child #2, List Item #2", "Child #2, List Item #3" };
+                var responseList2 = new[] { "Response: Child #2, List Item #1", "Response: Child #2, List Item #2", "Response: Child #2, List Item #3" };
+
+                var requestEnum1 = ComplexRequestEnum.RequestValue1;
+                var responseEnum1 = ComplexResponseEnum.ResponseValue1;
+
+                var requestEnum2 = ComplexRequestEnum.RequestValue2;
+                var responseEnum2 = ComplexResponseEnum.ResponseValue2;
+
+                var guid_1_1 = Guid.NewGuid();
+                var guid_1_2 = Guid.NewGuid();
+                var guid_2_1 = Guid.NewGuid();
+                var guid_2_2 = Guid.NewGuid();
+
+                var requestDictionary1 = new Dictionary<Guid, string>
+                {
+                    { guid_1_1, "Child #1, Dictionary #1" },
+                    { guid_1_2, "Child #1, Dictionary #2" },
+                };
+                var responseDictionary1 = new Dictionary<Guid, string>
+                {
+                    { guid_1_1, "Response: Child #1, Dictionary #1" },
+                    { guid_1_2, "Response: Child #1, Dictionary #2" },
+                };
+                
+                var requestDictionary2 = new Dictionary<Guid, string>
+                {
+                    { guid_2_1, "Child #2, Dictionary #1" },
+                    { guid_2_2, "Child #2, Dictionary #2" },
+                };
+                var responseDictionary2 = new Dictionary<Guid, string>
+                {
+                    { guid_2_1, "Response: Child #2, Dictionary #1" },
+                    { guid_2_2, "Response: Child #2, Dictionary #2" },
+                };
+
+                var requestSet1 = new HashSet<ComplexPair<ComplexRequestEnum, string>>
+                {
+                    new(ComplexRequestEnum.RequestValue1, "Child #1, ComplexSet #1"),
+                    new(ComplexRequestEnum.RequestValue3, "Child #1, ComplexSet #3"),
+                };
+                var responseSet1 = new HashSet<ComplexPair<ComplexResponseEnum, string>>
+                {
+                    new(ComplexResponseEnum.ResponseValue1, "Response: Child #1, ComplexSet #1"),
+                    new(ComplexResponseEnum.ResponseValue3, "Response: Child #1, ComplexSet #3"),
+                };
+
+                var requestSet2 = new HashSet<ComplexPair<ComplexRequestEnum, string>>
+                {
+                    new(ComplexRequestEnum.RequestValue1, "Child #2, ComplexSet #1"),
+                    new(ComplexRequestEnum.RequestValue3, "Child #2, ComplexSet #3"),
+                };
+                var responseSet2 = new HashSet<ComplexPair<ComplexResponseEnum, string>>
+                {
+                    new(ComplexResponseEnum.ResponseValue1, "Response: Child #2, ComplexSet #1"),
+                    new(ComplexResponseEnum.ResponseValue3, "Response: Child #2, ComplexSet #3"),
+                };
 
                 for (int i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
                 {
-                    var result = service.Process(new ComplexRequest
+                    var response = service.Process(new ComplexRequest
                     {
                         RequestId = requestId,
-                        NumberOfCopies = 3,
-                        Payload = DataStream.FromString(payload),
-                        Child = new ComplexObjectChild
+                        Payload1 = DataStream.FromString(requestPayload1),
+                        Payload2 = DataStream.FromString(requestPayload2),
+                        Child1 = new ComplexRequestChild
                         {
-                            First = DataStream.FromString(childPayload1),
-                            Second = DataStream.FromString(childPayload2)
-                        }
+                            ChildPayload1 = DataStream.FromString(requestChild1Payload1),
+                            ChildPayload2 = DataStream.FromString(requestChild1Payload2),
+                            ListOfStreams = requestList1.Select(DataStream.FromString).ToList(),
+                            EnumPayload = requestEnum1,
+                            DictionaryPayload = requestDictionary1,
+                            ComplexPayloadSet = requestSet1.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, DataStream.FromString(x.Item2))).ToHashSet()
+                        },
+                        Child2 = new ComplexRequestChild
+                        {
+                            ChildPayload1 = DataStream.FromString(requestChild2Payload1),
+                            ChildPayload2 = DataStream.FromString(requestChild2Payload2),
+                            ListOfStreams = requestList2.Select(DataStream.FromString).ToList(),
+                            EnumPayload = requestEnum2,
+                            DictionaryPayload = requestDictionary2,
+                            ComplexPayloadSet = requestSet2.Select(x => new ComplexPair<ComplexRequestEnum, DataStream>(x.Item1, DataStream.FromString(x.Item2))).ToHashSet()
+                        },
                     });
-                    result.RequestId.Should().Be(requestId);
 
-                    result.Payloads.Count.Should().Be(1);
-                    var payloads = result.Payloads.First().Value.ToArray();
-                    payloads[0].ReadAsString().Should().Be(resultPayload1);
-                    payloads[1].ReadAsString().Should().Be(resultPayload2);
-                    payloads[2].ReadAsString().Should().Be(resultPayload3);
+                    response.RequestId.Should().Be(requestId);
 
-                    result.Child.First.ReadAsString().Should().Be(resultChildPayload1);
-                    result.Child.Second.ReadAsString().Should().Be(resultChildPayload2);
+                    response.Payload1.ReadAsString().Should().Be(responsePayload1);
+                    response.Payload2.ReadAsString().Should().Be(responsePayload2);
+                    response.Child1.ChildPayload1.ReadAsString().Should().Be(responseChild1Payload1);
+                    response.Child1.ChildPayload2.ReadAsString().Should().Be(responseChild1Payload2);
+                    response.Child1.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(responseList1);
+                    response.Child1.EnumPayload.Should().Be(responseEnum1);
+                    response.Child1.DictionaryPayload.Should().BeEquivalentTo(responseDictionary1);
+                    response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, string>(x.Item1, x.Item2.ReadAsString())).ToHashSet().Should().BeEquivalentTo(responseSet1);
+                    
+                    response.Child2.ChildPayload1.ReadAsString().Should().Be(responseChild2Payload1);
+                    response.Child2.ChildPayload2.ReadAsString().Should().Be(responseChild2Payload2);
+                    response.Child2.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(responseList2);
+                    response.Child2.EnumPayload.Should().Be(responseEnum2);
+                    response.Child2.DictionaryPayload.Should().BeEquivalentTo(responseDictionary2);
+                    response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<ComplexResponseEnum, string>(x.Item1, x.Item2.ReadAsString())).ToHashSet().Should().BeEquivalentTo(responseSet2);
                 }
             }
         }

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -162,7 +162,7 @@ namespace Halibut.Tests
 
         [Test]
         [LatestAndPreviousClientAndServiceVersionsTestCases]
-        public async Task OctopusCanSendAndReceiveComplexObjectsWithMultipleDataStreams(ClientAndServiceTestCase clientAndServiceTestCase)
+        public async Task OctopusCanSendAndReceiveComplexObjects_WithMultipleDataStreams(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase
                        .CreateTestCaseBuilder()
@@ -170,114 +170,89 @@ namespace Halibut.Tests
                        .Build(CancellationToken))
             {
                 var service = clientAndService.CreateClient<IComplexObjectService>();
-                var requestId = "RequestIdentifier";
-                
                 var payload1 = "Payload #1";
                 var payload2 = "Payload #2";
-                
-                var child1Payload1 = "Child #1, Payload #1";
-                var child1Payload2 = "Child #1, Payload #2";
-                var child2Payload1 = "Child #2, Payload #1";
-                var child2Payload2 = "Child #2, Payload #2";
-
-                var list1 = new[] { "Child #1, List Item #1", "Child #1, List Item #2", "Child #1, List Item #3" };
-                var list2 = new[] { "Child #2, List Item #1", "Child #2, List Item #2", "Child #2, List Item #3" };
-
-                var enum1 = ComplexEnum.RequestValue1;
-                var enum2 = ComplexEnum.RequestValue2;
-
-                var child1Guid1 = Guid.NewGuid();
-                var child1Guid2 = Guid.NewGuid();
-                var child2Guid1 = Guid.NewGuid();
-                var child2Guild2 = Guid.NewGuid();
-
-                var dictionary1 = new Dictionary<Guid, string>
-                {
-                    { child1Guid1, "Child #1, Dictionary #1" },
-                    { child1Guid2, "Child #1, Dictionary #2" },
-                };
-                
-                var dictionary2 = new Dictionary<Guid, string>
-                {
-                    { child2Guid1, "Child #2, Dictionary #1" },
-                    { child2Guild2, "Child #2, Dictionary #2" },
-                };
-
-                var set1 = new HashSet<ComplexPair<string>>
-                {
-                    new(ComplexEnum.RequestValue1, "Child #1, ComplexSet #1"),
-                    new(ComplexEnum.RequestValue3, "Child #1, ComplexSet #3"),
-                };
-
-                var set2 = new HashSet<ComplexPair<string>>
-                {
-                    new(ComplexEnum.RequestValue1, "Child #2, ComplexSet #1"),
-                    new(ComplexEnum.RequestValue3, "Child #2, ComplexSet #3"),
-                };
 
                 for (int i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
                 {
-                    var request = new ComplexRequest
+                    var request = new ComplexObjectMultipleDataStreams
                     {
-                        RequestId = requestId,
                         Payload1 = DataStream.FromString(payload1),
                         Payload2 = DataStream.FromString(payload2),
-                        Child1 = new ComplexChild
-                        {
-                            ChildPayload1 = DataStream.FromString(child1Payload1),
-                            ChildPayload2 = DataStream.FromString(child1Payload2),
-                            ListOfStreams = list1.Select(DataStream.FromString).ToList(),
-                            EnumPayload = enum1,
-                            DictionaryPayload = dictionary1,
-                            ComplexPayloadSet = set1.Select(x => new ComplexPair<DataStream>(x.EnumValue, DataStream.FromString(x.Payload))).ToHashSet()
-                        },
-                        Child2 = new ComplexChild
-                        {
-                            ChildPayload1 = DataStream.FromString(child2Payload1),
-                            ChildPayload2 = DataStream.FromString(child2Payload2),
-                            ListOfStreams = list2.Select(DataStream.FromString).ToList(),
-                            EnumPayload = enum2,
-                            DictionaryPayload = dictionary2,
-                            ComplexPayloadSet = set2.Select(x => new ComplexPair<DataStream>(x.EnumValue, DataStream.FromString(x.Payload))).ToHashSet()
-                        },
                     };
-                    
-                    var response = service.Process(request);
 
-                    response.RequestId.Should().Be(requestId);
+                    var response = service.Process(request);
 
                     response.Payload1.Should().NotBeSameAs(request.Payload1);
                     response.Payload1.ReadAsString().Should().Be(payload1);
-                    
+
                     response.Payload2.Should().NotBeSameAs(request.Payload2);
                     response.Payload2.ReadAsString().Should().Be(payload2);
-
-                    response.Child1.Should().NotBeSameAs(request.Child1);
-                    response.Child1.ChildPayload1.Should().NotBeSameAs(request.Child1.ChildPayload1);
-                    response.Child1.ChildPayload1.ReadAsString().Should().Be(child1Payload1);
-                    response.Child1.ChildPayload2.Should().NotBeSameAs(request.Child1.ChildPayload2);
-                    response.Child1.ChildPayload2.ReadAsString().Should().Be(child1Payload2);
-                    response.Child1.ListOfStreams.Should().NotBeSameAs(request.Child1.ListOfStreams);
-                    response.Child1.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list1);
-                    response.Child1.EnumPayload.Should().Be(enum1);
-                    response.Child1.DictionaryPayload.Should().NotBeSameAs(request.Child1.DictionaryPayload);
-                    response.Child1.DictionaryPayload.Should().BeEquivalentTo(dictionary1);
-                    response.Child1.ComplexPayloadSet.Should().NotBeSameAs(request.Child1.ComplexPayloadSet);
-                    response.Child1.ComplexPayloadSet.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set1);
-
-                    response.Child2.Should().NotBeSameAs(request.Child2);
-                    response.Child2.ChildPayload1.Should().NotBeSameAs(request.Child2.ChildPayload1);
-                    response.Child2.ChildPayload1.ReadAsString().Should().Be(child2Payload1);
-                    response.Child2.ChildPayload2.Should().NotBeSameAs(request.Child2.ChildPayload2);
-                    response.Child2.ChildPayload2.ReadAsString().Should().Be(child2Payload2);
-                    response.Child2.ListOfStreams.Should().NotBeSameAs(request.Child2.ListOfStreams);
-                    response.Child2.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list2);
-                    response.Child2.EnumPayload.Should().Be(enum2);
-                    response.Child2.DictionaryPayload.Should().NotBeSameAs(request.Child2.DictionaryPayload);
-                    response.Child2.DictionaryPayload.Should().BeEquivalentTo(dictionary2);
-                    response.Child2.ComplexPayloadSet.Should().NotBeSameAs(request.Child2.ComplexPayloadSet);
-                    response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set2);
                 }
+            }
+        }
+
+        [Test]
+        [LatestAndPreviousClientAndServiceVersionsTestCases]
+        public async Task OctopusCanSendAndReceiveComplexObjects_WithMultipleComplexChildren(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var childPayload1 = "Child Payload #1";
+            var childPayload2 = "Child Payload #2";
+
+            var list = new[] { "List Item #1", "List Item #2", "List Item #3" };
+
+            var enumValue = ComplexEnum.RequestValue1;
+
+            var dictionary = new Dictionary<Guid, string>
+            {
+                { Guid.NewGuid(), "Dictionary #1" },
+                { Guid.NewGuid(), "Dictionary #2" },
+            };
+
+            var set = new HashSet<ComplexPair<string>>
+            {
+                new(ComplexEnum.RequestValue1, "ComplexSet #1"),
+                new(ComplexEnum.RequestValue3, "ComplexSet #3"),
+            };
+
+            using (var clientAndService = await clientAndServiceTestCase
+                       .CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .Build(CancellationToken))
+            {
+                var service = clientAndService.CreateClient<IComplexObjectService>();
+                var request = new ComplexObjectMultipleChildren
+                {
+                    Child1 = new ComplexChild1
+                    {
+                        ChildPayload1 = DataStream.FromString(childPayload1),
+                        ChildPayload2 = DataStream.FromString(childPayload2),
+                        DictionaryPayload = dictionary,
+                        ListOfStreams = list.Select(DataStream.FromString).ToList(),
+                    },
+                    Child2 = new ComplexChild2
+                    {
+                        EnumPayload = enumValue,
+                        ComplexPayloadSet = set.Select(x => new ComplexPair<DataStream>(x.EnumValue, DataStream.FromString(x.Payload))).ToHashSet()
+                    }
+                };
+
+                var response = service.Process(request);
+
+                response.Child1.Should().NotBeSameAs(request.Child1);
+                response.Child1.ChildPayload1.Should().NotBeSameAs(request.Child1.ChildPayload1);
+                response.Child1.ChildPayload1.ReadAsString().Should().Be(childPayload1);
+                response.Child1.ChildPayload2.Should().NotBeSameAs(request.Child1.ChildPayload2);
+                response.Child1.ChildPayload2.ReadAsString().Should().Be(childPayload2);
+                response.Child1.ListOfStreams.Should().NotBeSameAs(request.Child1.ListOfStreams);
+                response.Child1.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list);
+                response.Child1.DictionaryPayload.Should().NotBeSameAs(request.Child1.DictionaryPayload);
+                response.Child1.DictionaryPayload.Should().BeEquivalentTo(dictionary);
+                
+                response.Child2.Should().NotBeSameAs(request.Child2);
+                response.Child2.EnumPayload.Should().Be(enumValue);
+                response.Child2.ComplexPayloadSet.Should().NotBeSameAs(request.Child2.ComplexPayloadSet);
+                response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set);
             }
         }
     }


### PR DESCRIPTION
A [previous PR](https://github.com/OctopusDeploy/Halibut/pull/302) added some tests for sending/receiving complex objects, but there were some test cases missing. This PR reworks the test to cover more use cases, and now tests **sending/receiving the following within a single request/response multiple times**:

* Multiple DataStreams
* Multiple complex objects, each containing multiple DataStreams
* Multiple complex objects, each containing other complex objects types (e.g. Dictionary, List, Set, Enum)

The test will now cover the following test cases from the [discovery document](https://docs.google.com/document/d/1z0qff6yenIsGCdvHBseOfuVvVRUn18B6__1abHwT4dk/edit):

![image](https://github.com/OctopusDeploy/Halibut/assets/277700/8ec7e11c-f662-4f24-b1d0-23fe721bb837)

### Potential issue
Is the test _too_ complex now? While it covers more complex objects and exercises the code more thoroughly, there is now a lot of setup code, and the `ComplexObjectService` is also more complex.

[sc-53157]
