### PR TITLE
Fixes a async read which will never stop

### DIFF
--- a/source/Halibut/Transport/Protocol/ControlMessageReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessageReader.cs
@@ -59,7 +59,7 @@ namespace Halibut.Transport.Protocol
 
         internal async Task<string> ReadControlMessageAsync(Stream stream)
         {
-            var cts = new CancellationTokenSource(stream.ReadTimeout);
+            var cts = GetCancellationTokenSourceFromStreamReadTimeout(stream);
             StringBuilder sb = new StringBuilder();
             while (true)
             {
@@ -85,6 +85,16 @@ namespace Halibut.Transport.Protocol
 
                 sb.Append((char) nextByte[0]);
             }
+        }
+
+        static CancellationTokenSource GetCancellationTokenSourceFromStreamReadTimeout(Stream stream)
+        {
+            if (stream.CanTimeout)
+            {
+                return new CancellationTokenSource(stream.ReadTimeout);
+            }
+
+            return new CancellationTokenSource(HalibutLimits.TcpClientReceiveTimeout); // Just default to a higher timeout, rather than be cancellation token none
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ControlMessageReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessageReader.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Diagnostics;
 
 namespace Halibut.Transport.Protocol
 {
@@ -57,17 +59,18 @@ namespace Halibut.Transport.Protocol
 
         internal async Task<string> ReadControlMessageAsync(Stream stream)
         {
+            var cts = new CancellationTokenSource(stream.ReadTimeout);
             StringBuilder sb = new StringBuilder();
             while (true)
             {
                 var nextByte = new byte[1];
-                var read = await stream.ReadAsync(nextByte, 0, nextByte.Length);
+                var read = await stream.ReadAsync(nextByte, 0, nextByte.Length, cts.Token);
                 if (read == 0) throw new EndOfStreamException();
                 
                 // Control messages must end with \r\n and must not contain \r or \n
                 if (nextByte[0] == '\r')
                 {
-                    read = await stream.ReadAsync(nextByte, 0, nextByte.Length);
+                    read = await stream.ReadAsync(nextByte, 0, nextByte.Length, cts.Token);
                     if (read == 0) throw new EndOfStreamException();
 
                     if (nextByte[0] != '\n')


### PR DESCRIPTION
# Background

Fixes a bug where polling clients which never respond with a NEXT control message can cause the client to await a read that never times out.

This doesn't cause the client to be unable to receive a message or send new RPC calls, since its on the polling loop within the client that is held up. The Service itself, eventually realises no PROCEED messages is sent and so starts a new TCP connection under which new requests can be serviced.

[SC-54246]

# Results

Tasks are not left hanging awaiting on a stream read that may never complete.

## Before

```
.00007f610c2593a8 (1) System.Net.Security.SslStream+<ReadAsyncInternal>d__188`1[[System.Net.Security.AsyncReadWriteAdapter, System.Net.Security]]
..00007f610c259460 (0) Halibut.Transport.RewindableBufferStream+<ReadAsync>d__12
...00007f610c2594c0 (0) Halibut.Transport.Protocol.ControlMessageReader+<ReadControlMessageAsync>d__3
....00007f610c259520 (0) Halibut.Transport.Protocol.ControlMessageReader+<ReadUntilNonEmptyControlMessageAsync>d__2
.....00007f610c259580 (0) Halibut.Transport.Protocol.MessageExchangeStream+<ExpectNextOrEndAsync>d__23
......00007f610c2595e0 (0) Halibut.Transport.Protocol.MessageExchangeProtocol+<ProcessReceiverInternalAsync>d__17
.......00007f610c2418d0 (1) Halibut.Transport.Protocol.MessageExchangeProtocol+<ProcessSubscriberAsync>d__15
........00007f610c241930 (0) Halibut.Transport.Protocol.MessageExchangeProtocol+<ExchangeAsServerAsync>d__12
.........00007f610c1d4408 (1) Halibut.Transport.SecureListener+<ExecuteRequest>d__23
..........00007f610c1d4468 (0) Halibut.Transport.SecureListener+<HandleClient>d__22
...........00007f610c1d44c8 (0) Halibut.Transport.SecureListener+<>c__DisplayClass20_0+<<Accept>b__2>d
............00007f610c1bc688 System.Threading.Tasks.UnwrapPromise`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib]]
```

## After

```
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](TIOAdapter adapter)
   at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](TIOAdapter adapter, Memory`1 buffer)
   at Halibut.Transport.RewindableBufferStream.ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/RewindableBufferStream.cs:line 123
   at Halibut.Transport.Protocol.ControlMessageReader.ReadControlMessageAsync(Stream stream) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/Protocol/ControlMessageReader.cs:line 67
   at Halibut.Transport.Protocol.ControlMessageReader.ReadUntilNonEmptyControlMessageAsync(Stream stream) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/Protocol/ControlMessageReader.cs:line 55
   at Halibut.Transport.Protocol.MessageExchangeStream.ExpectNextOrEndAsync() in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/Protocol/MessageExchangeStream.cs:line 111
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 247
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ProcessSubscriberAsync(IPendingRequestQueue pendingRequests) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 180
   at Halibut.Transport.Protocol.MessageExchangeProtocol.ExchangeAsServerAsync(Func`2 incomingRequestProcessor, Func`2 pendingRequests) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs:line 124
   at Halibut.Transport.SecureListener.ExecuteRequest(TcpClient client) in /home/auser/Documents/octopus/Halibut/source/Halibut/Transport/SecureListener.cs:line 235 listen://[::]:43847/  98 Unhandled error when handling request from client: [::ffff:127.0.0.1]:41924
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
