### PR TITLE
Test polling service can process more requests when the network is paused during control messages being sent.

### DIFF
--- a/source/Halibut.Tests/Support/PortForwarding/PortForwardingDataSentLogger.cs
+++ b/source/Halibut.Tests/Support/PortForwarding/PortForwardingDataSentLogger.cs
@@ -1,0 +1,53 @@
+using Octopus.TestPortForwarder;
+using Serilog;
+
+namespace Halibut.Tests.Support.PortForwarding
+{
+    public static class PortForwarderDataSentLogger
+    {
+        public static PortForwarderBuilder WithPortForwarderDataLogging(this PortForwarderBuilder portForwarderBuilder, ServiceConnectionType serviceConnectionType)
+        {
+            if (serviceConnectionType == ServiceConnectionType.Listening) return portForwarderBuilder.WithDataLoggingForListening();
+            else return portForwarderBuilder.WithDataLoggingForPolling();
+        }
+
+        private static PortForwarderBuilder WithDataLoggingForPolling(this PortForwarderBuilder portForwarderBuilder)
+        {
+            var logger = new SerilogLoggerBuilder().Build().ForContext<PortForwarder>();
+            return portForwarderBuilder.WithDataObserver(new BiDirectionalDataTransferObserverBuilder()
+                .ObserveDataClientToOrigin(ServiceSent(logger))
+                .ObserveDataOriginToClient(ClientSent(logger))
+                .Build);
+        }
+
+        private static PortForwarderBuilder WithDataLoggingForListening(this PortForwarderBuilder portForwarderBuilder)
+        {
+            var logger = new SerilogLoggerBuilder().Build().ForContext<PortForwarder>();
+            return portForwarderBuilder.WithDataObserver(new BiDirectionalDataTransferObserverBuilder()
+                .ObserveDataOriginToClient(ServiceSent(logger))
+                .ObserveDataClientToOrigin(ClientSent(logger))
+                .Build);
+        }
+
+        /// <summary>
+        /// Client in this sense means the thing talking to Tentacle e.g. Octopus.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <returns></returns>
+        private static IDataTransferObserver ClientSent(ILogger logger)
+        {
+            return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, stream) =>
+            {
+                logger.Information("Client sent {Count} bytes", stream.Length);
+            }).Build();
+        }
+
+        private static IDataTransferObserver ServiceSent(ILogger logger)
+        {
+            return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, stream) =>
+            {
+                logger.Information("Service sent {Count} bytes", stream.Length);
+            }).Build();
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/PortForwarding/PortForwardingServiceSentObserver.cs
+++ b/source/Halibut.Tests/Support/PortForwarding/PortForwardingServiceSentObserver.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using Octopus.TestPortForwarder;
+using Serilog;
+
+namespace Halibut.Tests.Support.PortForwarding
+{
+    public static class PortForwardingServiceSentObserver
+    {
+        public static PortForwarderBuilder WithPortForwarderServiceSentDataObserver(this PortForwarderBuilder portForwarderBuilder, ServiceConnectionType serviceConnectionType, Action<TcpPump, MemoryStream> serviceSentDataCallback)
+        {
+            if (serviceConnectionType == ServiceConnectionType.Listening) return portForwarderBuilder.WithDataLoggingForListening(serviceSentDataCallback);
+            else return portForwarderBuilder.WithDataLoggingForPolling(serviceSentDataCallback);
+        }
+
+        private static PortForwarderBuilder WithDataLoggingForPolling(this PortForwarderBuilder portForwarderBuilder, Action<TcpPump, MemoryStream> serviceSentDataCallback)
+        {
+            var logger = new SerilogLoggerBuilder().Build().ForContext<PortForwarder>();
+            return portForwarderBuilder.WithDataObserver(new BiDirectionalDataTransferObserverBuilder()
+                .ObserveDataClientToOrigin(ServiceSent(serviceSentDataCallback))
+                .Build);
+        }
+
+        private static PortForwarderBuilder WithDataLoggingForListening(this PortForwarderBuilder portForwarderBuilder, Action<TcpPump, MemoryStream> serviceSentDataCallback)
+        {
+            var logger = new SerilogLoggerBuilder().Build().ForContext<PortForwarder>();
+            return portForwarderBuilder.WithDataObserver(new BiDirectionalDataTransferObserverBuilder()
+                .ObserveDataOriginToClient(ServiceSent(serviceSentDataCallback))
+                .Build);
+        }
+
+        private static IDataTransferObserver ServiceSent(Action<TcpPump, MemoryStream> serviceSentDataCallback)
+        {
+            return new DataTransferObserverBuilder().WithWritingDataObserver(serviceSentDataCallback).Build();
+        }
+    }
+}

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.PortForwarding;
+using Halibut.Tests.Util;
+using Halibut.TestUtils.Contracts;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Timeouts
+{
+    public class NextAndProceedControlMessageTimeoutsFixture : BaseTest
+    {
+        [Test]
+        public async Task PauseOnPollingTentacleSendingNextControlMessage_ShouldNotHangForEver()
+        {
+            var dataSentSizes = new List<long>();
+            long? pauseStreamWhenServiceSendsMessageOfSize = null;
+            var serviceConnectionType = ServiceConnectionType.Polling;
+            using (var clientAndService = await LatestClientAndLatestServiceBuilder
+                       .ForServiceConnectionType(serviceConnectionType)
+                       .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
+                           .WithPortForwarderDataLogging(serviceConnectionType)
+                           .WithPortForwarderServiceSentDataObserver(serviceConnectionType, (tcpPump, stream) =>
+                           {
+                               dataSentSizes.Add(stream.Length);
+                               if (pauseStreamWhenServiceSendsMessageOfSize != null && pauseStreamWhenServiceSendsMessageOfSize == stream.Length)
+                               {
+                                   Logger.Information("Pausing pump since a write of size {Size} was received", stream.Length);
+                                   tcpPump.Pause();
+                               }
+                           })
+                           .Build())
+                       .WithEchoService()
+                       .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
+                       .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService>();
+                
+                    echo.SayHello(Some.RandomAsciiStringOfLength(2000));
+                    // --> NEXT sent
+                    // --> Proceed sent
+                    await Task.Delay(TimeSpan.FromSeconds(3)); // Allow enough time for the polling queue to unnecessarily send a null message down the queue because of a race condition in the queue. 
+                    long nextMessageSize = dataSentSizes.Last();
+                    pauseStreamWhenServiceSendsMessageOfSize = nextMessageSize; // Lets hope they are all the same size
+
+                    echo.SayHello(Some.RandomAsciiStringOfLength(2000)); // Second last message
+                    // --> NEXT sent and pump paused here.
+                    
+                    var sw = Stopwatch.StartNew();
+                    // Service must detect that it can't get a PROCEED back in time and so must decide to abandon and then try again within
+                    // its retry policy.
+                    echo.SayHello(Some.RandomAsciiStringOfLength(2000));
+                    sw.Stop();
+                    Logger.Information("It took: " + sw.Elapsed);
+                    sw.Elapsed.Should().BeGreaterThanOrEqualTo(HalibutLimits.TcpClientHeartbeatReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
+                                                                                                                                         // the response to the 'Second last message' is put back into the queue.
+                        .And.BeLessThan(HalibutLimits.TcpClientReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -33,6 +33,7 @@ namespace Halibut.Tests.Timeouts
                                {
                                    Logger.Information("Pausing pump since a write of size {Size} was received", stream.Length);
                                    tcpPump.Pause();
+                                   pauseStreamWhenServiceSendsMessageOfSize = null;
                                }
                            })
                            .Build())
@@ -42,25 +43,26 @@ namespace Halibut.Tests.Timeouts
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
                 
-                    echo.SayHello(Some.RandomAsciiStringOfLength(2000));
-                    // --> NEXT sent
-                    // --> Proceed sent
-                    await Task.Delay(TimeSpan.FromSeconds(3)); // Allow enough time for the polling queue to unnecessarily send a null message down the queue because of a race condition in the queue. 
-                    long nextMessageSize = dataSentSizes.Last();
-                    pauseStreamWhenServiceSendsMessageOfSize = nextMessageSize; // Lets hope they are all the same size
+                echo.SayHello(Some.RandomAsciiStringOfLength(2000));
+                // --> NEXT sent
+                // --> Proceed sent
+                await Task.Delay(TimeSpan.FromSeconds(3)); // Allow enough time for the polling queue to unnecessarily send a null message down the queue because of a race condition in the queue. 
+                long nextMessageSize = dataSentSizes.Last();
+                pauseStreamWhenServiceSendsMessageOfSize = nextMessageSize; // Lets hope they are all the same size
+                Logger.Information("Will pause the pump next time the polling service sends a message of size {Size}", pauseStreamWhenServiceSendsMessageOfSize);
 
-                    echo.SayHello(Some.RandomAsciiStringOfLength(2000)); // Second last message
-                    // --> NEXT sent and pump paused here.
-                    
-                    var sw = Stopwatch.StartNew();
-                    // Service must detect that it can't get a PROCEED back in time and so must decide to abandon and then try again within
-                    // its retry policy.
-                    echo.SayHello(Some.RandomAsciiStringOfLength(2000));
-                    sw.Stop();
-                    Logger.Information("It took: " + sw.Elapsed);
-                    sw.Elapsed.Should().BeGreaterThanOrEqualTo(HalibutLimits.TcpClientHeartbeatReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
-                                                                                                                                         // the response to the 'Second last message' is put back into the queue.
-                        .And.BeLessThan(HalibutLimits.TcpClientReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
+                echo.SayHello(Some.RandomAsciiStringOfLength(2000)); // Second last message
+                // --> NEXT sent and pump paused here.
+                
+                var sw = Stopwatch.StartNew();
+                // Service must detect that it can't get a PROCEED back in time and so must decide to abandon and then try again within
+                // its retry policy.
+                echo.SayHello(Some.RandomAsciiStringOfLength(2000));
+                sw.Stop();
+                Logger.Information("It took: " + sw.Elapsed);
+                sw.Elapsed.Should().BeGreaterThanOrEqualTo(HalibutLimits.TcpClientHeartbeatReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
+                                                                                                                                     // the response to the 'Second last message' is put back into the queue.
+                    .And.BeLessThan(HalibutLimits.TcpClientReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
             }
         }
     }


### PR DESCRIPTION
# Background

Adds a test for a polling (service) tentacle where its `NEXT` control message doesn't make it to the service as at that point the TCP connection is paused.

The tests shows the polling tentacle realises something is wrong, on its read of `PROCEED`, and times out within the hart beat timeout allowing it to start a new TCP connection under which to process new requests.

Also adds some helpers for the port forwarder, including a very handy logger from the tentacle project.

[SC-53157]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
