### PR TITLE
Reduce number of parallel tests in teamcity

### DIFF
--- a/source/Halibut.Tests/Util/HowManyParallelTests.cs
+++ b/source/Halibut.Tests/Util/HowManyParallelTests.cs
@@ -1,0 +1,18 @@
+using System;
+using Halibut.Tests.Support.TestAttributes;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Util
+{
+    public class HowManyParallelTests : BaseTest
+    {
+        [Test]
+        public void HowManyTestsAreRunningInParallel()
+        {
+            // Only exists to make it easy to find out how many tests are running in parallel.
+            Logger.Information("The number of parallel tests are: {LevelOfParallelism} on a machine with {NumberOfCpuCores} cpu cores.", 
+                CustomLevelOfParallelismAttribute.LevelOfParallelism(),
+                Environment.ProcessorCount);
+        }
+    }
+}


### PR DESCRIPTION
# Background

On windows tests are timing out, perhaps because our tests run in kubernetes and k8s is telling us the number of CPU cores the host has resulting in that many parallel tests being run. The change here is to in teamcity on large hosts reduce the number of parallel tests.

Starting at reducing by half, we can reduce further as needed if that is required.
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
