### PR TITLE
Update tests to cover more use cases

### DIFF
--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -125,7 +125,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testWebSocket:true, testNetworkConditions: false)]
         [FailedWebSocketTestsBecomeInconclusive]
         public async Task SupportsDifferentServiceContractMethods(ClientAndServiceTestCase clientAndServiceTestCase)
         {
@@ -165,7 +165,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testWebSocket: true, testNetworkConditions: false)]
         [FailedWebSocketTestsBecomeInconclusive]
         public async Task StreamsCanBeSentWithProgressReporting(ClientAndServiceTestCase clientAndServiceTestCase)
         {


### PR DESCRIPTION
This PR updates the test case source attribute used by a couple of Halibut tests, so that they also cover the following use cases:
* Polling over web socket
* Previous client -> Latest server
* Latest client -> previous server

This will complete the following section of the [Hailbut test discovery doc](https://docs.google.com/document/d/1z0qff6yenIsGCdvHBseOfuVvVRUn18B6__1abHwT4dk/edit):
![image](https://github.com/OctopusDeploy/Halibut/assets/277700/22ae0e72-a6a1-4787-95ac-e3401f5d53f7)
