### PR TITLE
Improve disposing in tests

### DIFF
--- a/source/Halibut.Tests/Support/Try.cs
+++ b/source/Halibut.Tests/Support/Try.cs
@@ -4,8 +4,16 @@ namespace Halibut.Tests.Support
 {
     public static class Try
     {
-        public static void CatchingError(Action tryThisAction, Action<Exception> onFailure) {
-        
+        public static void CatchingError(Action tryThisAction, Action<Exception> onFailure) 
+        {
+            try
+            {
+                tryThisAction();
+            }
+            catch (Exception e)
+            {
+                onFailure(e);
+            }        
         }
     }
 }

--- a/source/Halibut.Tests/Support/Try.cs
+++ b/source/Halibut.Tests/Support/Try.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Halibut.Tests.Support
+{
+    public static class Try
+    {
+        public static void CatchingError(Action tryThisAction, Action<Exception> onFailure) {
+        
+        }
+    }
+}


### PR DESCRIPTION
# Background

Hopefully fixes what appears to be a double dispose or some other impossible situation which does ocure in this stack trace: (From [test](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_ChainFullChain/8900476?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandPull+Request+Details=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)
```
System.AggregateException : One or more errors occurred. (One or more errors occurred. (The CancellationTokenSource has been disposed.))
  ----> System.AggregateException : One or more errors occurred. (The CancellationTokenSource has been disposed.)
  ----> System.ObjectDisposedException : The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
   at System.Threading.CancellationTokenSource.NotifyCancellation(Boolean throwOnFirstException)
   at System.Threading.CancellationTokenSource.Cancel()
   at Halibut.Tests.Support.BackwardsCompatibility.LatestClientAndPreviousServiceVersionBuilder.ClientAndService.Dispose() in /opt/buildagent/work/ce9567031fa52250/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs:line 305
   at Halibut.Tests.TestPortForwarderFixture.ClientCanSendMessagesToTentacle_WithEchoService_AndPortForwarding_AndProxy(ClientAndServiceTestCase clientAndServiceTestCase) in /opt/buildagent/work/ce9567031fa52250/source/Halibut.Tests/TestPortForwarderFixture.cs:line 70
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
--AggregateException
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
   at System.Threading.CancellationTokenSource.NotifyCancellation(Boolean throwOnFirstException)
   at System.Threading.CancellationTokenSource.LinkedNCancellationTokenSource.<>c.<.cctor>b__4_0(Object s)
   at System.Threading.CancellationTokenSource.Invoke(Delegate d, Object state, CancellationTokenSource source)
   at System.Threading.CancellationTokenSource.CallbackNode.ExecuteCallback()
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
--ObjectDisposedException
   at System.Threading.CancellationTokenSource.Cancel()
   at System.IO.Pipelines.StreamPipeWriter.Cancel()
   at System.IO.Pipelines.StreamPipeWriter.<>c.<FlushAsyncInternal>b__39_0(Object state)
   at System.Threading.CancellationTokenSource.Invoke(Delegate d, Object state, CancellationTokenSource source)
   at System.Threading.CancellationTokenSource.CallbackNode.ExecuteCallback()
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
```

The changes are:
* Move the cancellation token source to be created in the build method so that they can never be shared and so can can't be disposed by the wrong thing that used it.
* update the dispose methods used in tests, to never throw and so allowing them to be called twice.
* Fixes the dispose methods so that everything has a go at being disposed.

# Results

<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/Issues/issues/... _(optional public issue)_

Fixes https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/... _(optional private issue)_

See [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) (including [this flowchart](https://whimsical.com/r-d-incoming-work-workflow-aug-21-NsDnGQXcwBLwU66a88Zhue) 

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
