### PR TITLE
Lock around finding a free a tcp port for websockets and when it is used

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Tests.Support;
 using Halibut.TestUtils.SampleProgram.Base.LogUtils;
@@ -57,15 +58,18 @@ namespace Halibut.TestUtils.SampleProgram.Base
                         realServiceEndpoint = new ServiceEndPoint(new Uri("poll://SQ-TENTAPOLL"), serviceCert.Thumbprint, proxyDetails);
                         break;
                     case ServiceConnectionType.PollingOverWebSocket:
-                        var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();
-                        var webSocketPath = SettingsHelper.GetSetting("websocketpath");
-                        var webSocketListeningUrl = $"https://+:{webSocketListeningPort}/{webSocketPath}";
+                        using (await TcpPortHelper.WaitForLock(CancellationToken.None))
+                        {
+                            var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();
+                            var webSocketPath = SettingsHelper.GetSetting("websocketpath");
+                            var webSocketListeningUrl = $"https://+:{webSocketListeningPort}/{webSocketPath}";
 
-                        client.ListenWebSocket(webSocketListeningUrl);
-                        Console.WriteLine($"WebSocket Polling listener is listening on: {webSocketListeningUrl}");
-                        // Do not change the log message as it is used by the HalibutTestBinaryRunners
-                        Console.WriteLine("Polling listener is listening on port: " + webSocketListeningPort);
-                        realServiceEndpoint = new ServiceEndPoint(new Uri("poll://SQ-TENTAPOLL"), serviceCert.Thumbprint, proxyDetails);
+                            client.ListenWebSocket(webSocketListeningUrl);
+                            Console.WriteLine($"WebSocket Polling listener is listening on: {webSocketListeningUrl}");
+                            // Do not change the log message as it is used by the HalibutTestBinaryRunners
+                            Console.WriteLine("Polling listener is listening on port: " + webSocketListeningPort);
+                            realServiceEndpoint = new ServiceEndPoint(new Uri("poll://SQ-TENTAPOLL"), serviceCert.Thumbprint, proxyDetails);
+                        }
                         break;
                     case ServiceConnectionType.Listening:
                         realServiceEndpoint = new ServiceEndPoint(new Uri(serviceAddressToConnectTo!), serviceCert.Thumbprint, proxyDetails);

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -194,12 +194,15 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
+                using var tcpPortConflictLock = await TcpPortHelper.WaitForLock(cancellationToken);
                 var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();
                 var webSocketPath = Guid.NewGuid().ToString();
                 var webSocketListeningUrl = $"https://+:{webSocketListeningPort}/{webSocketPath}";
                 var webSocketSslCertificateBindingAddress = $"0.0.0.0:{webSocketListeningPort}";
 
                 octopus.ListenWebSocket(webSocketListeningUrl);
+                tcpPortConflictLock.Dispose();
+
                 portForwarder = portForwarderFactory?.Invoke(webSocketListeningPort);
 
                 var webSocketSslCertificate = new WebSocketSslCertificateBuilder(webSocketSslCertificateBindingAddress).Build();

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -270,12 +270,14 @@ namespace Halibut.Tests.Support
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
+                using var tcpPortConflictLock = await TcpPortHelper.WaitForLock(cancellationToken);
                 var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();
                 var webSocketPath = Guid.NewGuid().ToString();
                 var webSocketListeningUrl = $"https://+:{webSocketListeningPort}/{webSocketPath}";
                 var webSocketSslCertificateBindingAddress = $"0.0.0.0:{webSocketListeningPort}";
 
                 client.ListenWebSocket(webSocketListeningUrl);
+                tcpPortConflictLock.Dispose();
 
                 var webSocketSslCertificate = new WebSocketSslCertificateBuilder(webSocketSslCertificateBindingAddress).Build();
                 disposableCollection.Add(webSocketSslCertificate);


### PR DESCRIPTION
# Background

This PR adds some best-effort locking to try and minimise port conflicts due to multiple tests trying to use the same port in parallel.

A race condition exists between finding a free TCP port and then using the free TCP port, which allows another test to steal the port or think the port is free.

This PR attempts to add some locking around this so it is thread-safe between tests.

This will not help when the out-of-test-process CompatBinary find and uses a TCP port directly itself as the locking is only process wide.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
