### PR TITLE
Add additional nuke targets to allow for net48 and net60 tests on windows to be split run separately

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -88,7 +88,9 @@
               "PackTestPortForwarder",
               "Restore",
               "TestLinux",
-              "TestWindows"
+              "TestWindows",
+              "TestWindowsNet48",
+              "TestWindowsNet60"
             ]
           }
         },
@@ -110,7 +112,9 @@
               "PackTestPortForwarder",
               "Restore",
               "TestLinux",
-              "TestWindows"
+              "TestWindows",
+              "TestWindowsNet48",
+              "TestWindowsNet60"
             ]
           }
         },

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -103,17 +103,41 @@ class Build : NukeBuild
     [PublicAPI]
     Target TestWindows => _ => _
         .DependsOn(Compile)
+        .DependsOn(TestWindowsNet48)
+        .DependsOn(TestWindowsNet60);
+
+    [PublicAPI]
+    Target TestWindowsNet60 => _ => _
+        .DependsOn(Compile)
         .Executes(() =>
         {
             DotMemoryUnit(
-                $"{DotNetPath.DoubleQuoteIfNeeded()} --propagate-exit-code --instance-name={Guid.NewGuid()} -- test {Solution.Halibut_Tests_DotMemory.Path} --configuration={Configuration} --no-build");
-            
+                $"{DotNetPath.DoubleQuoteIfNeeded()} --propagate-exit-code --instance-name={Guid.NewGuid()} -- test {Solution.Halibut_Tests_DotMemory.Path} --configuration={Configuration} --framework=net6.0 --no-build");
+
             DotNetTest(_ => _
                 .SetProjectFile(Solution.Halibut_Tests)
                 .SetConfiguration(Configuration)
+                .SetFramework("net6.0")
                 .EnableNoBuild()
                 .EnableNoRestore());
-            
+
+        });
+
+    [PublicAPI]
+    Target TestWindowsNet48 => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            DotMemoryUnit(
+                $"{DotNetPath.DoubleQuoteIfNeeded()} --propagate-exit-code --instance-name={Guid.NewGuid()} -- test {Solution.Halibut_Tests_DotMemory.Path} --configuration={Configuration} --framework=net48 --no-build");
+
+            DotNetTest(_ => _
+                .SetProjectFile(Solution.Halibut_Tests)
+                .SetConfiguration(Configuration)
+                .SetFramework("net48")
+                .EnableNoBuild()
+                .EnableNoRestore());
+
         });
 
     [PublicAPI]


### PR DESCRIPTION
# Background

Add additional nuke targets to allow for net48 and net60 tests on windows to be split run separately

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
