### PR TITLE
Add listening connect retry tests

### DIFF
--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.PortForwarding;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class ListeningConnectRetryFixture : BaseTest
+    {
+        [Test]
+        public async Task ListeningRetriesAttemptsUpToTheConfiguredValue()
+        {
+            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            using (var clientAndService = await LatestClientAndLatestServiceBuilder.Listening()
+                       .WithPortForwarding(port =>
+                       {
+                           var portForwarder = PortForwarderUtil.ForwardingToLocalPort(port)
+                               .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                               .Build();
+
+                           return portForwarder;
+                       })
+                       .WithEchoService()
+                       .Build(CancellationToken))
+            {
+                clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
+
+                var echoService = clientAndService.CreateClient<IEchoService>(point =>
+                {
+                    point.RetryListeningSleepInterval = TimeSpan.Zero;
+                    point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
+                    point.RetryCountLimit = 100;
+                });
+                
+                Assert.Throws<HalibutClientException>(() => echoService.SayHello("hello"));
+
+                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(100);
+            }
+        }
+        
+        [Test]
+        public async Task ListeningRetriesAttemptsUpToTheConfiguredTimeout()
+        {
+            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            using (var clientAndService = await LatestClientAndLatestServiceBuilder.Listening()
+                       .WithPortForwarding(port =>
+                       {
+                           var portForwarder = PortForwarderUtil.ForwardingToLocalPort(port)
+                               .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                               .Build();
+
+                           return portForwarder;
+                       })
+                       .WithEchoService()
+                       .Build(CancellationToken))
+            {
+                clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
+
+                var echoService = clientAndService.CreateClient<IEchoService>(point =>
+                {
+                    point.RetryListeningSleepInterval = TimeSpan.FromSeconds(1);
+                    point.ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(15);
+                    point.RetryCountLimit = 100000000;
+                });
+
+                var sw = Stopwatch.StartNew();
+                Assert.Throws<HalibutClientException>(() => echoService.SayHello("hello"));
+                sw.Stop();
+
+                
+                sw.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(7)/* Give a big amount of leeway */);
+            }
+        }
+        
+        [Test]
+        public async Task ListeningRetryListeningSleepIntervalWorks()
+        {
+            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            using (var clientAndService = await LatestClientAndLatestServiceBuilder.Listening()
+                       .WithPortForwarding(port =>
+                       {
+                           var portForwarder = PortForwarderUtil.ForwardingToLocalPort(port)
+                               .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                               .Build();
+
+                           return portForwarder;
+                       })
+                       .WithEchoService()
+                       .Build(CancellationToken))
+            {
+                clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
+
+                var echoService = clientAndService.CreateClient<IEchoService>(point =>
+                {
+                    point.RetryListeningSleepInterval = TimeSpan.FromSeconds(1);
+                    point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
+                    point.RetryCountLimit = 15;
+                });
+
+                var sw = Stopwatch.StartNew();
+                Assert.Throws<HalibutClientException>(() => echoService.SayHello("hello"));
+                sw.Stop();
+
+                
+                sw.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(7)/* Give a big amount of leeway */);
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -96,17 +96,54 @@ namespace Halibut.Tests
 
                 var echoService = clientAndService.CreateClient<IEchoService>(point =>
                 {
-                    point.RetryListeningSleepInterval = TimeSpan.FromSeconds(1);
+                    point.RetryListeningSleepInterval = TimeSpan.FromSeconds(10);
                     point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
-                    point.RetryCountLimit = 15;
+                    point.RetryCountLimit = 4;
                 });
 
                 var sw = Stopwatch.StartNew();
                 Assert.Throws<HalibutClientException>(() => echoService.SayHello("hello"));
                 sw.Stop();
 
-                
-                sw.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(7)/* Give a big amount of leeway */);
+                // Expected ~30s since we sleep 10s _between_ each attempt.
+                sw.Elapsed.Should().BeCloseTo(TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(15)/* Give a big amount of leeway for windows */);
+            }
+        }
+        
+        [Test]
+        public async Task ListeningRetriesAttemptsCanEventuallyWork()
+        {
+            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            using (var clientAndService = await LatestClientAndLatestServiceBuilder.Listening()
+                       .WithPortForwarding(port =>
+                       {
+                           var portForwarder = PortForwarderUtil.ForwardingToLocalPort(port)
+                               .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                               .Build();
+
+                           return portForwarder;
+                       })
+                       .WithEchoService()
+                       .Build(CancellationToken))
+            {
+                clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
+
+                var echoService = clientAndService.CreateClient<IEchoService>(point =>
+                {
+                    point.RetryListeningSleepInterval = TimeSpan.FromSeconds(1);
+                    point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
+                    point.RetryCountLimit = 999999;
+                });
+
+                var echoCallThatShouldEventuallySucced = Task.Run(() => echoService.SayHello("hello"));
+                while (tcpConnectionsCreatedCounter.ConnectionsCreatedCount < 5)
+                {
+                    Logger.Information("TCP count is at: {Count}", tcpConnectionsCreatedCounter.ConnectionsCreatedCount);
+                    await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken);
+                }
+                clientAndService.PortForwarder.ReturnToNormalMode();
+
+                await echoCallThatShouldEventuallySucced;
             }
         }
     }

--- a/source/Halibut.Tests/Support/PortForwarding/PortForwardingTcpConnectionsCreatedCounter.cs
+++ b/source/Halibut.Tests/Support/PortForwarding/PortForwardingTcpConnectionsCreatedCounter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using Octopus.TestPortForwarder;
+using Serilog;
+
+namespace Halibut.Tests.Support.PortForwarding
+{
+    public static class PortForwardingTcpConnectionsCreatedCounter
+    {
+        public static PortForwarderBuilder WithCountTcpConnectionsCreated(this PortForwarderBuilder portForwarderBuilder, out TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter)
+        {
+            
+            var myTcpConnectionsCreatedCounter = new TcpConnectionsCreatedCounter();
+            tcpConnectionsCreatedCounter = myTcpConnectionsCreatedCounter;
+            
+            return portForwarderBuilder.WithDataObserver(() =>
+            {
+                myTcpConnectionsCreatedCounter.ConnectionsCreatedCount++;
+                return new BiDirectionalDataTransferObserverBuilder().Build();
+            });
+        }
+    }
+    
+    public class TcpConnectionsCreatedCounter
+    {
+        public long ConnectionsCreatedCount { get; set; } = 0;
+    }
+}

--- a/source/Octopus.TestPortForwarder/BiDirectionalDataTransferObserver.cs
+++ b/source/Octopus.TestPortForwarder/BiDirectionalDataTransferObserver.cs
@@ -3,6 +3,9 @@ using System.Linq;
 
 namespace Octopus.TestPortForwarder
 {
+    /// <summary>
+    /// Observes data flowing over a single proxied connection.
+    /// </summary>
     public class BiDirectionalDataTransferObserver
     {
         public BiDirectionalDataTransferObserver(IDataTransferObserver dataTransferObserverClientToOrigin, IDataTransferObserver dataTransferObserverOriginToClient)


### PR DESCRIPTION
# Background

Adds tests around listening connect retries.

[SC-53157]

Also adds the ability to count the number of TCP connections accepted by the port forwarder.
Also always closes accept sockets in the Port Forwarder if an exception is raised before passing the port to something else to own and close.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
