### PR TITLE
Run polling cancellation tests on websockets

### DIFF
--- a/source/Halibut.Tests/Support/TestAttributes/PollingServiceConnectionTypesToTest.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/PollingServiceConnectionTypesToTest.cs
@@ -11,10 +11,9 @@ namespace Halibut.Tests.Support.TestAttributes
             var toTest = new List<ServiceConnectionType>
             {
                 ServiceConnectionType.Polling,
-// Disabled while these are causing flakey Team City Tests
-//#if SUPPORTS_WEB_SOCKET_CLIENT
-//             ServiceConnectionType.PollingOverWebSocket
-//#endif
+#if SUPPORTS_WEB_SOCKET_CLIENT
+                ServiceConnectionType.PollingOverWebSocket
+#endif
             };
             return ((IEnumerable<ServiceConnectionType>) toTest).GetEnumerator();
         }

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.TestServices;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
@@ -17,12 +18,12 @@ namespace Halibut.Tests
         public class AndTheRequestIsStillQueued : BaseTest
         {
             [Test]
-            public async Task TheRequestShouldBeCancelled()
+            [TestCaseSource(typeof(PollingServiceConnectionTypesToTest))]
+            public async Task TheRequestShouldBeCancelled(ServiceConnectionType serviceConnectionType)
             {
                 var cancellationTokenSource = new CancellationTokenSource();
-
-                using (var clientAndService = await LatestClientAndLatestServiceBuilder
-                           .Polling()
+                
+                using (var clientAndService = await LatestClientAndLatestServiceBuilder.ForServiceConnectionType(serviceConnectionType)
                            // No Tentacle
                            .NoService()
                            // CancelWhenRequestQueuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
@@ -51,13 +52,13 @@ namespace Halibut.Tests
         public class AndTheRequestHasBeenDequeuedButNoResponseReceived : BaseTest
         {
             [Test]
-            public async Task TheRequestShouldNotBeCancelled()
+            [TestCaseSource(typeof(PollingServiceConnectionTypesToTest))]
+            public async Task TheRequestShouldNotBeCancelled(ServiceConnectionType serviceConnectionType)
             {
                 var calls = new List<DateTime>();
                 var cancellationTokenSource = new CancellationTokenSource();
 
-                using (var clientAndService = await LatestClientAndLatestServiceBuilder
-                           .Polling()
+                using (var clientAndService = await LatestClientAndLatestServiceBuilder.ForServiceConnectionType(serviceConnectionType)
                            .WithDoSomeActionService(() =>
                            {
                                calls.Add(DateTime.UtcNow);


### PR DESCRIPTION
# Background

Run these polling cancellation tests on websockets as well.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
