### PR TITLE
Expand cancellation via client proxy tests

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateCountingService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateCountingService.cs
@@ -1,0 +1,24 @@
+using Halibut.TestUtils.Contracts;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class DelegateCountingService : ICountingService
+    {
+        ICountingService countingService;
+
+        public DelegateCountingService(ICountingService countingService)
+        {
+            this.countingService = countingService;
+        }
+
+        public int Increment()
+        {
+            return countingService.Increment();
+        }
+
+        public int GetCurrentValue()
+        {
+            return countingService.GetCurrentValue();
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateLockService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateLockService.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using Halibut.TestUtils.Contracts;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class DelegateLockService : ILockService
+    {
+        ILockService lockServiceImplementation;
+
+        public DelegateLockService(ILockService lockServiceImplementation)
+        {
+            this.lockServiceImplementation = lockServiceImplementation;
+        }
+
+        public void WaitForFileToBeDeleted(string fileToWaitFor, string fileSignalWhenRequestIsStarted)
+        {
+            lockServiceImplementation.WaitForFileToBeDeleted(fileToWaitFor, fileSignalWhenRequestIsStarted);
+        }
+
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -24,6 +24,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 services.Register<IEchoService>(() => new EchoService());
                 services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
                 services.Register<IComplexObjectService>(() => new ComplexObjectService());
+                services.Register<ILockService>(() => new LockService());
             }
 
             if (SettingsHelper.IsWithCachingService())
@@ -62,6 +63,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             RegisterDelegateService<IScriptService>(s => new DelegateScriptService(s));
             RegisterDelegateService<IScriptServiceV2>(s => new DelegateScriptServiceV2(s));
             RegisterDelegateService<ICapabilitiesServiceV2>(s => new DelegateCapabilitiesServiceV2(s));
+            RegisterDelegateService<ILockService>(s => new DelegateLockService(s));
 
             void RegisterDelegateService<T>(Func<T,T> createDelegateFunc)
             {

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -25,6 +25,8 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
                 services.Register<IComplexObjectService>(() => new ComplexObjectService());
                 services.Register<ILockService>(() => new LockService());
+                var singleCountingService = new CountingService();
+                services.Register<ICountingService>(() => singleCountingService);
             }
 
             if (SettingsHelper.IsWithCachingService())

--- a/source/Halibut.TestUtils.Contracts/CountingService.cs
+++ b/source/Halibut.TestUtils.Contracts/CountingService.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public class CountingService : ICountingService
+    {
+        int count;
+        public int Increment()
+        {
+            return Interlocked.Increment(ref count);
+        }
+
+        public int GetCurrentValue()
+        {
+            return count;
+        }
+    }
+}

--- a/source/Halibut.TestUtils.Contracts/ICountingService.cs
+++ b/source/Halibut.TestUtils.Contracts/ICountingService.cs
@@ -1,0 +1,8 @@
+namespace Halibut.TestUtils.Contracts
+{
+    public interface ICountingService
+    {
+        public int Increment();
+        public int GetCurrentValue();
+    }
+}

--- a/source/Halibut.TestUtils.Contracts/ILockService.cs
+++ b/source/Halibut.TestUtils.Contracts/ILockService.cs
@@ -1,0 +1,7 @@
+namespace Halibut.TestUtils.Contracts
+{
+    public interface ILockService
+    {
+        public void WaitForFileToBeDeleted(string fileToWaitFor, string fileSignalWhenRequestIsStarted);
+    }
+}

--- a/source/Halibut.TestUtils.Contracts/LockService.cs
+++ b/source/Halibut.TestUtils.Contracts/LockService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public class LockService : ILockService
+    {
+        public void WaitForFileToBeDeleted(string file, string fileSignalWhenRequestIsStarted)
+        {
+            
+            File.Create(fileSignalWhenRequestIsStarted);
+            while (File.Exists(file))
+            {
+                Thread.Sleep(20);
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -110,7 +110,7 @@ namespace Halibut.Tests
                     await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken);
                 }
                 
-                // The second call is now in flight.
+                // The call is now in flight.
                 // Call cancel on the cancellation token for that in flight request.
                 cts.Cancel();
                 

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -56,13 +56,12 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         [FailedWebSocketTestsBecomeInconclusive]
-        public async Task CanTalkToOldServicesWhichDontKnowAboutHalibutProxyRequestOptions(ServiceConnectionType serviceConnectionType)
+        public async Task HalibutProxyRequestOptionsCanBeSentToLatestAndOldServicesThatPreDateHalibutProxyRequestOptions(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await LatestClientAndPreviousServiceVersionBuilder
-                       .ForServiceConnectionType(serviceConnectionType)
-                       .WithServiceVersion("5.0.429")
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -71,27 +70,6 @@ namespace Halibut.Tests
                         se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
                         se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
                     });
-
-                var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
-                res.Should().Be("Hello!!...");
-            }
-        }
-        
-        [Test]
-        [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
-        [FailedWebSocketTestsBecomeInconclusive]
-        public async Task HalibutProxyOptionsCanBeSentByTheClient(ServiceConnectionType serviceConnectionType)
-        {
-            using (var clientAndService = await LatestClientAndLatestServiceBuilder
-                       .ForServiceConnectionType(serviceConnectionType)
-                       .WithStandardServices()
-                       .Build(CancellationToken))
-            {
-                var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
-                {
-                    se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
-                    se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
-                });
 
                 var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
                 res.Should().Be("Hello!!...");

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -73,14 +73,11 @@ namespace Halibut.Tests
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
-                var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>(se =>
-                    {
-                        se.PollingRequestQueueTimeout = TimeSpan.FromSeconds(20);
-                        se.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(20);
-                    });
+                var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>();
 
-                var res = echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()));
-                res.Should().Be("Hello!!...");
+                echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()))
+                    .Should()
+                    .Be("Hello!!...");
             }
         }
         

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -35,6 +35,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         Func<int, PortForwarder>? portForwarderFactory;
         LogLevel halibutLogLevel;
         bool withTentacleServices = false;
+        ILockService lockService;
 
         PreviousClientVersionAndLatestServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -116,6 +117,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.complexObjectService = complexObjectService;
             return this;
         }
+        
+        public PreviousClientVersionAndLatestServiceBuilder WithLockService(ILockService lockService)
+        {
+            this.lockService = lockService;
+            return this;
+        }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithStandardServices()
         {
@@ -126,7 +133,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return WithEchoServiceService(new EchoService())
                 .WithMultipleParametersTestService(new MultipleParametersTestService())
-                .WithComplexObjectService(new ComplexObjectService());
+                .WithComplexObjectService(new ComplexObjectService())
+                .WithLockService(new LockService());
         }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithTentacleServices()
@@ -193,7 +201,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 .Register(() => echoService)
                 .Register(() => cachingService)
                 .Register(() => multipleParametersTestService)
-                .Register(() => complexObjectService);
+                .Register(() => complexObjectService)
+                .Register(() => lockService);
 
             if (withTentacleServices)
             {

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -36,6 +36,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         LogLevel halibutLogLevel;
         bool withTentacleServices = false;
         ILockService lockService;
+        ICountingService countingService;
 
         PreviousClientVersionAndLatestServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -123,6 +124,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.lockService = lockService;
             return this;
         }
+        
+        public PreviousClientVersionAndLatestServiceBuilder WithCountingService(ICountingService countingService)
+        {
+            this.countingService = countingService;
+            return this;
+        }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithStandardServices()
         {
@@ -134,7 +141,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return WithEchoServiceService(new EchoService())
                 .WithMultipleParametersTestService(new MultipleParametersTestService())
                 .WithComplexObjectService(new ComplexObjectService())
-                .WithLockService(new LockService());
+                .WithLockService(new LockService())
+                .WithCountingService(new CountingService());
         }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithTentacleServices()
@@ -202,7 +210,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 .Register(() => cachingService)
                 .Register(() => multipleParametersTestService)
                 .Register(() => complexObjectService)
-                .Register(() => lockService);
+                .Register(() => lockService)
+                .Register(() => countingService);
 
             if (withTentacleServices)
             {

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -142,7 +142,8 @@ namespace Halibut.Tests.Support
                 .WithEchoService()
                 .WithMultipleParametersTestService()
                 .WithCachingService()
-                .WithComplexObjectService();
+                .WithComplexObjectService()
+                .WithLockService();
         }
 
         public LatestClientAndLatestServiceBuilder WithTentacleServices()

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -143,7 +143,8 @@ namespace Halibut.Tests.Support
                 .WithMultipleParametersTestService()
                 .WithCachingService()
                 .WithComplexObjectService()
-                .WithLockService();
+                .WithLockService()
+                .WithCountingService();
         }
 
         public LatestClientAndLatestServiceBuilder WithTentacleServices()

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
@@ -26,6 +26,12 @@ namespace Halibut.Tests.Support
         {
             return builder.WithService<ILockService>(() => new LockService());
         }
+        
+        public static LatestClientAndLatestServiceBuilder WithCountingService(this LatestClientAndLatestServiceBuilder builder)
+        {
+            var singleCountingService = new CountingService();
+            return builder.WithService<ICountingService>(() => singleCountingService);
+        }
 
         public static LatestClientAndLatestServiceBuilder WithDoSomeActionService(this LatestClientAndLatestServiceBuilder builder, Action action)
         {

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
@@ -21,6 +21,11 @@ namespace Halibut.Tests.Support
         {
             return builder.WithService<IComplexObjectService>(() => new ComplexObjectService());
         }
+        
+        public static LatestClientAndLatestServiceBuilder WithLockService(this LatestClientAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<ILockService>(() => new LockService());
+        }
 
         public static LatestClientAndLatestServiceBuilder WithDoSomeActionService(this LatestClientAndLatestServiceBuilder builder, Action action)
         {

--- a/source/Halibut.Tests/Support/TemporaryDirectory.cs
+++ b/source/Halibut.Tests/Support/TemporaryDirectory.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests.Support
         public string CreateRandomFile()
         {
             string randomFile = RandomFileName();
-            File.Create(randomFile);
+            File.Create(randomFile).Dispose();
             return randomFile;
         }
 

--- a/source/Halibut.Tests/Support/TemporaryDirectory.cs
+++ b/source/Halibut.Tests/Support/TemporaryDirectory.cs
@@ -15,6 +15,18 @@ namespace Halibut.Tests.Support
 
         public string DirectoryPath { get; }
 
+        public string CreateRandomFile()
+        {
+            string randomFile = RandomFileName();
+            File.Create(randomFile);
+            return randomFile;
+        }
+
+        public string RandomFileName()
+        {
+            return Path.Combine(DirectoryPath, Guid.NewGuid().ToString());
+        }
+
         string GetTempBasePath()
         {
             var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);


### PR DESCRIPTION
# Background

* Tests cancellation can be done via client proxy on polling and websockets.
* Tests HalibutProxyRequestOptions works with latest service.
* Test that HalibutProxyRequestOptions can not cancel in flight requests.
* Update existing cancellation tests to really check the RPC call was never actually made rather than just trust the exception.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
