### PR TITLE
Uplift parallel test to test backwards compatibility

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateReadDataStreamService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateReadDataStreamService.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+using Halibut.TestUtils.Contracts;
+using Halibut.TestUtils.SampleProgram.Base.Utils;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class DelegateReadDataStreamService : IReadDataStreamService
+    {
+        readonly IReadDataStreamService readDataStreamService;
+
+        public DelegateReadDataStreamService(IReadDataStreamService readDataStreamService)
+        {
+            this.readDataStreamService = readDataStreamService;
+        }
+        
+        public long SendData(DataStream[] dataStreams)
+        {
+            return readDataStreamService.SendData(dataStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToArray());
+        }
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -22,7 +22,8 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 services.Register<IEchoService>(() => new EchoService())
                     .Register<IMultipleParametersTestService>(() => new MultipleParametersTestService())
                     .Register<IComplexObjectService>(() => new ComplexObjectService())
-                    .Register<ILockService>(() => new LockService());
+                    .Register<ILockService>(() => new LockService())
+                    .Register<IReadDataStreamService>(() => new ReadDataStreamService());
 
                 var singleCountingService = new CountingService();
                 services.Register<ICountingService>(() => singleCountingService);
@@ -61,6 +62,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             RegisterDelegateService<IMultipleParametersTestService>(s => new DelegateMultipleParametersTestService(s));
             RegisterDelegateService<IComplexObjectService>(s => new DelegateComplexObjectService(s));
             RegisterDelegateService<IFileTransferService>(s => new DelegateFileTransferService(s));
+			RegisterDelegateService<IReadDataStreamService>(s => new DelegateReadDataStreamService(s));
             RegisterDelegateService<IScriptService>(s => new DelegateScriptService(s));
             RegisterDelegateService<IScriptServiceV2>(s => new DelegateScriptServiceV2(s));
             RegisterDelegateService<ICapabilitiesServiceV2>(s => new DelegateCapabilitiesServiceV2(s));

--- a/source/Halibut.TestUtils.Contracts/IReadDataStreamService.cs
+++ b/source/Halibut.TestUtils.Contracts/IReadDataStreamService.cs
@@ -1,4 +1,6 @@
-namespace Halibut.Tests.TestServices
+using System;
+
+namespace Halibut.TestUtils.Contracts
 {
     public interface IReadDataStreamService
     {

--- a/source/Halibut.TestUtils.Contracts/ReadDataStreamService.cs
+++ b/source/Halibut.TestUtils.Contracts/ReadDataStreamService.cs
@@ -1,6 +1,6 @@
-using System.Xml.Schema;
+using System;
 
-namespace Halibut.Tests.TestServices
+namespace Halibut.TestUtils.Contracts
 {
     public class ReadDataStreamService : IReadDataStreamService
     {

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -117,7 +117,6 @@ namespace Halibut.Tests
                        .WithStandardServices()
                        .WithHalibutLoggingLevel(LogLevel.Trace)
                        .As<LatestClientAndLatestServiceBuilder>()
-                       .WithReadDataStreamService()
                        .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
                        .Build(CancellationToken))
             {

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
+using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.TestUtils.Contracts;
@@ -15,7 +16,7 @@ namespace Halibut.Tests
     public class ParallelRequestsFixture : BaseTest
     {
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(ServiceConnectionType.Listening, testNetworkConditions: false)]
         [FailedWebSocketTestsBecomeInconclusive]
         public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
         {

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -1,12 +1,13 @@
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
-using Halibut.ServiceModel;
-using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
-using Halibut.Tests.TestServices;
+using Halibut.Tests.Support.TestCases;
+using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
 namespace Halibut.Tests
@@ -14,33 +15,42 @@ namespace Halibut.Tests
     public class ParallelRequestsFixture : BaseTest
     {
         [Test]
-        [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         [FailedWebSocketTestsBecomeInconclusive]
-        public async Task SendMessagesToTentacleInParallel(ServiceConnectionType serviceConnectionType)
+        public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            var services = new DelegateServiceFactory();
-            services.Register<IReadDataStreamService>(() => new ReadDataStreamService());
-
-            using (var clientAndService = await LatestClientAndLatestServiceBuilder
-                       .ForServiceConnectionType(serviceConnectionType)
-                       .WithHalibutLoggingLevel(LogLevel.Info)
-                       .WithServiceFactory(services)
-                       .WithServiceFactory(services).Build(CancellationToken))
+            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .WithHalibutLoggingLevel(LogLevel.Info)
+                .WithStandardServices()
+                .Build(CancellationToken);
             {
                 var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();
 
                 var dataStreams = CreateDataStreams();
 
-                var messagesAreSentTheSameTimeSemaphore = new Semaphore(0, dataStreams.Length);
+                var messagesAreSentTheSameTimeSemaphore = new SemaphoreSlim(0, dataStreams.Length);
 
+                int threadCount = 64;
+                int threadCompletionCount = 0;
                 var threads = new List<Thread>();
-                for (var i = 0; i < 64; i++)
+                var exceptions = new ConcurrentBag<Exception>();
+                for (var i = 0; i < threadCount; i++)
                 {
                     var thread = new Thread(() =>
                     {
-                        messagesAreSentTheSameTimeSemaphore.WaitOne();
-                        var recieved = readDataSteamService.SendData(dataStreams);
-                        recieved.Should().Be(5 * dataStreams.Length);
+                        // Gotta handle exceptions when running in a 
+                        // Thread, or you're gonna have a bad time.
+                        try
+                        {
+                            messagesAreSentTheSameTimeSemaphore.Wait(CancellationToken);
+                            var received = readDataSteamService.SendData(dataStreams);
+                            received.Should().Be(5 * dataStreams.Length);
+                            Interlocked.Increment(ref threadCompletionCount);
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions.Add(e);
+                        }
                     });
                     thread.Start();
                     threads.Add(thread);
@@ -49,6 +59,8 @@ namespace Halibut.Tests
                 messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
 
                 WaitForAllThreads(threads);
+                exceptions.Should().BeEmpty();
+                threadCompletionCount.Should().Be(threadCount);
             }
         }
 
@@ -65,7 +77,7 @@ namespace Halibut.Tests
             return dataStreams;
         }
 
-        static void WaitForAllThreads(List<Thread> threads)
+        void WaitForAllThreads(List<Thread> threads)
         {
             foreach (var thread in threads)
             {

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -33,6 +33,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         ICachingService cachingService = new CachingService();
         IMultipleParametersTestService multipleParametersTestService = new MultipleParametersTestService();
         IComplexObjectService complexObjectService = new ComplexObjectService();
+        IReadDataStreamService readDataStreamService = new ReadDataStreamService();
         Func<int, PortForwarder>? portForwarderFactory;
         LogLevel halibutLogLevel;
         bool withTentacleServices = false;
@@ -132,6 +133,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
+        public PreviousClientVersionAndLatestServiceBuilder WithReadDataStreamService(IReadDataStreamService readDataStreamService)
+        {
+            this.readDataStreamService = readDataStreamService;
+            return this;
+        }
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithStandardServices()
         {
             return WithStandardServices();
@@ -142,6 +149,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return WithEchoServiceService(new EchoService())
                 .WithMultipleParametersTestService(new MultipleParametersTestService())
                 .WithComplexObjectService(new ComplexObjectService())
+                .WithReadDataStreamService(new ReadDataStreamService())
                 .WithLockService(new LockService())
                 .WithCountingService(new CountingService());
         }
@@ -222,7 +230,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 .Register(() => multipleParametersTestService)
                 .Register(() => complexObjectService)
                 .Register(() => lockService)
-                .Register(() => countingService);
+                .Register(() => countingService)
+				.Register(() => readDataStreamService);
 
             if (withTentacleServices)
             {

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -8,6 +8,7 @@ using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
 using Halibut.Tests.Support.Logging;
+using Halibut.Tests.TestServices;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.Contracts.Tentacle.Services;
 using Halibut.Transport.Proxy;
@@ -18,6 +19,7 @@ using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.TestPortForwarder;
 using Serilog.Extensions.Logging;
 using ILog = Halibut.Diagnostics.ILog;
+using ICachingService = Halibut.TestUtils.Contracts.ICachingService;
 
 namespace Halibut.Tests.Support
 {
@@ -164,7 +166,8 @@ namespace Halibut.Tests.Support
                 .WithCachingService()
                 .WithComplexObjectService()
                 .WithLockService()
-                .WithCountingService();
+                .WithCountingService()
+                .WithReadDataStreamService();
         }
 
         public LatestClientAndLatestServiceBuilder WithTentacleServices()

--- a/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
@@ -17,8 +17,40 @@ namespace Halibut.Tests.Support.TestAttributes
         {
         }
         
+        public LatestAndPreviousClientAndServiceVersionsTestCasesAttribute(ServiceConnectionType serviceConnectionType, bool testNetworkConditions = true) :
+            base(
+                typeof(LatestAndPreviousClientAndServiceVersionsTestCases),
+                nameof(LatestAndPreviousClientAndServiceVersionsTestCases.GetEnumeratorForServiceConnectionType),
+                new object[] { new[] { serviceConnectionType}, testNetworkConditions })
+        {
+        }
+        
+        public LatestAndPreviousClientAndServiceVersionsTestCasesAttribute(ServiceConnectionType[] serviceConnectionTypes, bool testNetworkConditions = true) :
+            base(
+                typeof(LatestAndPreviousClientAndServiceVersionsTestCases),
+                nameof(LatestAndPreviousClientAndServiceVersionsTestCases.GetEnumeratorForServiceConnectionType),
+                new object[] { serviceConnectionTypes, testNetworkConditions })
+        {
+        }
+        
         static class LatestAndPreviousClientAndServiceVersionsTestCases
         {
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumeratorForServiceConnectionType(ServiceConnectionType[] serviceConnectionTypes, bool testNetworkConditions)
+            {
+                var builder = new ClientAndServiceTestCasesBuilder(
+                    new[] {
+                        ClientAndServiceTestVersion.Latest(),
+                        ClientAndServiceTestVersion.ClientOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ClientVersion),
+                        ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ServiceVersion),
+                    },
+                    serviceConnectionTypes,
+                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect }
+                );
+
+                return builder.Build().GetEnumerator();
+                
+            }
+            
             public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions)
             {
                 var builder = new ClientAndServiceTestCasesBuilder(


### PR DESCRIPTION
This PR updates the `SendMessagesToTentacleInParallel` test so that it tests all relevant backwards compatibility scenarios.

Also added in a try/catch within the Thread operation (nUnit _really_ doesn't like unhandled exceptions being thrown within threads), and some sanity checks to ensure all threads complete successfully.

[sc-53157]