### PR TITLE
PollingOverWebSockets can fail to close a WebSocket connection once it is finished with

### DIFF
--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -141,8 +141,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [Timeout(15000)]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)] // TODO - A bug in the PollingOverWebSocket implementation means this never completes
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         [FailedWebSocketTestsBecomeInconclusive]
         public async Task FailWhenServerThrowsDuringADataStream(ClientAndServiceTestCase clientAndServiceTestCase)
         {
@@ -163,8 +162,8 @@ namespace Halibut.Tests
                     Assert.Throws<HalibutClientException>(() => readDataSteamService.SendData(new DataStream(10000, stream => throw new Exception("Oh noes"))));
                 }
 
-                var recieved = readDataSteamService.SendData(DataStream.FromString("hello"));
-                recieved.Should().Be(5);
+                var received = readDataSteamService.SendData(DataStream.FromString("hello"));
+                received.Should().Be(5);
             }
         }
     }


### PR DESCRIPTION
# Background

Address a bug in PollingOverWebSockets, where the SecureWebSocketListener fails to terminate the WebSocket connection after completing its sending loop. As a result, the connection to the Tentacle remains open, but no further messages are transmitted. Consequently, the WebSocket Tentacle becomes unresponsive, unable to receive any new messages until the connection is terminated through other means, such as a Tentacle process restart.

# Results

## Before

In a scenario where the `SecureWebSocketListener`  `await ExchangeMessages(webSocketStream)` completes without an error, the WebSocket connection would be kept alive, but nothing else would ever be sent over the connection.

This could occur due to an exception e.g. see `FailWhenServerThrowsDuringADataStream`. Before this change, the test would hang forever until it timed out.

## After

Once the `SecureWebSocketListener` exists the `await ExchangeMessages(webSocketStream)` the connection is closed and the PollingOverWebSocket Tentacle will reconnect to Server and receive any pending requests.

`FailWhenServerThrowsDuringADataStream` now passes for WebSockets

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
