### PR TITLE
Switch to using LatestClientAndLatestServiceTestCases in ExceptionReturnedByHalibutProxyExtensionMethodFixture

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -145,13 +145,12 @@ namespace Halibut.Tests.Diagnostics
             }
 
             [Test]
-            [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
             [FailedWebSocketTestsBecomeInconclusive]
-            public async Task BecauseTheDataStreamHadAnErrorOpeningTheFileWithFileStream_WhenSending_ItIsNotANetworkError(ServiceConnectionType serviceConnectionType)
+            public async Task BecauseTheDataStreamHadAnErrorOpeningTheFileWithFileStream_WhenSending_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await LatestClientAndLatestServiceBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithEchoService()
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .WithStandardServices()
                            .Build(CancellationToken))
                 {
                     var echo = clientAndService.CreateClient<IEchoService>();
@@ -166,13 +165,12 @@ namespace Halibut.Tests.Diagnostics
             }
 
             [Test]
-            [TestCaseSource(typeof(ServiceConnectionTypesToTest))]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
             [FailedWebSocketTestsBecomeInconclusive]
-            public async Task BecauseTheDataStreamThrowAFileNotFoundException_WhenSending_ItIsNotANetworkError(ServiceConnectionType serviceConnectionType)
+            public async Task BecauseTheDataStreamThrowAFileNotFoundException_WhenSending_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await LatestClientAndLatestServiceBuilder
-                           .ForServiceConnectionType(serviceConnectionType)
-                           .WithEchoService()
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .WithStandardServices()
                            .Build(CancellationToken))
                 {
                     var echo = clientAndService.CreateClient<IEchoService>();


### PR DESCRIPTION
# Background

Switch to using LatestClientAndLatestServiceTestCases in ExceptionReturnedByHalibutProxyExtensionMethodFixture.

Done while reading over what this class did.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
