### PR TITLE
Test listening only keeps healthy connections in the pool

### DIFF
--- a/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
+++ b/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.PortForwarding;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class ListeningTentaclesUseAPoolOfConnectionsFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false)]
+        public async Task TestOnlyHealthConnectionsAreKeptInThePool(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
+                           .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                           .Build())
+                       .WithStandardServices()
+                       .AsLatestClientAndLatestServiceBuilder()
+                       .WithPortForwarding(out var portForwarder)
+                       .WithDoSomeActionService(() => portForwarder.Value.PauseExistingConnections())
+                       .Build(CancellationToken))
+            {
+                var echoService = clientAndService.CreateClient<IEchoService>(point =>
+                {
+                    // This test should never need to make use of this since no bad connections should be in the pool
+                    point.RetryListeningSleepInterval = TimeSpan.FromMinutes(10);
+                });
+                var pauseCurrentTcpConnections = clientAndService.CreateClient<IDoSomeActionService>();
+
+                echoService.SayHello("This should make one connection");
+                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1);
+                
+                echoService.SayHello("Should re-use the same connection");
+                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "We should use the same connection since the last was healthy");
+
+                Assert.Throws<HalibutClientException>(() => pauseCurrentTcpConnections.Action());
+                // Connection should not be put back into the pool
+                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "This should still be using the same connection since it is on this call we break the connection.");
+
+                var sw = Stopwatch.StartNew();
+                echoService.SayHello("This should immediately create a new connection");
+                sw.Stop();
+                
+                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(2, "Since the last connection should not have been put back into the pool.");
+
+                sw.Elapsed.Should().BeLessThan(HalibutLimits.TcpClientHeartbeatReceiveTimeout, "we should not be putting the bad connection back into the pool, " +
+                                                                                               "then pulling it out detecting it is bad and then attempting to create a new connection");
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -123,7 +123,7 @@ namespace Halibut.Tests.Support
 
         public LatestClientAndLatestServiceBuilder WithPortForwarding(out Reference<PortForwarder> portForwarder)
         {
-            this.WithPortForwarding();
+            if(this.portForwarderFactory == null) this.WithPortForwarding();
 
             this.portForwarderReference = new Reference<PortForwarder>();
             portForwarder = this.portForwarderReference;

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
@@ -13,17 +13,20 @@ namespace Halibut.Tests.Support.TestAttributes
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class LatestClientAndLatestServiceTestCasesAttribute : TestCaseSourceAttribute
     {
-        public LatestClientAndLatestServiceTestCasesAttribute(bool testWebSocket = true, bool testNetworkConditions = true, bool testListening = true) :
+        public LatestClientAndLatestServiceTestCasesAttribute(bool testWebSocket = true, 
+            bool testNetworkConditions = true, 
+            bool testListening = true,
+            bool testPolling = true) :
             base(
                 typeof(LatestClientAndLatestServiceTestCases), 
                 nameof(LatestClientAndLatestServiceTestCases.GetEnumerator), 
-                new object[]{ testWebSocket, testNetworkConditions, testListening })
+                new object[]{ testWebSocket, testNetworkConditions, testListening, testPolling})
         {
         }
         
         static class LatestClientAndLatestServiceTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -35,6 +38,11 @@ namespace Halibut.Tests.Support.TestAttributes
                 if (!testListening)
                 {
                     serviceConnectionTypes.Remove(ServiceConnectionType.Listening);
+                }
+
+                if (!testPolling)
+                {
+                    serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
 
                 var builder = new ClientAndServiceTestCasesBuilder(


### PR DESCRIPTION
# Background

Test listening only keeps healthy connections in the pool and re-uses those healthy connections.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
