### PR TITLE
Fix a WebSocket bug where a SendAsync was not being awaited

### DIFF
--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -78,11 +78,11 @@ namespace Halibut.Transport.Protocol
                 .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        public Task WriteTextMessage(string message)
+        public async Task WriteTextMessage(string message)
         {
             AssertCanReadOrWrite();
             var buffer = new ArraySegment<byte>(Encoding.UTF8.GetBytes(message));
-            return context.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
+            await context.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None);
         }
 
         void AssertCanReadOrWrite()

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -36,7 +36,7 @@ namespace Halibut.Transport
             var stream = new WebSocketStream(client);
 
             log.Write(EventType.Security, "Performing handshake");
-            stream.WriteTextMessage("MX");
+            stream.WriteTextMessage("MX").ConfigureAwait(false).GetAwaiter().GetResult();
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}", serviceEndpoint.BaseUri, serviceEndpoint.RemoteThumbprint);
 


### PR DESCRIPTION
# Background

A WebSocket SendAsync call was not being awaited, resulting in the possibility of two SendAsync calls being in flight at the same time on the WebSocket, which is not supported

# Results

## Before

`System.InvalidOperationException: There is already one outstanding 'SendAsync' call for this WebSocket instance. ReceiveAsync and SendAsync can be called simultaneously, but at most one outstanding operation for each of them is allowed at the same time.`

## After

No error

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
