### PR TITLE
Only use a stable version of Halibut for PollingOverWebsocket Tests

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/CompatBaseDelegateServiceFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/CompatBaseDelegateServiceFactory.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Halibut.ServiceModel;
+
+namespace Halibut.TestUtils.SampleProgram.Base
+{
+    public class CompatBaseDelegateServiceFactory : IServiceFactory
+    {
+        readonly Dictionary<string, Func<object>> services = new(StringComparer.OrdinalIgnoreCase);
+        readonly HashSet<Type> serviceTypes = new();
+
+        public CompatBaseDelegateServiceFactory Register<TContract>(Func<TContract> implementation)
+        {
+            var serviceType = typeof(TContract);
+            services.Add(serviceType.Name, () => implementation());
+            lock (serviceTypes)
+            {
+                serviceTypes.Add(serviceType);
+            }
+
+            return this;
+        }
+
+        public IServiceLease CreateService(string serviceName)
+        {
+            var serviceType = GetService(serviceName);
+            return CreateService(serviceType);
+        }
+
+        Func<object> GetService(string name)
+        {
+            if (!services.TryGetValue(name, out var result))
+            {
+                throw new Exception("Service not found: " + name);
+            }
+
+            return result;
+        }
+
+        static IServiceLease CreateService(Func<object> serviceBuilder)
+        {
+            var service = serviceBuilder();
+            return new Lease(service);
+        }
+
+        public IReadOnlyList<Type> RegisteredServiceTypes
+        {
+            get
+            {
+                lock (serviceTypes)
+                {
+                    return serviceTypes.ToList();
+                }
+            }
+        }
+
+        #region Nested type: Lease
+
+        class Lease : IServiceLease
+        {
+            readonly object service;
+
+            public Lease(object service)
+            {
+                this.service = service;
+            }
+
+            public object Service => service;
+
+            public void Dispose()
+            {
+                if (service is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using Halibut.ServiceModel;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.Contracts.Tentacle.Services;
 using Octopus.Tentacle.Contracts;
@@ -15,16 +14,16 @@ namespace Halibut.TestUtils.SampleProgram.Base
         /// ie Old/Previous Service.
         /// </summary>
         /// <returns></returns>
-        public static DelegateServiceFactory CreateServiceFactory()
+        public static CompatBaseDelegateServiceFactory CreateServiceFactory()
         {
-            
-            var services = new DelegateServiceFactory();
+            var services = new CompatBaseDelegateServiceFactory();
             if (SettingsHelper.IsWithStandardServices())
             {
-                services.Register<IEchoService>(() => new EchoService());
-                services.Register<IMultipleParametersTestService>(() => new MultipleParametersTestService());
-                services.Register<IComplexObjectService>(() => new ComplexObjectService());
-                services.Register<ILockService>(() => new LockService());
+                services.Register<IEchoService>(() => new EchoService())
+                    .Register<IMultipleParametersTestService>(() => new MultipleParametersTestService())
+                    .Register<IComplexObjectService>(() => new ComplexObjectService())
+                    .Register<ILockService>(() => new LockService());
+
                 var singleCountingService = new CountingService();
                 services.Register<ICountingService>(() => singleCountingService);
             }
@@ -36,10 +35,10 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
             if (SettingsHelper.IsWithTentacleServices())
             {
-                services.Register<IFileTransferService>(() => new FileTransferService());
-                services.Register<IScriptService>(() => new ScriptService());
-                services.Register<IScriptServiceV2>(() => new ScriptServiceV2());
-                services.Register<ICapabilitiesServiceV2>(() => new CapabilitiesServiceV2());
+                services.Register<IFileTransferService>(() => new FileTransferService())
+                    .Register<IScriptService>(() => new ScriptService())
+                    .Register<IScriptServiceV2>(() => new ScriptServiceV2())
+                    .Register<ICapabilitiesServiceV2>(() => new CapabilitiesServiceV2());
             }
 
             return services;
@@ -52,9 +51,9 @@ namespace Halibut.TestUtils.SampleProgram.Base
         /// <param name="clientWhichTalksToLatestHalibut"></param>
         /// <param name="realServiceEndpoint"></param>
         /// <returns></returns>
-        public static DelegateServiceFactory CreateProxyingServicesServiceFactory(HalibutRuntime clientWhichTalksToLatestHalibut, ServiceEndPoint realServiceEndpoint)
+        public static CompatBaseDelegateServiceFactory CreateProxyingServicesServiceFactory(HalibutRuntime clientWhichTalksToLatestHalibut, ServiceEndPoint realServiceEndpoint)
         {
-            var services = new DelegateServiceFactory();
+            var services = new CompatBaseDelegateServiceFactory();
             // No need to check if is with standard services since, the Test itself has the service and so controls what is available
             // or not. This will just pass on the request to the service that may or may not exist.
             

--- a/source/Halibut.TestUtils.CompatBinary.v6_0_658/Halibut.TestUtils.CompatBinary.v6_0_658.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v6_0_658/Halibut.TestUtils.CompatBinary.v6_0_658.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <LangVersion>9.0</LangVersion>
+        <RootNamespace>Halibut.TestUtils.SampleProgram.v6_0_658</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+        <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Halibut" Version="6.0.658" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/source/Halibut.TestUtils.CompatBinary.v6_0_658/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v6_0_658/Program.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Halibut.TestUtils.SampleProgram.Base;
+
+namespace Halibut.TestUtils.SampleProgram.v6_0_658
+{
+    public class Program
+    {
+        public static async Task<int> Main()
+        {
+            return await BackwardsCompatProgramBase.Main();
+        }
+    }
+}

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\Halibut\Halibut.csproj" />
     <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_429\Halibut.TestUtils.CompatBinary.v5_0_429.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_236\Halibut.TestUtils.CompatBinary.v5_0_236.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v6_0_658\Halibut.TestUtils.CompatBinary.v6_0_658.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,9 +57,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             }
         }
 
-        public LatestClientAndPreviousServiceVersionBuilder WithServiceVersion(string? version)
+        public LatestClientAndPreviousServiceVersionBuilder WithServiceVersion(Version version)
         {
-            this.version = version;
+            this.version = version.ToString();
             return this;
         }
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -90,9 +89,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             return this;
         }
 
-        public PreviousClientVersionAndLatestServiceBuilder WithClientVersion(string version)
+        public PreviousClientVersionAndLatestServiceBuilder WithClientVersion(Version version)
         {
-            this.version = version;
+            this.version = version.ToString();
             return this;
         }
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousVersions.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousVersions.cs
@@ -1,11 +1,19 @@
-﻿namespace Halibut.Tests.Support.BackwardsCompatibility
+﻿using System;
+
+namespace Halibut.Tests.Support.BackwardsCompatibility
 {
     public static class PreviousVersions
     {
         // Version prior to new exception types being added to Halibut. All exceptions are HalibutClientException
-        public const string v5_0_429 = "5.0.429";
+        public static readonly Version v5_0_429 = new("5.0.429");
 
         // The last release with meaningful changes prior to Script Service V2
-        public const string v5_0_236_Used_In_Tentacle_6_3_417 = "5.0.236";
+        public static readonly Version v5_0_236_Used_In_Tentacle_6_3_417 = new ("5.0.236");
+
+        // The earliest release with a stable WebSocket implementation
+        public static readonly Version v6_0_658_WebSocket_Stability_Fixes = new("6.0.658");
+
+
+        public static Version StableWebSocketVersion => v6_0_658_WebSocket_Stability_Fixes;
     }
 }

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCasesBuilder.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCasesBuilder.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Util;
 
 namespace Halibut.Tests.Support.TestCases
@@ -11,20 +14,22 @@ namespace Halibut.Tests.Support.TestCases
 
         public ClientAndServiceTestCasesBuilder(
             ClientAndServiceTestVersion[] clientServiceTestVersions,
-            ServiceConnectionType[] ServiceConnectionTypes,
+            ServiceConnectionType[] serviceConnectionTypes,
             NetworkConditionTestCase[] networkConditionTestCases)
         {
             this.clientServiceTestVersions = clientServiceTestVersions;
-            serviceConnectionTypes = ServiceConnectionTypes;
+            this.serviceConnectionTypes = serviceConnectionTypes;
             this.networkConditionTestCases = networkConditionTestCases;
         }
 
         public IEnumerable<ClientAndServiceTestCase> Build()
         {
-            foreach (var clientServiceTestVersion in clientServiceTestVersions)
+            foreach (var (clientVersion, serviceVersion) in clientServiceTestVersions.Select(x => (x.ClientVersion, x.ServiceVersion)))
             {
                 foreach (var serviceConnectionType in serviceConnectionTypes)
                 {
+                    var clientServiceTestVersion = GetStableClientAndServiceVersionForServiceType(serviceConnectionType, clientVersion, serviceVersion);
+
                     foreach (var networkConditionTestCase in networkConditionTestCases)
                     {
                         // Slightly bad network conditions e.g. a delay of 20ms can blow out test times especially when running for 2000 iterations.
@@ -38,6 +43,38 @@ namespace Halibut.Tests.Support.TestCases
                         yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion);
                     }
                 }
+            }
+        }
+
+        ClientAndServiceTestVersion GetStableClientAndServiceVersionForServiceType(ServiceConnectionType serviceConnectionType, Version? clientVersion, Version? serviceVersion)
+        {
+            if (clientVersion != null)
+            {
+                return ClientAndServiceTestVersion.ClientOfVersion(clientVersion);
+            }
+
+            if (serviceVersion != null)
+            {
+                return serviceConnectionType switch
+                {
+                    ServiceConnectionType.PollingOverWebSocket => ClientAndServiceTestVersion.ServiceOfVersion(BumpToStableWebSocketVersionIfRequired(serviceVersion)!),
+                    _ => ClientAndServiceTestVersion.ServiceOfVersion(serviceVersion)
+                };
+            }
+
+            return ClientAndServiceTestVersion.Latest();
+
+            static Version? BumpToStableWebSocketVersionIfRequired(Version? version)
+            {
+                if (version != null)
+                {
+                    if (version < PreviousVersions.StableWebSocketVersion)
+                    {
+                        return PreviousVersions.StableWebSocketVersion;
+                    }
+                }
+
+                return version;
             }
         }
     }

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestVersion.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestVersion.cs
@@ -10,11 +10,12 @@ namespace Halibut.Tests.Support.TestCases
     {
         
         // null means latest.
-        public string? ClientVersion;
-        // null means latest.
-        public string? ServiceVersion;
+        public Version? ClientVersion { get; }
 
-        ClientAndServiceTestVersion(string? clientVersion, string? serviceVersion)
+        // null means latest.
+        public Version? ServiceVersion { get; }
+
+        ClientAndServiceTestVersion(Version? clientVersion, Version? serviceVersion)
         {
             ClientVersion = clientVersion;
             ServiceVersion = serviceVersion;
@@ -25,12 +26,12 @@ namespace Halibut.Tests.Support.TestCases
             return new ClientAndServiceTestVersion(null, null);
         }
 
-        public static ClientAndServiceTestVersion ClientOfVersion(string clientVersion)
+        public static ClientAndServiceTestVersion ClientOfVersion(Version clientVersion)
         {
             return new ClientAndServiceTestVersion(clientVersion, null);
         }
 
-        public static ClientAndServiceTestVersion ServiceOfVersion(string serviceVersion)
+        public static ClientAndServiceTestVersion ServiceOfVersion(Version serviceVersion)
         {
             return new ClientAndServiceTestVersion(null, serviceVersion);
         }

--- a/source/Halibut.sln
+++ b/source/Halibut.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestProxy", "Halibu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.Contracts", "Halibut.TestUtils.Contracts\Halibut.TestUtils.Contracts.csproj", "{59786272-1F8F-4553-9C1E-B73360BB0559}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v6_0_658", "Halibut.TestUtils.CompatBinary.v6_0_658\Halibut.TestUtils.CompatBinary.v6_0_658.csproj", "{F8030304-7DDA-4757-B956-5299FC904B76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -154,6 +156,18 @@ Global
 		{59786272-1F8F-4553-9C1E-B73360BB0559}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{59786272-1F8F-4553-9C1E-B73360BB0559}.Release|x86.ActiveCfg = Release|Any CPU
 		{59786272-1F8F-4553-9C1E-B73360BB0559}.Release|x86.Build.0 = Release|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Debug|x86.Build.0 = Debug|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Release|x86.ActiveCfg = Release|Any CPU
+		{F8030304-7DDA-4757-B956-5299FC904B76}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Background

PollingOverWebSocket Services before 6.0.658 are unstable and cause test failures. TestCases will not use an earlier version forPollingOverWebSocket Tests

## After

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/5d76312b-a134-4acc-9ff8-eda52d87466e)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
