### PR TITLE
Enable trace logging for flakey parallel test

### DIFF
--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests
         public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                .WithHalibutLoggingLevel(LogLevel.Info)
+                .WithHalibutLoggingLevel(LogLevel.Trace)
                 .WithStandardServices()
                 .Build(CancellationToken);
             {

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -221,7 +221,10 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             // A Halibut Runtime that is used as a client to forward requests to the previous version
             // of Halibut Runtime that will actually talk to the Service (Tentacle) below
-            var proxyClient = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
+            var proxyClient = new HalibutRuntimeBuilder()
+                .WithServerCertificate(clientCertAndThumbprint.Certificate2)
+                .WithLogFactory(new TestContextLogFactory("ProxyClient", halibutLogLevel))
+                .Build();
             proxyClient.Trust(serviceCertAndThumbprint.Thumbprint);
 
             var serviceFactory = new DelegateServiceFactory()


### PR DESCRIPTION
The `SendMessagesToTentacleInParallel` test can be [flakey on the build server](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_ChainFullChain/8968257?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandPull+Request+Details=true&expandBuildProblemsSection=true&expandBuildTestsSection=true) when testing previous client -> latest service, but we don't currently have enough info to investigate.

This PR does the following:
* Ensure that logs from the 'proxy client' instance are logged correctly
* Enables trace level logging for the flakey test.