### PR TITLE
Enable halibut logging in previous service supplied Halibut runtime

### DIFF
--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Logging;
 using Halibut.TestProxy;
+using Halibut.Tests.Support.Logging;
 using Halibut.Transport.Proxy;
 using Octopus.TestPortForwarder;
 using Serilog.Extensions.Logging;
@@ -170,7 +171,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 throw new Exception("The version of the service must be set.");
             }
 
-            var octopus = new HalibutRuntime(clientCertAndThumbprint.Certificate2);
+            var octopus = new HalibutRuntimeBuilder()
+                .WithServerCertificate(clientCertAndThumbprint.Certificate2)
+                .WithLogFactory(new TestContextLogFactory("Client", halibutLogLevel))
+                .Build();
+            
             octopus.Trust(serviceCertAndThumbprint.Thumbprint);
 
             HalibutTestBinaryRunner.RunningOldHalibutBinary? runningOldHalibutBinary = null;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -225,6 +225,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 .WithServerCertificate(clientCertAndThumbprint.Certificate2)
                 .WithLogFactory(new TestContextLogFactory("ProxyClient", halibutLogLevel))
                 .Build();
+            
             proxyClient.Trust(serviceCertAndThumbprint.Thumbprint);
 
             var serviceFactory = new DelegateServiceFactory()


### PR DESCRIPTION
# Background

So that we can get error logs in our tests.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
