### PR TITLE
Enable blame crash

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -110,7 +110,8 @@ class Build : NukeBuild
                     .SetConfiguration(Configuration)
                     .SetFramework(framework)
                     .EnableNoBuild()
-                    .EnableNoRestore());
+                    .EnableNoRestore()
+                    .EnableBlameCrash());
 
             });
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -111,7 +111,8 @@ class Build : NukeBuild
                     .SetFramework(framework)
                     .EnableNoBuild()
                     .EnableNoRestore()
-                    .EnableBlameCrash());
+                    .EnableBlameCrash()
+                    .SetBlameCrashDumpType("full"));
 
             });
     }


### PR DESCRIPTION
# Background

Enables blame crash, as recommended by builds team.

Hang dumps are not enabled, since I wasn't sure if the timeout applied to an individual test or the entire test run.

[SC-53909]


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
