### PR TITLE
Halibut Memory Optimisations

### DIFF
--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -20,21 +20,21 @@ namespace Halibut
     public class HalibutRuntime : IHalibutRuntime
     {
         public static readonly string DefaultFriendlyHtmlPageContent = "<html><body><p>Hello!</p></body></html>";
-        readonly ConcurrentDictionary<Uri, IPendingRequestQueue> queues = new ConcurrentDictionary<Uri, IPendingRequestQueue>();
+        readonly ConcurrentDictionary<Uri, IPendingRequestQueue> queues = new();
         readonly IPendingRequestQueueFactory queueFactory;
         readonly X509Certificate2 serverCertificate;
-        readonly List<IDisposable> listeners = new List<IDisposable>();
+        readonly List<IDisposable> listeners = new();
         readonly ITrustProvider trustProvider;
-        readonly ConcurrentDictionary<Uri, ServiceEndPoint> routeTable = new ConcurrentDictionary<Uri, ServiceEndPoint>();
+        readonly ConcurrentDictionary<Uri, ServiceEndPoint> routeTable = new();
         readonly IServiceInvoker invoker;
         readonly ILogFactory logs;
-        readonly ConnectionManager connectionManager = new ConnectionManager();
-        readonly PollingClientCollection pollingClients = new PollingClientCollection();
+        readonly ConnectionManager connectionManager = new();
+        readonly PollingClientCollection pollingClients = new();
         string friendlyHtmlPageContent = DefaultFriendlyHtmlPageContent;
-        Dictionary<string, string> friendlyHtmlPageHeaders = new Dictionary<string, string>();
+        Dictionary<string, string> friendlyHtmlPageHeaders = new();
         readonly IMessageSerializer messageSerializer;
         readonly ITypeRegistry typeRegistry;
-        readonly ResponseCache responseCache = new();
+        readonly Lazy<ResponseCache> responseCache = new();
         Func<RetryPolicy> PollingReconnectRetryPolicy;
 
         [Obsolete]
@@ -239,7 +239,7 @@ namespace Halibut
         {
             var endPoint = request.Destination;
 
-            var cachedResponse = responseCache.GetCachedResponse(endPoint, request, methodInfo);
+            var cachedResponse = responseCache.Value.GetCachedResponse(endPoint, request, methodInfo);
 
             if (cachedResponse != null)
             {
@@ -259,7 +259,7 @@ namespace Halibut
                 default: throw new ArgumentException("Unknown endpoint type: " + endPoint.BaseUri.Scheme);
             }
 
-            responseCache.CacheResponse(endPoint, request, methodInfo, response, OverrideErrorResponseMessageCaching);
+            responseCache.Value.CacheResponse(endPoint, request, methodInfo, response, OverrideErrorResponseMessageCaching);
 
             return response;
         }

--- a/source/Halibut/Transport/Protocol/ControlMessageReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessageReader.cs
@@ -59,7 +59,7 @@ namespace Halibut.Transport.Protocol
 
         internal async Task<string> ReadControlMessageAsync(Stream stream)
         {
-            var cts = GetCancellationTokenSourceFromStreamReadTimeout(stream);
+            using var cts = GetCancellationTokenSourceFromStreamReadTimeout(stream);
             StringBuilder sb = new StringBuilder();
             while (true)
             {

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -226,6 +226,7 @@ namespace Halibut.Transport
         public void Dispose()
         {
             cts.Cancel();
+            cts.Dispose();
             log.Write(EventType.ListenerStopped, "Listener stopped");
         }
     }


### PR DESCRIPTION
# Background

Change the MemoryCache in the HalibutRuntime to only be created when needed. While the impact on Tentacleof creating this is minimal, it creates memory noise when running hundreds of HalibutRuntimes in the same Process.

CancellationTokenSource memory leak. Fix some issues where cancellation token sources were not being disposed of.

## Before

This is potentially contrived results as it is running 1 Halibut Client and 100 Halibut Services in the same process but there is an obvious CancellationTokenSource disposal issue.

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/977ba6c6-7166-4148-898a-d2f040c71b2e)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/4b8912bd-5590-4174-b749-64f0ffe72bcb)


## After

Gone

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/52372ce9-9442-4768-8b2c-5af7e3c4eab5)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/de24b238-f8f4-4770-a311-173391812950)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
