### PR TITLE
Add basic support of testing async and sync clients in one test.

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -169,10 +169,12 @@ namespace Halibut.Tests.Diagnostics
             public async Task BecauseOfAInvalidCertificateException_WhenConnectingToListening_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                           .WithStandardServices()
+                           .AsLatestClientAndLatestServiceBuilder()
+                           .WithClientTrustingTheWrongCertificate()
+                           .WithEchoService()
                            .Build(CancellationToken))
                 {
-                    var echo = clientAndService.CreateClient<IEchoService>(remoteThumbprint: "Wrong Thumbrprint");
+                    var echo = clientAndService.CreateClient<IEchoService>();
 
                     Assert.Throws<HalibutClientException>(() => echo.SayHello("Hello"))
                         .IsNetworkError()

--- a/source/Halibut.Tests/Support/ForceClientProxyType.cs
+++ b/source/Halibut.Tests/Support/ForceClientProxyType.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Halibut.Tests.Support
+{
+    public enum ForceClientProxyType
+    {
+        SyncClient,
+        AsyncClient
+    }
+
+    public static class ForceClientProxyTypeValues
+    {
+        public static ForceClientProxyType[] All = {ForceClientProxyType.SyncClient, ForceClientProxyType.AsyncClient};
+    }
+}

--- a/source/Halibut.Tests/Support/IClientAndService.cs
+++ b/source/Halibut.Tests/Support/IClientAndService.cs
@@ -11,9 +11,9 @@ namespace Halibut.Tests.Support
         HalibutRuntime Client { get; }
         PortForwarder? PortForwarder { get; }
         HttpProxyService? HttpProxy { get; }
-        TService CreateClient<TService>(CancellationToken? cancellationToken = null, string? remoteThumbprint = null);
+        TService CreateClient<TService>(CancellationToken? cancellationToken = null);
         TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint);
-        TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken, string? remoteThumbprint = null);
+        TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken);
         TClientAndService CreateClient<TService, TClientAndService>();
         TClientAndService CreateClient<TService, TClientAndService>(Action<ServiceEndPoint> modifyServiceEndpoint);
     }

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -16,5 +16,6 @@ namespace Halibut.Tests.Support
         IClientAndServiceBuilder WithHalibutLoggingLevel(LogLevel info);
         IClientAndServiceBuilder WithCachingService();
         IClientAndServiceBuilder NoService();
+        IClientAndServiceBuilder WithForcingClientProxyType(ForceClientProxyType forceClientProxyType);
     }
 }

--- a/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
@@ -14,17 +14,19 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testWebSocket = true,
             bool testNetworkConditions = true,
             bool testListening = true,
-            bool testPolling = true) :
+            bool testPolling = true,
+            bool testAsyncAndSyncClients = false // False while this area of the test infra is being built out.
+            ) :
             base(
                 typeof(LatestAndPreviousClientAndServiceVersionsTestCases),
                 nameof(LatestAndPreviousClientAndServiceVersionsTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients})
         {
         }
         
         static class LatestAndPreviousClientAndServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -42,6 +44,12 @@ namespace Halibut.Tests.Support.TestAttributes
                 {
                     serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
+
+                ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];
+                if (testAsyncAndSyncClients)
+                {
+                    clientProxyTypesToTest = ForceClientProxyTypeValues.All;
+                }
                 
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] {
@@ -50,8 +58,9 @@ namespace Halibut.Tests.Support.TestAttributes
                         ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ServiceVersion),
                     },
                     serviceConnectionTypes.ToArray(),
-                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect }
-                );
+                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
+                    clientProxyTypesToTest
+                    );
 
                 return builder.Build().GetEnumerator();
             }

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using Halibut.Tests.Support.TestCases;
 using NUnit.Framework;
@@ -19,18 +18,19 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testNetworkConditions = true,
             bool testListening = true,
             bool testPolling = true,
+            bool testAsyncAndSyncClients = false, // False while this area of the test infra is being built out.
             params object[] additionalParameters
             ) :
             base(
                 typeof(LatestClientAndLatestServiceTestCases),
                 nameof(LatestClientAndLatestServiceTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, additionalParameters })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, additionalParameters })
         {
         }
 
         static class LatestClientAndLatestServiceTestCases
         {
-            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, object[] additionalParameters)
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, object[] additionalParameters)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -48,11 +48,18 @@ namespace Halibut.Tests.Support.TestAttributes
                 {
                     serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
+                
+                ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];
+                if (testAsyncAndSyncClients)
+                {
+                    clientProxyTypesToTest = ForceClientProxyTypeValues.All;
+                }
 
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] { ClientAndServiceTestVersion.Latest() },
                     serviceConnectionTypes.ToArray(),
-                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect }
+                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
+                    clientProxyTypesToTest
                 );
                 
                 foreach (var clientAndServiceTestCase in builder.Build())

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
@@ -10,17 +10,21 @@ namespace Halibut.Tests.Support.TestAttributes
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class LatestClientAndPreviousServiceVersionsTestCasesAttribute : TestCaseSourceAttribute
     {
-        public LatestClientAndPreviousServiceVersionsTestCasesAttribute(bool testWebSocket = true, bool testNetworkConditions = true, bool testListening = true) :
+        public LatestClientAndPreviousServiceVersionsTestCasesAttribute(bool testWebSocket = true, 
+            bool testNetworkConditions = true,
+            bool testListening = true,
+            bool testAsyncAndSyncClients = false // False while this area of the test infra is being built out.
+            ) :
             base(
                 typeof(LatestClientAndPreviousServiceVersionsTestCases),
                 nameof(LatestClientAndPreviousServiceVersionsTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testAsyncAndSyncClients })
         {
         }
         
         static class LatestClientAndPreviousServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testAsyncAndSyncClients)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -33,13 +37,20 @@ namespace Halibut.Tests.Support.TestAttributes
                 {
                     serviceConnectionTypes.Remove(ServiceConnectionType.Listening);
                 }
+                
+                ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];
+                if (testAsyncAndSyncClients)
+                {
+                    clientProxyTypesToTest = ForceClientProxyTypeValues.All;
+                }
 
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] {
                         ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ServiceVersion),
                     },
                     serviceConnectionTypes.ToArray(),
-                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect }
+                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
+                    clientProxyTypesToTest
                 );
 
                 return builder.Build().GetEnumerator();

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCase.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCase.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestCases
 {
@@ -17,12 +20,15 @@ namespace Halibut.Tests.Support.TestCases
         /// </summary>
         public int RecommendedIterations { get; }
 
-        public ClientAndServiceTestCase(ServiceConnectionType serviceConnectionType, NetworkConditionTestCase networkConditionTestCase, int recommendedIterations, ClientAndServiceTestVersion clientAndServiceTestVersion)
+        public ForceClientProxyType? ForceClientProxyType { get; }
+
+        public ClientAndServiceTestCase(ServiceConnectionType serviceConnectionType, NetworkConditionTestCase networkConditionTestCase, int recommendedIterations, ClientAndServiceTestVersion clientAndServiceTestVersion, ForceClientProxyType? forceClientProxyType)
         {
             ServiceConnectionType = serviceConnectionType;
             NetworkConditionTestCase = networkConditionTestCase;
             RecommendedIterations = recommendedIterations;
             ClientAndServiceTestVersion = clientAndServiceTestVersion;
+            ForceClientProxyType = forceClientProxyType;
         }
 
         public IClientAndServiceBuilder CreateTestCaseBuilder()
@@ -35,13 +41,28 @@ namespace Halibut.Tests.Support.TestCases
                 builder.WithPortForwarding(i => NetworkConditionTestCase.PortForwarderFactory(i, logger));
             }
 
+            if (ForceClientProxyType != null)
+            {
+                builder.WithForcingClientProxyType(ForceClientProxyType.Value);
+            }
+
             return builder;
         }
         
         public override string ToString()
         {
             // This is used as the test parameter name, so make this something someone can understand in teamcity or their IDE.
-            return $"{ServiceConnectionType}, {ClientAndServiceTestVersion.ToString(ServiceConnectionType)}, {NetworkConditionTestCase}, RecommendedIterations: {RecommendedIterations}";
+            var testParameter = new List<string>();
+            testParameter.Add(ServiceConnectionType.ToString());
+            testParameter.Add(ClientAndServiceTestVersion.ToString(ServiceConnectionType));
+            testParameter.Add(NetworkConditionTestCase.ToString());
+            testParameter.Add($"RecommendedIters: {RecommendedIterations}");
+            if (ForceClientProxyType != null)
+            {
+                testParameter.Add(ForceClientProxyType.ToString());
+            }
+            
+            return string.Join(", ", testParameter);
         }
     }
 }

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCasesBuilder.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCasesBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Halibut.Tests.Util;
 
 namespace Halibut.Tests.Support.TestCases
@@ -8,15 +9,18 @@ namespace Halibut.Tests.Support.TestCases
         readonly ClientAndServiceTestVersion[] clientServiceTestVersions;
         readonly ServiceConnectionType[] serviceConnectionTypes;
         readonly NetworkConditionTestCase[] networkConditionTestCases;
+        readonly ForceClientProxyType[] forceClientProxyTypes;
 
         public ClientAndServiceTestCasesBuilder(
             ClientAndServiceTestVersion[] clientServiceTestVersions,
             ServiceConnectionType[] ServiceConnectionTypes,
-            NetworkConditionTestCase[] networkConditionTestCases)
+            NetworkConditionTestCase[] networkConditionTestCases,
+            ForceClientProxyType[] forceClientProxyTypes)
         {
             this.clientServiceTestVersions = clientServiceTestVersions;
             serviceConnectionTypes = ServiceConnectionTypes;
             this.networkConditionTestCases = networkConditionTestCases;
+            this.forceClientProxyTypes = forceClientProxyTypes;
         }
 
         public IEnumerable<ClientAndServiceTestCase> Build()
@@ -35,7 +39,24 @@ namespace Halibut.Tests.Support.TestCases
                             recommendedIterations = StandardIterationCount.ForServiceType(serviceConnectionType, clientServiceTestVersion);
                         }
 
-                        yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion);
+                        if (!forceClientProxyTypes.Any())
+                        {
+                            yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, null);
+                        }
+                        else
+                        {
+                            if (clientServiceTestVersion.IsPreviousClient())
+                            {
+                                yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, null);
+                            }
+                            else
+                            {
+                                foreach (var forceClientProxyType in forceClientProxyTypes)
+                                {
+                                    yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, forceClientProxyType);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientEchoService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientEchoService.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientEchoService
+    {
+        Task<int> LongRunningOperationAsync();
+
+        Task<string> SayHelloAsync(string name);
+
+        Task<bool> CrashAsync();
+
+        Task<int> CountBytesAsync(DataStream stream);
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientMultipleParametersTestService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientMultipleParametersTestService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.TestUtils.Contracts;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientMultipleParametersTestService
+    {
+        Task MethodReturningVoidAsync(long a, long b);
+        Task<long> AddAsync(long a, long b);
+        Task<double> AddAsync(double a, double b);
+        Task<decimal> AddAsync(decimal a, decimal b);
+        Task<string> HelloAsync();
+        Task<string> HelloAsync(string a);
+        Task<string> HelloAsync(string a, string b);
+        Task<string> HelloAsync(string a, string b, string c);
+        Task<string> HelloAsync(string a, string b, string c, string d);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e, string f);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, string i);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j);
+        Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k);
+        Task<string> AmbiguousAsync(string a, string b);
+        Task<string> AmbiguousAsync(string a, Tuple<string, string> b);
+        Task<MapLocation> GetLocationAsync(MapLocation loc);
+        
+    }
+}

--- a/source/Halibut.Tests/TestServices/AsyncSyncCompat/AdaptSyncProxyToAsyncProxy.cs
+++ b/source/Halibut.Tests/TestServices/AsyncSyncCompat/AdaptSyncProxyToAsyncProxy.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.AsyncSyncCompat
+{
+    /// <summary>
+    ///     Given a Sync Proxy e.g. halibutRunTime.CrateClient
+    ///     <INotAsyncAtAllService>
+    ///         ();
+    ///         And converts it to a async version of that service.
+    /// </summary>
+    public class AdaptSyncProxyToAsyncProxy : DispatchProxyAsync
+    {
+        object syncHalibutProxy;
+        Type syncHalubutProxyType;
+
+        public void Configure(object syncHalibutProxy, Type syncHalubutProxyType)
+        {
+            this.syncHalibutProxy = syncHalibutProxy;
+            this.syncHalubutProxyType = syncHalubutProxyType;
+        }
+
+        public override object Invoke(MethodInfo methodInfo, object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        MethodInfo? GetSyncMethod(MethodInfo asyncMethodInfo)
+        {
+            return AsyncCompatibilityHelper.FindMatchingSyncMethod(asyncMethodInfo, syncHalubutProxyType);
+        }
+
+        public override async Task InvokeAsync(MethodInfo asyncMethodInfo, object[] args)
+        {
+            await Task.CompletedTask;
+            var syncMethod = GetSyncMethod(asyncMethodInfo);
+            try
+            {
+                syncMethod.Invoke(syncHalibutProxy, args);
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException!;
+            }
+        }
+
+        public override Task<T> InvokeAsyncT<T>(MethodInfo asyncMethodInfo, object[] args)
+        {
+            var syncMethod = GetSyncMethod(asyncMethodInfo);
+
+            try
+            {
+                var result = (T) syncMethod.Invoke(syncHalibutProxy, args);
+                return Task.FromResult(result);
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException!;
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/TestServices/AsyncSyncCompat/AdaptToSyncOrAsyncTestCase.cs
+++ b/source/Halibut.Tests/TestServices/AsyncSyncCompat/AdaptToSyncOrAsyncTestCase.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using Halibut.Tests.Support;
+
+namespace Halibut.Tests.TestServices.AsyncSyncCompat
+{
+    public class AdaptToSyncOrAsyncTestCase
+    {
+        /// <summary>
+        /// Doesn't actually adapt anything, just helps make sure we are testing what we expect to test.
+        /// </summary>
+        /// <param name="forceClientProxyType"></param>
+        /// <param name="halibutRuntime"></param>
+        /// <param name="serviceEndpoint"></param>
+        /// <typeparam name="TService"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public TService Adapt<TService>(ForceClientProxyType? forceClientProxyType, HalibutRuntime halibutRuntime, ServiceEndPoint serviceEndpoint, CancellationToken cancellationToken)
+        {
+            if (forceClientProxyType == null)
+            {
+                return halibutRuntime.CreateClient<TService>(serviceEndpoint, cancellationToken);
+            }
+            throw new Exception("Can't force sync or async with single generic type CreateClient, use CreateClient<TService, TClientService>");
+        }
+        
+        public TClientService Adapt<TService, TClientService>(ForceClientProxyType? forceClientProxyType, HalibutRuntime halibutRuntime, ServiceEndPoint serviceEndpoint)
+        {
+            if (forceClientProxyType == null)
+            {
+                return halibutRuntime.CreateClient<TService, TClientService>(serviceEndpoint);
+            }
+
+            if (forceClientProxyType == ForceClientProxyType.AsyncClient)
+            {
+                new ServiceInterfaceInspector().EnsureAllMethodsAreAsync<TClientService>();
+                return halibutRuntime.CreateAsyncClient<TService, TClientService>(serviceEndpoint);
+            }
+
+            if (forceClientProxyType == ForceClientProxyType.SyncClient)
+            {
+                new ServiceInterfaceInspector().EnsureAllMethodsAreAsync<TClientService>();
+
+                return CreateSyncHalibutProxyAndAdaptItToAnAsyncInterface<TService, TClientService>(halibutRuntime, serviceEndpoint);
+            }
+
+            throw new Exception("It is unclear how this was reached.");
+        }
+
+        
+        
+        static TAsyncClientService CreateSyncHalibutProxyAndAdaptItToAnAsyncInterface<TServiceWhichMustBeSync, TAsyncClientService>(HalibutRuntime halibutRuntime, ServiceEndPoint serviceEndpoint)
+        {
+            var syncVersionType = typeof(TServiceWhichMustBeSync);
+            
+            var syncVersion = halibutRuntime.CreateClient<TServiceWhichMustBeSync>(serviceEndpoint);
+
+            var syncToAsyncAdaptor = DispatchProxyAsync.Create<TAsyncClientService, AdaptSyncProxyToAsyncProxy>();
+            (syncToAsyncAdaptor as AdaptSyncProxyToAsyncProxy).Configure(syncVersion, syncVersionType);
+
+            return syncToAsyncAdaptor;
+        }
+    }
+}

--- a/source/Halibut.Tests/TestServices/AsyncSyncCompat/ServiceInterfaceInspector.cs
+++ b/source/Halibut.Tests/TestServices/AsyncSyncCompat/ServiceInterfaceInspector.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.AsyncSyncCompat
+{
+    public class ServiceInterfaceInspector
+    {
+        public void EnsureAllMethodsAreAsync<T>()
+        {
+            foreach (var methodInfo in typeof(T).GetMethods())
+            {
+                if (!IsMethodAsync(methodInfo))
+                {
+                    throw new Exception($"Not all methods on {typeof(T)} are async, e.g. {methodInfo}");
+                }
+            }
+        }
+
+        static bool IsMethodAsync(MethodInfo methodInfo)
+        {
+            return typeof(Task).IsAssignableFrom(methodInfo.ReturnType);
+        }
+
+        public void EnsureServiceTypeAndClientServiceTypeHaveMatchingMethods<TService, TClientService>()
+        {
+            var serviceType = typeof(TService); 
+            foreach (var methodInfo in typeof(TClientService).GetMethods())
+            {
+                string nameToSearchFor = methodInfo.Name;
+                if (IsMethodAsync(methodInfo))
+                {
+                    nameToSearchFor = nameToSearchFor.Substring(0, nameToSearchFor.Length - "Async".Length);
+                }
+                
+                var res = serviceType.GetMethod(nameToSearchFor, methodInfo.GetParameters().Select(p => p.ParameterType).ToArray());
+                if (res != null)
+                {
+                    // TODO check return type matches, for now it will fail when the call returns.
+                    continue;
+                }
+                throw new Exception($"Could not method matching {methodInfo} on {typeof(TService)}");
+            }   
+        }
+    }
+}

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -5,6 +5,7 @@ using Halibut.Exceptions;
 using Halibut.Logging;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
@@ -20,10 +21,10 @@ namespace Halibut.Tests
                        .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
-                var echo = clientAndService.CreateClient<IEchoService>();
-                Func<string> readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                Func<Task<string>> readAsyncCall = async () => await echo.SayHelloAsync("Say hello to a service that does not exist.");
 
-                readAsyncCall.Should().Throw<ServiceNotFoundHalibutClientException>();
+                await readAsyncCall.Should().ThrowAsync<ServiceNotFoundHalibutClientException>();
             }
         }
     }

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -14,7 +14,7 @@ namespace Halibut.Tests
     public class WhenCallingAServiceThatDoesNotExist : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncAndSyncClients: true)]
         public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
+    <PackageReference Include="NetCoreStack.DispatchProxyAsync" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -227,6 +227,16 @@ namespace Halibut
             return proxy;
 #endif
         }
+        
+        public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint endpoint)
+        {
+            typeRegistry.AddToMessageContract(typeof(TService));
+            var logger = logs.ForEndpoint(endpoint.BaseUri);
+
+            var proxy = DispatchProxyAsync.Create<TAsyncClientService, HalibutProxyWithAsync>();
+            (proxy as HalibutProxyWithAsync).Configure(SendOutgoingRequestAsync, typeof(TService), endpoint, logger, CancellationToken.None);
+            return proxy;
+        }
 
         // https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#warning-sync-over-async
         [Obsolete("Consider implementing an async HalibutProxy instead")]
@@ -236,6 +246,36 @@ namespace Halibut
         }
         
         async Task<ResponseMessage> SendOutgoingRequestSynchronouslyAsync(RequestMessage request, MethodInfo methodInfo, CancellationToken cancellationToken)
+        {
+            var endPoint = request.Destination;
+
+            var cachedResponse = responseCache.Value.GetCachedResponse(endPoint, request, methodInfo);
+
+            if (cachedResponse != null)
+            {
+                return cachedResponse;
+            }
+
+            ResponseMessage response;
+
+            switch (endPoint.BaseUri.Scheme.ToLowerInvariant())
+            {
+                case "https":
+                    response = SendOutgoingHttpsRequest(request, cancellationToken);
+                    break;
+                case "poll":
+                    response = await SendOutgoingPollingRequest(request, cancellationToken);
+                    break;
+                default: throw new ArgumentException("Unknown endpoint type: " + endPoint.BaseUri.Scheme);
+            }
+
+            responseCache.Value.CacheResponse(endPoint, request, methodInfo, response, OverrideErrorResponseMessageCaching);
+
+            return response;
+        }
+        
+        // Eventually this will actually be async
+        async Task<ResponseMessage> SendOutgoingRequestAsync(RequestMessage request, MethodInfo methodInfo, CancellationToken cancellationToken)
         {
             var endPoint = request.Destination;
 

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -46,6 +46,22 @@ namespace Halibut
         /// </typeparam>
         /// <returns></returns>
         public TClientService CreateClient<TService, TClientService>(ServiceEndPoint endpoint);
+
+        /// <summary>
+        /// Creates a Halibut client mapping the methods from TClientService to TService, with support for async methods
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <typeparam name="TService">The interface the remote service implements.</typeparam>
+        /// <typeparam name="TAsyncClientService">The type that will be returned. Must have the same methods as TService except
+        /// that each method may have an additional argument at the end of HalibutProxyRequestOptions. When requests are made
+        /// to the service the HalibutProxyRequestOptions is dropped and the request is sent as though it was called on the
+        /// equivalent method of TService.
+        ///
+        /// For example if TService is interface IFoo { void Bar(string); }
+        /// TClientService would be: IClientFoo { void Bar(string, HalibutProxyRequestOptions); }
+        /// </typeparam>
+        /// <returns></returns>
+        public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint endpoint);
         void Trust(string clientThumbprint);
         void RemoveTrust(string clientThumbprint);
         void TrustOnly(IReadOnlyList<string> thumbprints);

--- a/source/Halibut/ServiceModel/AsyncCompatibilityHelper.cs
+++ b/source/Halibut/ServiceModel/AsyncCompatibilityHelper.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Halibut.ServiceModel
+{
+    public class AsyncCompatibilityHelper
+    {
+        public static MethodInfo? TryFindMatchingSyncMethod(MethodInfo asyncMethodInfo, Type syncServiceInterfaceType)
+        {
+            if (!asyncMethodInfo.Name.EndsWith("Async"))
+            {
+                throw new Exception($"Async methods must end in 'Async': " + asyncMethodInfo);
+            }
+                
+            var syncMethodName = SyncMethodName(asyncMethodInfo);
+            return syncServiceInterfaceType.GetMethod(syncMethodName, asyncMethodInfo.GetParameters().Select(p => p.ParameterType).ToArray());
+        }
+
+        static string SyncMethodName(MethodInfo asyncMethodInfo)
+        {
+            return asyncMethodInfo.Name.Substring(0, asyncMethodInfo.Name.Length - "Async".Length);
+        }
+
+        public static MethodInfo FindMatchingSyncMethod(MethodInfo asyncMethodInfo, Type syncServiceInterfaceType)
+        {
+            var syncMethodInfo = TryFindMatchingSyncMethod(asyncMethodInfo, syncServiceInterfaceType);
+            if (syncMethodInfo == null)
+            {
+                throw new Exception( $"Could not find an async counterpart for: '{asyncMethodInfo}' we looked for {SyncMethodName(asyncMethodInfo)} but could " +
+                                     $"not find a match in {syncServiceInterfaceType.FullName}");
+            }
+
+            return syncMethodInfo;
+        }
+    }
+}

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Diagnostics;
+using Halibut.Exceptions;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.ServiceModel
+{
+    public class HalibutProxyWithAsync : DispatchProxyAsync
+    {
+        Func<RequestMessage, MethodInfo, CancellationToken, Task<ResponseMessage>> messageRouter;
+        Type contractType;
+        ServiceEndPoint endPoint;
+        long callId;
+        bool configured;
+        CancellationToken globalCancellationToken;
+        ILog logger;
+
+        public void Configure(Func<RequestMessage, MethodInfo, CancellationToken, Task<ResponseMessage>> messageRouter, Type contractType, ServiceEndPoint endPoint, ILog logger, CancellationToken cancellationToken)
+        {
+            this.messageRouter = messageRouter;
+            this.contractType = contractType;
+            this.endPoint = endPoint;
+            this.globalCancellationToken = cancellationToken;
+            this.configured = true;
+            this.logger = logger;
+        }
+
+        public override object Invoke(MethodInfo targetMethod, object[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override async Task InvokeAsync(MethodInfo asyncMethod, object[] args)
+        {
+            var (serviceMethod, result) = await MakeRpcCall(asyncMethod, args);
+        }
+
+        public override async Task<T> InvokeAsyncT<T>(MethodInfo asyncMethod, object[] args)
+        {
+            var (serviceMethod, result) = await MakeRpcCall(asyncMethod, args);
+
+            var returnType = serviceMethod.ReturnType;
+            if (result != null && returnType != typeof(void) && !returnType.IsInstanceOfType(result))
+            {
+                result = (T) Convert.ChangeType(result, returnType);
+            }
+
+            return (T) result;
+        }
+
+        async Task<(MethodInfo, object)> MakeRpcCall(MethodInfo asyncMethod, object[] args)
+        {
+            var serviceMethod = AsyncCompatibilityHelper.FindMatchingSyncMethod(asyncMethod, contractType);
+
+            if (!configured)
+                throw new Exception("Proxy not configured");
+
+            var trimmedArgsAndHalibutProxyRequestOptions = TrimOffHalibutProxyRequestOptions(args);
+            args = trimmedArgsAndHalibutProxyRequestOptions.args;
+            var halibutProxyRequestOptions = trimmedArgsAndHalibutProxyRequestOptions.halibutProxyRequestOptions;
+
+            var request = CreateRequest(serviceMethod, args);
+
+            var response = await messageRouter(request, serviceMethod, ConnectingCancellationToken(halibutProxyRequestOptions));
+
+            EnsureNotError(response);
+            
+            return (serviceMethod, response.Result);
+        }
+
+        RequestMessage CreateRequest(MethodInfo targetMethod, object[] args)
+        {
+            var activityId = Guid.NewGuid();
+
+            var request = new RequestMessage
+            {
+                Id = contractType.Name + "::" + targetMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
+                ActivityId = activityId,
+                Destination = endPoint,
+                MethodName = targetMethod.Name,
+                ServiceName = contractType.Name,
+                Params = args
+            };
+            return request;
+        }
+
+        CancellationToken ConnectingCancellationToken(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            if (halibutProxyRequestOptions == null || halibutProxyRequestOptions.ConnectCancellationToken == null)
+            {
+                return globalCancellationToken;
+            }
+
+            return (CancellationToken) halibutProxyRequestOptions.ConnectCancellationToken;
+        }
+
+        void EnsureNotError(ResponseMessage responseMessage)
+        {
+            if (responseMessage == null)
+                throw new HalibutClientException("No response was received from the endpoint within the allowed time.");
+
+            if (responseMessage.Error == null)
+                return;
+
+            ThrowExceptionFromReceivedError(responseMessage.Error, logger);
+        }
+
+        internal static void ThrowExceptionFromReceivedError(ServerError error, ILog logger)
+        {
+            var realException = error.Details as string;
+
+            try
+            {
+                if (!string.IsNullOrEmpty(error.HalibutErrorType))
+                {
+                    var theType = Type.GetType(error.HalibutErrorType);
+                    if (theType != null && theType != typeof(HalibutClientException))
+                    {
+                        var ctor = theType.GetConstructor(new[] { typeof(string), typeof(string) });
+                        Exception e = (Exception)ctor.Invoke(new object[] { error.Message, realException });
+                        throw e;
+                    }
+                }
+
+                if (error.Message.StartsWith("Service not found: "))
+                {
+                    throw new ServiceNotFoundHalibutClientException(error.Message, realException);
+                }
+
+                if (error.Message.StartsWith("Service ") && error.Message.EndsWith(" not found"))
+                {
+                    throw new MethodNotFoundHalibutClientException(error.Message, realException);
+                }
+
+                if (error.Details.StartsWith("System.Reflection.AmbiguousMatchException: "))
+                {
+                    throw new AmbiguousMethodMatchHalibutClientException(error.Message, realException);
+                }
+
+                if (error.Details.StartsWith("System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation."))
+                {
+                    throw new ServiceInvocationHalibutClientException(error.Message, realException);
+                }
+
+            }
+            catch (Exception exception) when (!(exception is HalibutClientException))
+            {
+                // Something went wrong trying to understand the ServerError revert back to the old behaviour of just
+                // throwing a standard halibut client exception.
+                logger.Write(EventType.Error, "Error {0} when processing ServerError", exception);
+            }
+
+            throw new HalibutClientException(error.Message, realException);
+
+        }
+
+        internal static (object[] args, HalibutProxyRequestOptions halibutProxyRequestOptions) TrimOffHalibutProxyRequestOptions(object[] args)
+        {
+            if (args.Length == 0) return (args, null);
+            object last = args.Last();
+            if (last is not HalibutProxyRequestOptions) return (args, null);
+
+            args = args.Take(args.Length - 1).ToArray();
+
+            return (args, (HalibutProxyRequestOptions) last);
+        }
+    }
+}

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -63,7 +63,7 @@ namespace Halibut.ServiceModel
             args = trimmedArgsAndHalibutProxyRequestOptions.args;
             var halibutProxyRequestOptions = trimmedArgsAndHalibutProxyRequestOptions.halibutProxyRequestOptions;
 
-            var request = CreateRequest(serviceMethod, args);
+            var request = CreateRequest(asyncMethod, serviceMethod, args);
 
             var response = await messageRouter(request, serviceMethod, ConnectingCancellationToken(halibutProxyRequestOptions));
 
@@ -72,13 +72,20 @@ namespace Halibut.ServiceModel
             return (serviceMethod, response.Result);
         }
 
-        RequestMessage CreateRequest(MethodInfo targetMethod, object[] args)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="asyncMethod">The async client method called, used in the call id.</param>
+        /// <param name="targetMethod">The method to actually invoke</param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        RequestMessage CreateRequest(MethodInfo asyncMethod, MethodInfo targetMethod, object[] args)
         {
             var activityId = Guid.NewGuid();
 
             var request = new RequestMessage
             {
-                Id = contractType.Name + "::" + targetMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
+                Id = contractType.Name + "::" + asyncMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
                 ActivityId = activityId,
                 Destination = endPoint,
                 MethodName = targetMethod.Name,


### PR DESCRIPTION
# Background

Adds support for testing both async and sync Halibut clients in a single test as well as adds a first cut support for async clients (although sync calls are made under the hood).

Tests that wish to test both paths must:
 - Make use of `clientAndService.CreateClient<ISomeService, IAsyncClientSomeService>()`.
 - use the async methods on `IAsyncClientSomeService` and await them.
 - For now, must opt in with `testAsyncAndSyncClients: true` in the attribute.
 
The `LatestAndPreviousClientAndServiceVersionsTestCases` and `LatestClientAndLatestServiceTestCases` will force sync and async clients when `testAsyncAndSyncClients: true` is set. Under the hood the relevant builder will ask the `HalibutRuntime` to create either a sync or async proxy depending on the test case. When a `sync` proxy is created the `AdaptSyncProxyToAsyncProxy` is used to wrap that `sync` proxy into a `async` proxy. In this way, a single test can just make async calls on async client side services, and the test can map that to a `sync` proxy returned by the `HalibutProxy`.


## Async proxy support added.

This PR adds async proxy support by creating a new `CreateAsyncClient` call, which uses the new `HalibutProxyWithAsync` class. In this way the new async code is complete separate from the existing sync code.

Async methods on Interfaces require their async methods to end in `Async` e.g. `SayHello()` on `IEchoService` must be `SayHelloAsync` on `IAsyncClientEchoService`. The `HalibutProxyWithAsync` will trim off the `Async` part and convert the return type to its non async versions e.g. `Task<string>` becomes `string` before sending over the wire. This means the calls are backwards compatible since we never send anything that suggests the client is async to the service.

The new `CreateClientV2<TService, TClientService>` method call must be used to create async clients. The `TClientService` may contain the `async` methods while `TService` must be the interface the `Service` actually implements. A call to this method might be:
```
CreateAsyncClient<IEchoService, IAsyncClientEchoService>
```
Where `IEchoService` is the sync version of the interface which the service implements and `IAsyncClientEchoService` is a async version of the interface where each method is changed to return a `Task` or `Task<T>` and ends in `Async`.


Note that the `HalibutProxyWithAsync` calls into the existing code which quickly becomes sync. TODO in future PRs is to make that all async.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
