### PR TITLE
Remove unused IPendingRequestQueue.Dequeue method

### DIFF
--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -113,7 +113,6 @@ namespace Halibut.Tests
 
                 public bool IsEmpty => inner.IsEmpty;
                 public void ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => inner.ApplyResponse(response, destination);
-                public RequestMessage Dequeue() => inner.Dequeue();
                 public async Task<RequestMessage> DequeueAsync() => await inner.DequeueAsync();
 
                 public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
@@ -165,14 +164,7 @@ namespace Halibut.Tests
 
                 public bool IsEmpty => inner.IsEmpty;
                 public void ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => inner.ApplyResponse(response, destination);
-
-                public RequestMessage Dequeue()
-                {
-                    var response = inner.Dequeue();
-                    cancellationTokenSource.Cancel();
-                    return response;
-                }
-
+                
                 public async Task<RequestMessage> DequeueAsync()
                 {
                     var response = await inner.DequeueAsync();

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -9,7 +9,6 @@ namespace Halibut.ServiceModel
     {
         bool IsEmpty { get; }
         void ApplyResponse(ResponseMessage response, ServiceEndPoint destination);
-        RequestMessage Dequeue();
         Task<RequestMessage> DequeueAsync();
         Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken);
     }

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -86,33 +86,6 @@ namespace Halibut.ServiceModel
             }
         }
 
-
-        public RequestMessage Dequeue()
-        {
-            var pending = DequeueNext();
-            if (pending == null)
-            {
-                return null;
-            }
-
-            return pending.BeginTransfer() ? pending.Request : null;
-        }
-
-        PendingRequest DequeueNext()
-        {
-            var first = TakeFirst();
-            if (first != null)
-            {
-                return first;
-            }
-            
-            using (var cts = new CancellationTokenSource(pollingQueueWaitTimeout))
-                hasItems.Wait(cts.Token);
-
-            hasItems.Reset();
-            return TakeFirst();
-        }
-
         public async Task<RequestMessage> DequeueAsync()
         {
             var pending = await DequeueNextAsync();


### PR DESCRIPTION
# Background

[sc-53982]

The Dequeue method is not effectively used. Delete Dequeue from the IPendingRequest queue and delete the one caller of that and the one caller of that and Halibut compiles. This makes sense since async dequeue is required to have 1000s of polling tentacles connected but not doing anything.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
