### PR TITLE
Add MultipleRequestsCanBeInFlightInParallel test

### DIFF
--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
+using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.TestUtils.Contracts;

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -19,48 +19,47 @@ namespace Halibut.Tests
         public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                .WithHalibutLoggingLevel(LogLevel.Trace)
+                .WithHalibutLoggingLevel(LogLevel.Info)
                 .WithStandardServices()
                 .Build(CancellationToken);
+            
+            var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();
+
+            var dataStreams = CreateDataStreams();
+
+            var messagesAreSentTheSameTimeSemaphore = new SemaphoreSlim(0, dataStreams.Length);
+
+            int threadCount = 64;
+            int threadCompletionCount = 0;
+            var threads = new List<Thread>();
+            var exceptions = new ConcurrentBag<Exception>();
+            for (var i = 0; i < threadCount; i++)
             {
-                var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();
-
-                var dataStreams = CreateDataStreams();
-
-                var messagesAreSentTheSameTimeSemaphore = new SemaphoreSlim(0, dataStreams.Length);
-
-                int threadCount = 64;
-                int threadCompletionCount = 0;
-                var threads = new List<Thread>();
-                var exceptions = new ConcurrentBag<Exception>();
-                for (var i = 0; i < threadCount; i++)
+                var thread = new Thread(() =>
                 {
-                    var thread = new Thread(() =>
+                    // Gotta handle exceptions when running in a 
+                    // Thread, or you're gonna have a bad time.
+                    try
                     {
-                        // Gotta handle exceptions when running in a 
-                        // Thread, or you're gonna have a bad time.
-                        try
-                        {
-                            messagesAreSentTheSameTimeSemaphore.Wait(CancellationToken);
-                            var received = readDataSteamService.SendData(dataStreams);
-                            received.Should().Be(5 * dataStreams.Length);
-                            Interlocked.Increment(ref threadCompletionCount);
-                        }
-                        catch (Exception e)
-                        {
-                            exceptions.Add(e);
-                        }
-                    });
-                    thread.Start();
-                    threads.Add(thread);
-                }
-
-                messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
-
-                WaitForAllThreads(threads);
-                exceptions.Should().BeEmpty();
-                threadCompletionCount.Should().Be(threadCount);
+                        messagesAreSentTheSameTimeSemaphore.Wait(CancellationToken);
+                        var received = readDataSteamService.SendData(dataStreams);
+                        received.Should().Be(5 * dataStreams.Length);
+                        Interlocked.Increment(ref threadCompletionCount);
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                });
+                thread.Start();
+                threads.Add(thread);
             }
+
+            messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
+
+            WaitForAllThreads(threads);
+            exceptions.Should().BeEmpty();
+            threadCompletionCount.Should().Be(threadCount);
         }
 
         static DataStream[] CreateDataStreams()

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -62,10 +62,7 @@ namespace Halibut.Tests
             }
 
             // Wait for all requests to be started
-            while (requestStartedFilePaths.Any(p => !File.Exists(p)))
-            {
-                await Task.Delay(10);
-            }
+            await Wait.For(() => Task.FromResult(requestStartedFilePaths.All(File.Exists)), CancellationToken);
 
             Interlocked.Read(ref threadCompletionCount).Should().Be(0);
             exceptions.Should().BeEmpty();


### PR DESCRIPTION
This PR adds a test to verify that many requests can be "in-flight" simultaneously.

[sc-53157]

# How to review this PR

The test _does not_ clean up the 'file signal' file that gets created by `LockService`. I've tried multiple approaches, but each potential solution has caused test failures due to either race conditions or 'file is being used by another process' exceptions. The files are all 0-bytes, so this won't cause any storage problems on the build agents or local dev environments, but it would be better to clean up after ourselves here - any ideas?

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
