### PR TITLE
Add async methods to MessageExchangeStream and MessageExchangeProtocol

### DIFF
--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -230,6 +230,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             var proxyClient = new HalibutRuntimeBuilder()
                 .WithServerCertificate(clientCertAndThumbprint.Certificate2)
                 .WithLogFactory(new TestContextLogFactory("ProxyClient", halibutLogLevel))
+                .WithAsyncHalibutFeatureEnabled()
                 .Build();
             
             proxyClient.Trust(serviceCertAndThumbprint.Thumbprint);

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -18,8 +17,8 @@ using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.TestPortForwarder;
 using Serilog.Extensions.Logging;
-using ILog = Halibut.Diagnostics.ILog;
 using ICachingService = Halibut.TestUtils.Contracts.ICachingService;
+using ILog = Halibut.Diagnostics.ILog;
 
 namespace Halibut.Tests.Support
 {
@@ -287,12 +286,17 @@ namespace Halibut.Tests.Support
 
             var factory = CreatePendingRequestQueueFactory(octopusLogFactory);
 
-            var octopusBuilder = new HalibutRuntimeBuilder()
+            var clientBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(clientCertAndThumbprint.Certificate2)
                 .WithLogFactory(octopusLogFactory)
                 .WithPendingRequestQueueFactory(factory);
-            
-            var client = octopusBuilder.Build();
+
+            if (forceClientProxyType == ForceClientProxyType.AsyncClient)
+            {
+                clientBuilder = clientBuilder.WithAsyncHalibutFeatureEnabled();
+            }
+
+            var client = clientBuilder.Build();
             client.Trust(clientTrustsThumbprint);
 
             HalibutRuntime? service = null;

--- a/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
+++ b/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
@@ -52,7 +52,7 @@ namespace Halibut.Tests.Support
                 // This is the change, call this instead of: TestContext.Progress
 
                 var logLine = output.ToString();
-                if (TeamCityDetection.IsRunningInTeamCity())
+                if (TeamCityDetection.IsRunningInTeamCity() || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("Force_Test_Context_Write")))
                 {
                     // Writing to TestContext doesn't seem to result in the output showing up under the test in TeamCity.
                     TestContext.Write(logLine);

--- a/source/Halibut.Tests/Support/TestAttributes/SyncAndAsyncAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/SyncAndAsyncAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Threading.Tasks;
+using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
@@ -48,6 +49,48 @@ namespace Halibut.Tests.Support.TestAttributes
             {
                 await action();
             }
+        }
+
+        public static SyncOrAsyncAndResult<T> WhenSync<T>(this SyncOrAsync syncOrAsync, Func<T> action)
+        {
+            if (syncOrAsync == SyncOrAsync.Sync)
+            {
+                return new SyncOrAsyncAndResult<T>(syncOrAsync, action());
+            }
+
+            return new SyncOrAsyncAndResult<T>(syncOrAsync, default);
+        }
+
+        public static async Task<T> WhenAsync<T>(this SyncOrAsyncAndResult<T> syncOrAsyncAndResult, Func<Task<T>> action)
+        {
+            if (syncOrAsyncAndResult.SyncOrAsync == SyncOrAsync.Async)
+            {
+                return await action();
+            }
+
+            return syncOrAsyncAndResult.Result!;
+        }
+
+        public static AsyncHalibutFeature ToAsyncHalibutFeature(this SyncOrAsync syncOrAsync)
+        {
+            return syncOrAsync switch
+            {
+                SyncOrAsync.Sync => AsyncHalibutFeature.Disabled,
+                SyncOrAsync.Async => AsyncHalibutFeature.Enabled,
+                _ => throw new ArgumentOutOfRangeException(nameof(syncOrAsync), syncOrAsync, null)
+            };
+        }
+    }
+
+    public class SyncOrAsyncAndResult<T>
+    {
+        public SyncOrAsync SyncOrAsync { get; }
+        public T? Result{ get; }
+
+        public SyncOrAsyncAndResult(SyncOrAsync syncOrAsync, T? result)
+        {
+            SyncOrAsync = syncOrAsync;
+            Result = result;
         }
     }
 }

--- a/source/Halibut.Tests/Support/TestAttributes/SyncAndAsyncAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/SyncAndAsyncAttribute.cs
@@ -33,42 +33,50 @@ namespace Halibut.Tests.Support.TestAttributes
 
     public static class SyncOrAsyncExtensions
     {
-        public static SyncOrAsync WhenSync(this SyncOrAsync syncOrAsync, Action action)
+        public static SyncOrAsyncWithoutResult WhenSync(this SyncOrAsync syncOrAsync, Action action)
         {
             if (syncOrAsync == SyncOrAsync.Sync)
             {
                 action();
             }
 
-            return syncOrAsync;
+            return new(syncOrAsync);
         }
 
-        public static async Task WhenAsync(this SyncOrAsync syncOrAsync, Func<Task> action)
+        public static async Task WhenAsync(this SyncOrAsyncWithoutResult syncOrAsyncWithoutResult, Func<Task> action)
         {
-            if (syncOrAsync == SyncOrAsync.Async)
+            if (syncOrAsyncWithoutResult.SyncOrAsync == SyncOrAsync.Async)
             {
                 await action();
             }
         }
 
-        public static SyncOrAsyncAndResult<T> WhenSync<T>(this SyncOrAsync syncOrAsync, Func<T> action)
+        public static void WhenAsync(this SyncOrAsyncWithoutResult syncOrAsyncWithoutResult, Action action)
+        {
+            if (syncOrAsyncWithoutResult.SyncOrAsync == SyncOrAsync.Async)
+            {
+                action();
+            }
+        }
+
+        public static SyncOrAsyncWithResult<T> WhenSync<T>(this SyncOrAsync syncOrAsync, Func<T> action)
         {
             if (syncOrAsync == SyncOrAsync.Sync)
             {
-                return new SyncOrAsyncAndResult<T>(syncOrAsync, action());
+                return new SyncOrAsyncWithResult<T>(syncOrAsync, action());
             }
 
-            return new SyncOrAsyncAndResult<T>(syncOrAsync, default);
+            return new SyncOrAsyncWithResult<T>(syncOrAsync, default);
         }
 
-        public static async Task<T> WhenAsync<T>(this SyncOrAsyncAndResult<T> syncOrAsyncAndResult, Func<Task<T>> action)
+        public static async Task<T> WhenAsync<T>(this SyncOrAsyncWithResult<T> syncOrAsyncWithResult, Func<Task<T>> action)
         {
-            if (syncOrAsyncAndResult.SyncOrAsync == SyncOrAsync.Async)
+            if (syncOrAsyncWithResult.SyncOrAsync == SyncOrAsync.Async)
             {
                 return await action();
             }
 
-            return syncOrAsyncAndResult.Result!;
+            return syncOrAsyncWithResult.Result!;
         }
 
         public static AsyncHalibutFeature ToAsyncHalibutFeature(this SyncOrAsync syncOrAsync)
@@ -82,12 +90,22 @@ namespace Halibut.Tests.Support.TestAttributes
         }
     }
 
-    public class SyncOrAsyncAndResult<T>
+    public class SyncOrAsyncWithoutResult
+    {
+        public SyncOrAsync SyncOrAsync { get; }
+
+        public SyncOrAsyncWithoutResult(SyncOrAsync syncOrAsync)
+        {
+            SyncOrAsync = syncOrAsync;
+        }
+    }
+
+    public class SyncOrAsyncWithResult<T>
     {
         public SyncOrAsync SyncOrAsync { get; }
         public T? Result{ get; }
 
-        public SyncOrAsyncAndResult(SyncOrAsync syncOrAsync, T? result)
+        public SyncOrAsyncWithResult(SyncOrAsync syncOrAsync, T? result)
         {
             SyncOrAsync = syncOrAsync;
             Result = result;

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Diagnostics;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Transport;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Tests.Transport
+{
+    public static class ConnectionManagerExtensionMethods
+    {
+        public static async Task<IConnection> AcquireConnection_SyncOrAsync(this ConnectionManager connectionManager, SyncOrAsync syncOrAsync, ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            return await syncOrAsync
+                .WhenSync(() => connectionManager.AcquireConnection(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken))
+                .WhenAsync(async () => await connectionManager.AcquireConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken));
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -1,12 +1,13 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Diagnostics;
 using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
 using Halibut.Transport;
 using Halibut.Transport.Protocol;
-using Halibut.Util;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -15,38 +16,44 @@ namespace Halibut.Tests.Transport
     [TestFixture]
     public class ConnectionManagerFixture
     {
-        IConnection connection;
-        IConnectionFactory connectionFactory;
-
-        [SetUp]
-        public void SetUp()
+        public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder) SetUp(SyncOrAsync syncOrAsync)
         {
-            connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, GetProtocol, Substitute.For<ILog>());
-            connectionFactory = Substitute.For<IConnectionFactory>();
-            connectionFactory.EstablishNewConnection(GetProtocol, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(connection);
+            MessageExchangeProtocol ExchangeProtocolBuilder(Stream s, ILog l) => GetProtocol(s, l, syncOrAsync);
+
+            var connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, ExchangeProtocolBuilder, Substitute.For<ILog>());
+            var connectionFactory = Substitute.For<IConnectionFactory>();
+            connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(connection);
+
+            return (connectionFactory, ExchangeProtocolBuilder);
         }
 
         [Test]
-        public void DisposedConnectionsAreRemovedFromActive_WhenMultipleConnectionsAreActive()
+        [SyncAndAsync]
+        public async Task DisposedConnectionsAreRemovedFromActive_WhenMultipleConnectionsAreActive(SyncOrAsync syncOrAsync)
         {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
             //do it twice because this bug only triggers on multiple enumeration, having 1 in the collection doesn't trigger the bug
-            connectionManager.AcquireConnection(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
-            connectionManager.AcquireConnection(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
 
             connectionManager.Disconnect(serviceEndpoint, null);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
         }
 
         [Test]
-        public void ReleasedConnectionsAreNotActive()
+        [SyncAndAsync]
+        public async Task ReleasedConnectionsAreNotActive(SyncOrAsync syncOrAsync)
         {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
-            var activeConnection = connectionManager.AcquireConnection(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
@@ -54,12 +61,15 @@ namespace Halibut.Tests.Transport
         }
 
         [Test]
-        public void DisposedConnectionsAreRemovedFromActive()
+        [SyncAndAsync]
+        public async Task DisposedConnectionsAreRemovedFromActive(SyncOrAsync syncOrAsync)
         {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
-            var activeConnection = connectionManager.AcquireConnection(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             activeConnection.Dispose();
@@ -67,21 +77,24 @@ namespace Halibut.Tests.Transport
         }
 
         [Test]
-        public void DisconnectDisposesActiveConnections()
+        [SyncAndAsync]
+        public async Task DisconnectDisposesActiveConnections(SyncOrAsync syncOrAsync)
         {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
-            var activeConnection = connectionManager.AcquireConnection(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
         }
 
-        public MessageExchangeProtocol GetProtocol(Stream stream, ILog log)
+        public MessageExchangeProtocol GetProtocol(Stream stream, ILog log, SyncOrAsync syncOrAsync)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), AsyncHalibutFeature.Disabled, log), log);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), syncOrAsync.ToAsyncHalibutFeature(), log), log);
         }
     }
 }

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -6,6 +6,7 @@ using Halibut.Diagnostics;
 using Halibut.Tests.Support;
 using Halibut.Transport;
 using Halibut.Transport.Protocol;
+using Halibut.Util;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -80,7 +81,7 @@ namespace Halibut.Tests.Transport
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog log)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), log), log);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), AsyncHalibutFeature.Disabled, log), log);
         }
     }
 }

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -18,6 +18,7 @@ namespace Halibut
         Action<MessageSerializerBuilder> configureMessageSerializerBuilder;
         ITypeRegistry typeRegistry;
         Func<RetryPolicy> pollingReconnectRetryPolicy = RetryPolicy.Create;
+        AsyncHalibutFeature asyncHalibutFeature = AsyncHalibutFeature.Disabled;
 
         public HalibutRuntimeBuilder WithServiceFactory(IServiceFactory serviceFactory)
         {
@@ -61,6 +62,12 @@ namespace Halibut
             return this;
         }
 
+        public HalibutRuntimeBuilder WithAsyncHalibutFeatureEnabled()
+        {
+            this.asyncHalibutFeature = AsyncHalibutFeature.Enabled;
+            return this;
+        }
+
         internal HalibutRuntimeBuilder WithPollingReconnectRetryPolicy(Func<RetryPolicy> pollingReconnectRetryPolicy)
         {
             this.pollingReconnectRetryPolicy = pollingReconnectRetryPolicy;
@@ -83,7 +90,7 @@ namespace Halibut
             configureMessageSerializerBuilder?.Invoke(builder);
             var messageSerializer = builder.WithTypeRegistry(typeRegistry).Build();
 
-            return new HalibutRuntime(serviceFactory, serverCertificate, trustProvider, queueFactory, logFactory, typeRegistry, messageSerializer, pollingReconnectRetryPolicy);
+            return new HalibutRuntime(serviceFactory, serverCertificate, trustProvider, queueFactory, logFactory, typeRegistry, messageSerializer, pollingReconnectRetryPolicy, asyncHalibutFeature);
         }
     }
 }

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -70,10 +70,9 @@ namespace Halibut.Transport
                             // We have successfully connected at this point so reset the retry policy
                             // Subsequent connection issues will try and reconnect quickly and then back-off
                             retry.Success();
-
                             protocol.ExchangeAsSubscriber(subscription, handleIncomingRequest);
                         }, cancellationToken);
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0612
                         retry.Success();
                     }
                     finally

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -1,22 +1,57 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Halibut.Transport.Protocol
 {
     public interface IMessageExchangeStream
     {
+        [Obsolete]
         void IdentifyAsClient();
+        Task IdentifyAsClientAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         void SendNext();
+        Task SendNextAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         void SendProceed();
+        [Obsolete]
         Task SendProceedAsync();
+        Task SendProceedAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         void SendEnd();
+        Task SendEndAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         bool ExpectNextOrEnd();
+        [Obsolete]
         Task<bool> ExpectNextOrEndAsync();
+        Task<bool> ExpectNextOrEndAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         void ExpectProceeed();
+        Task ExpectProceedAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         void IdentifyAsSubscriber(string subscriptionId);
+        Task IdentifyAsSubscriberAsync(string subscriptionId, CancellationToken cancellationToken);
+
+        [Obsolete]
         void IdentifyAsServer();
+        Task IdentifyAsServerAsync(CancellationToken cancellationToken);
+
+        [Obsolete] 
         RemoteIdentity ReadRemoteIdentity();
+        Task<RemoteIdentity> ReadRemoteIdentityAsync(CancellationToken cancellationToken);
+
+        [Obsolete]
         void Send<T>(T message);
+        Task SendAsync<T>(T message, CancellationToken cancellationToken);
+
+        [Obsolete]
         T Receive<T>();
+        Task<T> ReceiveAsync<T>(CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/IMessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/IMessageSerializer.cs
@@ -1,11 +1,18 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.Transport.Protocol
 {
     public interface IMessageSerializer
     {
+        [Obsolete]
         void WriteMessage<T>(Stream stream, T message);
+        Task WriteMessageAsync<T>(Stream stream, T message, CancellationToken cancellationToken);
 
+        [Obsolete]
         T ReadMessage<T>(RewindableBufferStream stream);
+        Task<T> ReadMessageAsync<T>(RewindableBufferStream stream, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -41,12 +41,10 @@ namespace Halibut.Transport.Protocol
 
         public async Task<ResponseMessage> ExchangeAsClientAsync(RequestMessage request, CancellationToken cancellationToken)
         {
-            // TODO - ASYNC ME UP!
-            await Task.CompletedTask;
+            await PrepareExchangeAsClientAsync(cancellationToken);
 
-#pragma warning disable CS0612
-            return ExchangeAsClient(request);
-#pragma warning restore CS0612
+            await stream.SendAsync(request, cancellationToken);
+            return await stream.ReceiveAsync<ResponseMessage>(cancellationToken);
         }
 
         public void StopAcceptingClientRequests()
@@ -54,11 +52,18 @@ namespace Halibut.Transport.Protocol
             acceptClientRequests = false;
         }
 
+        [Obsolete]
         public void EndCommunicationWithServer()
         {
             stream.SendEnd();
         }
 
+        public async Task EndCommunicationWithServer(CancellationToken cancellationToken)
+        {
+            await stream.SendEndAsync(cancellationToken);
+        }
+
+        [Obsolete]
         void PrepareExchangeAsClient()
         {
             try
@@ -80,6 +85,28 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        async Task PrepareExchangeAsClientAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (!identified)
+                {
+                    await stream.IdentifyAsClientAsync(cancellationToken);
+                    identified = true;
+                }
+                else
+                {
+                    await stream.SendNextAsync(cancellationToken);
+                    await stream.ExpectProceedAsync(cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new ConnectionInitializationFailedException(ex);
+            }
+        }
+
+        [Obsolete]
         public void ExchangeAsSubscriber(Uri subscriptionId, Func<RequestMessage, ResponseMessage> incomingRequestProcessor, int maxAttempts = int.MaxValue)
         {
             if (!identified)
@@ -94,9 +121,25 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        public async Task ExchangeAsSubscriberAsync(Uri subscriptionId, Func<RequestMessage, ResponseMessage> incomingRequestProcessor, int maxAttempts, CancellationToken cancellationToken)
+        {
+            if (!identified)
+            {
+                await stream.IdentifyAsSubscriberAsync(subscriptionId.ToString(), cancellationToken);
+                identified = true;
+            }
+
+            for (var i = 0; i < maxAttempts; i++)
+            {
+                await ReceiveAndProcessRequestAsync(stream, incomingRequestProcessor, cancellationToken);
+            }
+        }
+
+        [Obsolete]
         static void ReceiveAndProcessRequest(IMessageExchangeStream stream, Func<RequestMessage, ResponseMessage> incomingRequestProcessor)
         {
             var request = stream.Receive<RequestMessage>();
+
             if (request != null)
             {
                 var response = InvokeAndWrapAnyExceptions(request, incomingRequestProcessor);
@@ -107,6 +150,21 @@ namespace Halibut.Transport.Protocol
             stream.ExpectProceeed();
         }
 
+        static async Task ReceiveAndProcessRequestAsync(IMessageExchangeStream stream, Func<RequestMessage, ResponseMessage> incomingRequestProcessor, CancellationToken cancellationToken)
+        {
+            var request = await stream.ReceiveAsync<RequestMessage>(cancellationToken);
+
+            if (request != null)
+            {
+                var response = InvokeAndWrapAnyExceptions(request, incomingRequestProcessor);
+                await stream.SendAsync(response, cancellationToken);
+            }
+
+            await stream.SendNextAsync(cancellationToken);
+            await stream.ExpectProceedAsync(cancellationToken);
+        }
+
+        [Obsolete]
         public async Task ExchangeAsServerSynchronouslyAsync(Func<RequestMessage, ResponseMessage> incomingRequestProcessor, Func<RemoteIdentity, IPendingRequestQueue> pendingRequests)
         {
             var identity = stream.ReadRemoteIdentity();
@@ -124,6 +182,25 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        public async Task ExchangeAsServerAsync(Func<RequestMessage, ResponseMessage> incomingRequestProcessor, Func<RemoteIdentity, IPendingRequestQueue> pendingRequests, CancellationToken cancellationToken)
+        {
+            var identity = await stream.ReadRemoteIdentityAsync(cancellationToken);
+            await stream.IdentifyAsServerAsync(cancellationToken);
+
+            switch (identity.IdentityType)
+            {
+                case RemoteIdentityType.Client:
+                    await ProcessClientRequestsAsync(incomingRequestProcessor, cancellationToken);
+                    break;
+                case RemoteIdentityType.Subscriber:
+                    await ProcessSubscriberAsync(pendingRequests(identity), cancellationToken);
+                    break;
+                default:
+                    throw new ProtocolException("Unexpected remote identity: " + identity.IdentityType);
+            }
+        }
+
+        [Obsolete]
         void ProcessClientRequests(Func<RequestMessage, ResponseMessage> incomingRequestProcessor)
         {
             while (acceptClientRequests)
@@ -155,6 +232,47 @@ namespace Halibut.Transport.Protocol
             }
         }
         
+        async Task ProcessClientRequestsAsync(Func<RequestMessage, ResponseMessage> incomingRequestProcessor, CancellationToken cancellationToken)
+        {
+            while (acceptClientRequests && !cancellationToken.IsCancellationRequested)
+            {
+                var request = await stream.ReceiveAsync<RequestMessage>(cancellationToken);
+
+                if (request == null || !acceptClientRequests)
+                {
+                    return;
+                }
+
+                var response = InvokeAndWrapAnyExceptions(request, incomingRequestProcessor);
+
+                if (!acceptClientRequests || cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                
+                await stream.SendAsync(response, cancellationToken);
+
+                try
+                {
+                    if (!acceptClientRequests || cancellationToken.IsCancellationRequested || !await stream.ExpectNextOrEndAsync(cancellationToken))
+                    {
+                        return;
+                    }
+                }
+                catch (Exception ex) when (ex.IsSocketConnectionTimeout())
+                {
+                    // We get socket timeout on the Listening side (a Listening Tentacle in Octopus use) as part of normal operation
+                    // if we don't hear from the other end within our TcpRx Timeout.
+                    log.Write(EventType.Diagnostic, "No messages received from client for timeout period. Connection closed and will be re-opened when required");
+                    
+                    return;
+                }
+
+                await stream.SendProceedAsync(cancellationToken);
+            }
+        }
+
+        [Obsolete]
         async Task ProcessSubscriberSynchronouslyAsync(IPendingRequestQueue pendingRequests)
         {
             while (true)
@@ -167,6 +285,22 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        async Task ProcessSubscriberAsync(IPendingRequestQueue pendingRequests, CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var nextRequest = await pendingRequests.DequeueAsync(cancellationToken);
+
+                var success = await ProcessReceiverInternalAsync(pendingRequests, nextRequest, cancellationToken);
+                
+                if (!success)
+                {
+                    return;
+                }
+            }
+        }
+
+        [Obsolete]
         async Task<bool> ProcessReceiverInternalSynchronouslyAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest)
         {
             try
@@ -202,6 +336,49 @@ namespace Halibut.Transport.Protocol
                 return false;
             }
             await stream.SendProceedAsync();
+            return true;
+        }
+        
+        async Task<bool> ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await stream.SendAsync(nextRequest, cancellationToken);
+                if (nextRequest != null)
+                {
+                    var response = await stream.ReceiveAsync<ResponseMessage>(cancellationToken);
+                    await pendingRequests.ApplyResponse(response, nextRequest.Destination);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (nextRequest != null)
+                {
+                    var response = ResponseMessage.FromException(nextRequest, ex);
+                    await pendingRequests.ApplyResponse(response, nextRequest.Destination);
+                }
+
+                return false;
+            }
+
+            try
+            {
+                if (!await stream.ExpectNextOrEndAsync(cancellationToken))
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex) when (ex.IsSocketConnectionTimeout())
+            {
+                // We get socket timeout on the server when the network connection to a polling client drops
+                // (in Octopus this is the server for a Polling Tentacle)
+                // In normal operation a client will poll more often than the timeout so we shouldn't see this.
+                log.Write(EventType.Diagnostic, "No messages received from client for timeout period. This may be due to network problems. Connection will be re-opened when required.");
+
+                return false;
+            }
+
+            await stream.SendProceedAsync(cancellationToken);
             return true;
         }
 

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -58,7 +58,7 @@ namespace Halibut.Transport.Protocol
             stream.SendEnd();
         }
 
-        public async Task EndCommunicationWithServer(CancellationToken cancellationToken)
+        public async Task EndCommunicationWithServerAsync(CancellationToken cancellationToken)
         {
             await stream.SendEndAsync(cancellationToken);
         }

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -75,7 +75,7 @@ namespace Halibut.Transport.Protocol
 
         async Task SendControlMessageAsync(string message, CancellationToken cancellationToken)
         {
-            await stream.WriteLineAsync(message, cancellationToken);
+            await stream.WriteControlLineAsync(message, cancellationToken);
             await stream.FlushAsync(cancellationToken);
         }
 
@@ -89,8 +89,8 @@ namespace Halibut.Transport.Protocol
 
         async Task SendIdentityMessageAsync(string identityLine, CancellationToken cancellationToken)
         {
-            await stream.WriteLineAsync(identityLine, cancellationToken);
-            await stream.WriteLineAsync(cancellationToken);
+            await stream.WriteControlLineAsync(identityLine, cancellationToken);
+            await stream.WriteEmptyControlLineAsync(cancellationToken);
             await stream.FlushAsync(cancellationToken);
         }
 
@@ -227,7 +227,7 @@ namespace Halibut.Transport.Protocol
         public async Task IdentifyAsSubscriberAsync(string subscriptionId, CancellationToken cancellationToken)
         {
             await SendIdentityMessageAsync($"{MxSubscriber} {currentVersion} {subscriptionId}", cancellationToken);
-            await ExpectServerIdentityAsync(cancellationToken).ConfigureAwait(false);
+            await ExpectServerIdentityAsync(cancellationToken);
         }
 
         [Obsolete]

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -7,6 +7,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
+using Halibut.Transport.Streams;
+using Halibut.Util;
 
 namespace Halibut.Transport.Protocol
 {
@@ -21,22 +23,28 @@ namespace Halibut.Transport.Protocol
 
         readonly RewindableBufferStream stream;
         readonly ILog log;
-        readonly StreamWriter streamWriter;
+        [Obsolete]
+        readonly StreamWriter streamWriter = null;
         readonly IMessageSerializer serializer;
-        readonly Version currentVersion = new Version(1, 0);
-        readonly ControlMessageReader controlMessageReader = new ControlMessageReader();
+        readonly Version currentVersion = new(1, 0);
+        readonly ControlMessageReader controlMessageReader = new();
 
-        public MessageExchangeStream(Stream stream, IMessageSerializer serializer, ILog log)
+        public MessageExchangeStream(Stream stream, IMessageSerializer serializer, AsyncHalibutFeature asyncHalibutFeature, ILog log)
         {
-            this.stream = new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
+            this.stream = asyncHalibutFeature.IsEnabled() ? new RewindableBufferStream(new TimeoutStream(stream), HalibutLimits.RewindableBufferStreamSize) : new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
             this.log = log;
-            streamWriter = new StreamWriter(this.stream, new UTF8Encoding(false)) { NewLine = "\r\n" };
             this.serializer = serializer;
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            streamWriter = new StreamWriter(this.stream, new UTF8Encoding(false)) { NewLine = "\r\n" };
+#pragma warning restore CS0612 // Type or member is obsolete
+            
             SetNormalTimeouts();
         }
 
         static int streamCount;
 
+        [Obsolete]
         public void IdentifyAsClient()
         {
             log.Write(EventType.Diagnostic, "Identifying as a client");
@@ -44,18 +52,34 @@ namespace Halibut.Transport.Protocol
             ExpectServerIdentity();
         }
 
+        public async Task IdentifyAsClientAsync(CancellationToken cancellationToken)
+        {
+            log.Write(EventType.Diagnostic, "Identifying as a client");
+            await SendIdentityMessageAsync($"{MxClient} {currentVersion}", cancellationToken);
+            await ExpectServerIdentityAsync(cancellationToken);
+        }
+
+        [Obsolete]
         void SendControlMessage(string message)
         {
             streamWriter.WriteLine(message);
             streamWriter.Flush();
         }
 
+        [Obsolete]
         async Task SendControlMessageAsync(string message)
         {
             await streamWriter.WriteLineAsync(message).ConfigureAwait(false);
             await streamWriter.FlushAsync().ConfigureAwait(false);
         }
 
+        async Task SendControlMessageAsync(string message, CancellationToken cancellationToken)
+        {
+            await stream.WriteLineAsync(message, cancellationToken);
+            await stream.FlushAsync(cancellationToken);
+        }
+
+        [Obsolete]
         void SendIdentityMessage(string identityLine)
         {
             streamWriter.WriteLine(identityLine);
@@ -63,6 +87,14 @@ namespace Halibut.Transport.Protocol
             streamWriter.Flush();
         }
 
+        async Task SendIdentityMessageAsync(string identityLine, CancellationToken cancellationToken)
+        {
+            await stream.WriteLineAsync(identityLine, cancellationToken);
+            await stream.WriteLineAsync(cancellationToken);
+            await stream.FlushAsync(cancellationToken);
+        }
+
+        [Obsolete]
         public void SendNext()
         {
             SetShortTimeouts();
@@ -70,16 +102,31 @@ namespace Halibut.Transport.Protocol
             SetNormalTimeouts();
         }
 
+        public async Task SendNextAsync(CancellationToken cancellationToken)
+        {
+            SetShortTimeouts();
+            await SendControlMessageAsync(Next, cancellationToken);
+            SetNormalTimeouts();
+        }
+
+        [Obsolete]
         public void SendProceed()
         {
             SendControlMessage(Proceed);
         }
 
+        [Obsolete]
         public async Task SendProceedAsync()
         {
             await SendControlMessageAsync(Proceed).ConfigureAwait(false);
         }
 
+        public async Task SendProceedAsync(CancellationToken cancellationToken)
+        {
+            await SendControlMessageAsync(Proceed, cancellationToken);
+        }
+
+        [Obsolete]
         public void SendEnd()
         {
             SetShortTimeouts();
@@ -87,6 +134,14 @@ namespace Halibut.Transport.Protocol
             SetNormalTimeouts();
         }
 
+        public async Task SendEndAsync(CancellationToken cancellationToken)
+        {
+            SetShortTimeouts(); 
+            await SendControlMessageAsync(End, cancellationToken);
+            SetNormalTimeouts();
+        }
+
+        [Obsolete]
         public bool ExpectNextOrEnd()
         {
             var line = controlMessageReader.ReadUntilNonEmptyControlMessage(stream);
@@ -102,6 +157,7 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        [Obsolete]
         public async Task<bool> ExpectNextOrEndAsync()
         {
             var line = await controlMessageReader.ReadUntilNonEmptyControlMessageAsync(stream).ConfigureAwait(false);
@@ -117,6 +173,20 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        public async Task<bool> ExpectNextOrEndAsync(CancellationToken cancellationToken)
+        {
+            var line = await controlMessageReader.ReadUntilNonEmptyControlMessageAsync(stream, cancellationToken);
+            
+            return line switch
+            {
+                Next => true,
+                null => false,
+                End => false,
+                _ => throw new ProtocolException($"Expected {Next} or {End}, got: " + line)
+            };
+        }
+
+        [Obsolete]
         public void ExpectProceeed()
         {
             SetShortTimeouts();
@@ -128,19 +198,50 @@ namespace Halibut.Transport.Protocol
             SetNormalTimeouts();
         }
 
-        
+        public async Task ExpectProceedAsync(CancellationToken cancellationToken)
+        {
+            SetShortTimeouts();
 
+            var line = await controlMessageReader.ReadUntilNonEmptyControlMessageAsync(stream, cancellationToken);
+
+            if (line == null)
+            {
+                throw new AuthenticationException($"Expected {Proceed}, got no data");
+            }
+
+            if (line != Proceed)
+            {
+                throw new ProtocolException($"Expected {Proceed}, got: " + line);
+            }
+
+            SetNormalTimeouts();
+        }
+
+        [Obsolete]
         public void IdentifyAsSubscriber(string subscriptionId)
         {
             SendIdentityMessage($"{MxSubscriber} {currentVersion} {subscriptionId}");
             ExpectServerIdentity();
         }
 
+        public async Task IdentifyAsSubscriberAsync(string subscriptionId, CancellationToken cancellationToken)
+        {
+            await SendIdentityMessageAsync($"{MxSubscriber} {currentVersion} {subscriptionId}", cancellationToken);
+            await ExpectServerIdentityAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        [Obsolete]
         public void IdentifyAsServer()
         {
             SendIdentityMessage($"{MxServer} {currentVersion}");
         }
 
+        public async Task IdentifyAsServerAsync(CancellationToken cancellationToken)
+        {
+            await SendIdentityMessageAsync($"{MxServer} {currentVersion}", cancellationToken);
+        }
+
+        [Obsolete]
         public RemoteIdentity ReadRemoteIdentity()
         {
             var line = controlMessageReader.ReadControlMessage(stream);
@@ -176,6 +277,51 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        public async Task<RemoteIdentity> ReadRemoteIdentityAsync(CancellationToken cancellationToken)
+        {
+            var line = await controlMessageReader.ReadControlMessageAsync(stream, cancellationToken);
+            if (string.IsNullOrEmpty(line))
+            {
+                throw new ProtocolException("Unable to receive the remote identity; the identity line was empty.");
+            }
+
+            var emptyLine = await controlMessageReader.ReadControlMessageAsync(stream, cancellationToken);
+            if (emptyLine.Length != 0)
+            {
+                throw new ProtocolException("Unable to receive the remote identity; the following line was not empty.");
+            }
+
+            var parts = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            try
+            {
+                var identityType = ParseIdentityType(parts[0]);
+                if (identityType == RemoteIdentityType.Subscriber)
+                {
+                    if (parts.Length < 3)
+                    {
+                        throw new ProtocolException("Unable to receive the remote identity; the client identified as a subscriber, but did not supply a subscription ID.");
+                    }
+
+                    var subscriptionId = new Uri(parts[2]);
+
+                    return new RemoteIdentity(identityType, subscriptionId);
+                }
+                
+                return new RemoteIdentity(identityType);
+            }
+            catch (ProtocolException)
+            {
+                log.Write(EventType.Error, "Response:");
+                log.Write(EventType.Error, line);
+
+                var remainingStreamData = await new StreamReader(stream, new UTF8Encoding(false)).ReadToEndAsync();
+                log.Write(EventType.Error, remainingStreamData);
+
+                throw;
+            }
+        }
+
+        [Obsolete]
         public void Send<T>(T message)
         {
             using (var capture = StreamCapture.New())
@@ -187,6 +333,18 @@ namespace Halibut.Transport.Protocol
             log.Write(EventType.Diagnostic, "Sent: {0}", message);
         }
 
+        public async Task SendAsync<T>(T message, CancellationToken cancellationToken)
+        {
+            using (var capture = StreamCapture.New())
+            {
+                await serializer.WriteMessageAsync(stream, message, cancellationToken);
+                await WriteEachStreamAsync(capture.SerializedStreams, cancellationToken);
+            }
+
+            log.Write(EventType.Diagnostic, "Sent: {0}", message);
+        }
+
+        [Obsolete]
         public T Receive<T>()
         {
             using (var capture = StreamCapture.New())
@@ -196,6 +354,16 @@ namespace Halibut.Transport.Protocol
                 log.Write(EventType.Diagnostic, "Received: {0}", result);
                 return result;
             }
+        }
+
+        public async Task<T> ReceiveAsync<T>(CancellationToken cancellationToken)
+        {
+            using var capture = StreamCapture.New();
+
+            var result = await serializer.ReadMessageAsync<T>(stream, cancellationToken);
+            await ReadStreamsAsync(capture, cancellationToken);
+            log.Write(EventType.Diagnostic, "Received: {0}", result);
+            return result;
         }
 
         static RemoteIdentityType ParseIdentityType(string identityType)
@@ -213,6 +381,7 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        [Obsolete]
         void ExpectServerIdentity()
         {
             var identity = ReadRemoteIdentity();
@@ -220,6 +389,17 @@ namespace Halibut.Transport.Protocol
                 throw new ProtocolException("Expected the remote endpoint to identity as a server. Instead, it identified as: " + identity.IdentityType);
         }
 
+        async Task ExpectServerIdentityAsync(CancellationToken cancellationToken)
+        {
+            var identity = await ReadRemoteIdentityAsync(cancellationToken);
+
+            if (identity.IdentityType != RemoteIdentityType.Server)
+            {
+                throw new ProtocolException("Expected the remote endpoint to identity as a server. Instead, it identified as: " + identity.IdentityType);
+            }
+        }
+
+        [Obsolete]
         void ReadStreams(StreamCapture capture)
         {
             var expected = capture.DeserializedStreams.Count;
@@ -230,6 +410,17 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        async Task ReadStreamsAsync(StreamCapture capture, CancellationToken cancellationToken)
+        {
+            var expected = capture.DeserializedStreams.Count;
+
+            for (var i = 0; i < expected; i++)
+            {
+                await ReadStreamAsync(capture, cancellationToken);
+            }
+        }
+
+        [Obsolete]
         void ReadStream(StreamCapture capture)
         {
             var reader = new BinaryReader(stream);
@@ -244,6 +435,16 @@ namespace Halibut.Transport.Protocol
             }
 
             ((IDataStreamInternal)dataStream).Received(tempFile);
+        }
+
+        async Task ReadStreamAsync(StreamCapture capture, CancellationToken cancellationToken)
+        {
+            // TODO - ASYNC ME UP!
+            await Task.CompletedTask;
+
+#pragma warning disable CS0612
+            ReadStream(capture);
+#pragma warning restore CS0612
         }
 
         TemporaryFileStream CopyStreamToFile(Guid id, long length, BinaryReader reader)
@@ -271,6 +472,7 @@ namespace Halibut.Transport.Protocol
             return dataStream;
         }
 
+        [Obsolete]
         void WriteEachStream(IEnumerable<DataStream> streams)
         {
             foreach (var dataStream in streams)
@@ -286,6 +488,15 @@ namespace Halibut.Transport.Protocol
                 writer.Write(dataStream.Length);
                 writer.Flush();
             }
+        }
+
+        async Task WriteEachStreamAsync(IEnumerable<DataStream> streams, CancellationToken cancellationToken)
+        {
+            // TODO - ASYNC ME UP!
+            await Task.CompletedTask;
+#pragma warning disable CS0612
+            WriteEachStream(streams);
+#pragma warning restore CS0612
         }
 
         void SetNormalTimeouts()

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Transport.Observability;
 using Halibut.Transport.Streams;
@@ -62,6 +64,14 @@ namespace Halibut.Transport.Protocol
             observer.MessageWritten(compressedByteCountingStream.BytesWritten);
         }
 
+        public async Task WriteMessageAsync<T>(Stream stream, T message, CancellationToken cancellationToken)
+        {
+            // TODO - ASYNC ME UP!
+            await Task.CompletedTask;
+
+            WriteMessage(stream, message);
+        }
+
         public T ReadMessage<T>(RewindableBufferStream stream)
         {
             using (var errorRecordingStream = new ErrorRecordingStream(stream, closeInner: false))
@@ -95,6 +105,14 @@ namespace Halibut.Transport.Protocol
                 
                 throw exceptionFromDeserialisation;
             }
+        }
+
+        public async Task<T> ReadMessageAsync<T>(RewindableBufferStream stream, CancellationToken cancellationToken)
+        {
+            // TODO - ASYNC ME UP!
+            await Task.CompletedTask;
+
+            return ReadMessage<T>(stream);
         }
 
         T ReadCompressedMessage<T>(Stream stream, IRewindableBuffer rewindableBuffer)

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -32,7 +32,7 @@ namespace Halibut.Transport
         {
             return lastUsed < DateTimeOffset.UtcNow.Subtract(HalibutLimits.SafeTcpClientPooledConnectionTimeout);
         }
-
+        
         public void Dispose()
         {
             try
@@ -40,7 +40,10 @@ namespace Halibut.Transport
                 protocol.StopAcceptingClientRequests();
                 try
                 {
+                    // TODO - ASYNC ME UP!
+#pragma warning disable CS0612
                     protocol.EndCommunicationWithServer();
+#pragma warning restore CS0612
                 }
                 catch (Exception)
                 {

--- a/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Transport.Streams
+{
+    public static class StreamExtensionMethods
+    {
+        // The NewLine and Encoding must not be changed as it will break backward compatibility.
+        static readonly string NewLine = "\r\n";
+        static readonly Encoding Encoding = new UTF8Encoding(false);
+
+        public static async Task WriteLineAsync(this Stream stream, string s, CancellationToken cancellationToken)
+        {
+            var bytes = Encoding.GetBytes(s + NewLine);
+            await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+        }
+
+        public static async Task WriteLineAsync(this Stream stream, CancellationToken cancellationToken)
+        {
+            await stream.WriteLineAsync(string.Empty, cancellationToken);
+        }
+    }
+}

--- a/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
@@ -11,15 +11,15 @@ namespace Halibut.Transport.Streams
         static readonly string NewLine = "\r\n";
         static readonly Encoding Encoding = new UTF8Encoding(false);
 
-        public static async Task WriteLineAsync(this Stream stream, string s, CancellationToken cancellationToken)
+        public static async Task WriteControlLineAsync(this Stream stream, string s, CancellationToken cancellationToken)
         {
             var bytes = Encoding.GetBytes(s + NewLine);
             await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
         }
 
-        public static async Task WriteLineAsync(this Stream stream, CancellationToken cancellationToken)
+        public static async Task WriteEmptyControlLineAsync(this Stream stream, CancellationToken cancellationToken)
         {
-            await stream.WriteLineAsync(string.Empty, cancellationToken);
+            await stream.WriteControlLineAsync(string.Empty, cancellationToken);
         }
     }
 }

--- a/source/Halibut/Util/AsyncHalibutFeature.cs
+++ b/source/Halibut/Util/AsyncHalibutFeature.cs
@@ -1,0 +1,21 @@
+﻿namespace Halibut.Util
+{
+    public enum AsyncHalibutFeature
+    {
+        Enabled,
+        Disabled    
+    }
+
+    public static class AsyncHalibutFeatureExtensionMethods
+    {
+        public static bool IsEnabled(this AsyncHalibutFeature feature)
+        {
+            return feature == AsyncHalibutFeature.Enabled;
+        }
+
+        public static bool IsDisabled(this AsyncHalibutFeature feature)
+        {
+            return feature == AsyncHalibutFeature.Disabled;
+        }
+    }
+}


### PR DESCRIPTION
# Background

This PR adds async versions of the methods in `MessageExchangeProtocol` and `MessageExchangeStream` to support a fully Async Halibut

The PR also adds a new parameter to the constructor of the `HalibutRuntime` - `AsyncHalibutFeature` to control if Async features should be used in the Runtime and to allow the existing Sync Halibut to remain pretty much unchanged in the way it works.

A small memory issue for the test runner around the proactive disposal of ResponseCaches is also addressed in this PR. It does not pose an issue for Server or Tentacle as they do not create many HalibutRuntimes and dispose of them throughout the applications lifecycle.

## Unit Tests

Only a few unit tests have been converted to run on sync and async that cover this area. A second PR will add them in as this PR is already quite large.

As this is an in-development feature it poses no real risk adding the test coverage after this is merged.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
