### PR TITLE
Fix creation async proxies that have options also test async/sync usagefixture and BadCerts 

### DIFF
--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -7,6 +7,7 @@ using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.SyncClientWithOptions;
 using Halibut.TestUtils.Contracts;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
@@ -30,7 +31,7 @@ namespace Halibut.Tests
                 var data = new byte[1024 * 1024 + 15];
                 new Random().NextBytes(data);
 
-                var echo = clientAndService.CreateClient<ICountingService, IClientCountingService>(point =>
+                var echo = clientAndService.CreateClient<ICountingService, ISyncClientCountingServiceWithOptions>(point =>
                     {
                         point.RetryCountLimit = 1000000;
                         point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
@@ -74,7 +75,7 @@ namespace Halibut.Tests
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
-                var echo = clientAndService.CreateClient<IEchoService, IClientEchoService>();
+                var echo = clientAndService.CreateClient<IEchoService, ISyncClientEchoServiceWithOptions>();
 
                 echo.SayHello("Hello!!", new HalibutProxyRequestOptions(new CancellationToken()))
                     .Should()
@@ -92,7 +93,7 @@ namespace Halibut.Tests
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
-                var lockService = clientAndService.CreateClient<ILockService, IClientLockService>();
+                var lockService = clientAndService.CreateClient<ILockService, ISyncClientLockServiceWithOptions>();
 
                 var cts = new CancellationTokenSource();
                 using var tmpDir = new TemporaryDirectory();
@@ -123,28 +124,6 @@ namespace Halibut.Tests
                 // Now the lock is released we should be able to complete the request.
                 await inFlightRequest;
             }
-        }
-
-        public interface IClientEchoService
-        {
-            int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-            string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-            bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
-
-            int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
-        }
-        
-        public interface IClientLockService
-        {
-            public void WaitForFileToBeDeleted(string fileToWaitFor, string fileSignalWhenRequestIsStarted, HalibutProxyRequestOptions halibutProxyRequestOptions);
-        }
-        
-        public interface IClientCountingService
-        {
-            public int Increment(HalibutProxyRequestOptions halibutProxyRequestOptions);
-            public int GetCurrentValue(HalibutProxyRequestOptions halibutProxyRequestOptions);
         }
     }
 

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -495,6 +495,14 @@ namespace Halibut.Tests.Support
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TClientService>(forceClientProxyType, Client, serviceEndpoint);
             }
+            
+            
+            public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
+            {
+                var serviceEndpoint = new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
+                modifyServiceEndpoint(serviceEndpoint);
+                return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(forceClientProxyType, Client, serviceEndpoint);
+            }
 
             public void Dispose()
             {

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientComplexObjectService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientComplexObjectService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Halibut.TestUtils.Contracts;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientComplexObjectService
+    {
+        Task<ComplexObjectMultipleDataStreams> ProcessAsync(ComplexObjectMultipleDataStreams request);
+        Task<ComplexObjectMultipleChildren> ProcessAsync(ComplexObjectMultipleChildren request);
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientCountingService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientCountingService.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientCountingService
+    {
+        public Task<int> IncrementAsync();
+        public Task<int> GetCurrentValueAsync();
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientCountingServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientCountingServiceWithOptions.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientCountingServiceWithOptions
+    {
+        public Task<int> IncrementAsync(HalibutProxyRequestOptions halibutProxyRequestOptions);
+        public Task<int> GetCurrentValueAsync(HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/TestServices/AsyncSyncCompat/AdaptSyncProxyToAsyncProxy.cs
+++ b/source/Halibut.Tests/TestServices/AsyncSyncCompat/AdaptSyncProxyToAsyncProxy.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests.TestServices.AsyncSyncCompat
 
         MethodInfo? GetSyncMethod(MethodInfo asyncMethodInfo)
         {
-            return AsyncCompatibilityHelper.FindMatchingSyncMethod(asyncMethodInfo, syncHalubutProxyType);
+            return AsyncCompatibilityHelper.FindMatchingSyncMethod(asyncMethodInfo, syncHalubutProxyType, false);
         }
 
         public override async Task InvokeAsync(MethodInfo asyncMethodInfo, object[] args)

--- a/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientCountingServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientCountingServiceWithOptions.cs
@@ -1,0 +1,10 @@
+﻿using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.SyncClientWithOptions
+{
+    public interface ISyncClientCountingServiceWithOptions
+    {
+        public int Increment(HalibutProxyRequestOptions halibutProxyRequestOptions);
+        public int GetCurrentValue(HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientEchoServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientEchoServiceWithOptions.cs
@@ -1,0 +1,15 @@
+﻿using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.SyncClientWithOptions
+{
+    public interface ISyncClientEchoServiceWithOptions
+    {
+        int LongRunningOperation(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        string SayHello(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        bool Crash(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        int CountBytes(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientLockServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientLockServiceWithOptions.cs
@@ -1,0 +1,9 @@
+﻿using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.SyncClientWithOptions
+{
+    public interface ISyncClientLockServiceWithOptions
+    {
+        public void WaitForFileToBeDeleted(string fileToWaitFor, string fileSignalWhenRequestIsStarted, HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut/ServiceModel/AsyncCompatibilityHelper.cs
+++ b/source/Halibut/ServiceModel/AsyncCompatibilityHelper.cs
@@ -7,7 +7,7 @@ namespace Halibut.ServiceModel
 {
     public class AsyncCompatibilityHelper
     {
-        public static MethodInfo? TryFindMatchingSyncMethod(MethodInfo asyncMethodInfo, Type syncServiceInterfaceType)
+        public static MethodInfo? TryFindMatchingSyncMethod(MethodInfo asyncMethodInfo, Type syncServiceInterfaceType, bool dropHalibutProxyOptionsFromAsyncMethod)
         {
             if (!asyncMethodInfo.Name.EndsWith("Async"))
             {
@@ -15,7 +15,13 @@ namespace Halibut.ServiceModel
             }
                 
             var syncMethodName = SyncMethodName(asyncMethodInfo);
-            return syncServiceInterfaceType.GetMethod(syncMethodName, asyncMethodInfo.GetParameters().Select(p => p.ParameterType).ToArray());
+            
+            var paramsToLookFor = asyncMethodInfo.GetParameters().Select(p => p.ParameterType).ToArray();
+            if (dropHalibutProxyOptionsFromAsyncMethod && paramsToLookFor.Length > 0 && paramsToLookFor.Last() == typeof(HalibutProxyRequestOptions))
+            {
+                 paramsToLookFor = paramsToLookFor.Take(paramsToLookFor.Length - 1).ToArray();
+            }
+            return syncServiceInterfaceType.GetMethod(syncMethodName, paramsToLookFor);
         }
 
         static string SyncMethodName(MethodInfo asyncMethodInfo)
@@ -23,9 +29,9 @@ namespace Halibut.ServiceModel
             return asyncMethodInfo.Name.Substring(0, asyncMethodInfo.Name.Length - "Async".Length);
         }
 
-        public static MethodInfo FindMatchingSyncMethod(MethodInfo asyncMethodInfo, Type syncServiceInterfaceType)
+        public static MethodInfo FindMatchingSyncMethod(MethodInfo asyncMethodInfo, Type syncServiceInterfaceType, bool dropHalibutProxyOptionsFromAsyncMethod)
         {
-            var syncMethodInfo = TryFindMatchingSyncMethod(asyncMethodInfo, syncServiceInterfaceType);
+            var syncMethodInfo = TryFindMatchingSyncMethod(asyncMethodInfo, syncServiceInterfaceType, dropHalibutProxyOptionsFromAsyncMethod);
             if (syncMethodInfo == null)
             {
                 throw new Exception( $"Could not find an async counterpart for: '{asyncMethodInfo}' we looked for {SyncMethodName(asyncMethodInfo)} but could " +

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -54,7 +54,7 @@ namespace Halibut.ServiceModel
 
         async Task<(MethodInfo, object)> MakeRpcCall(MethodInfo asyncMethod, object[] args)
         {
-            var serviceMethod = AsyncCompatibilityHelper.FindMatchingSyncMethod(asyncMethod, contractType);
+            var serviceMethod = AsyncCompatibilityHelper.FindMatchingSyncMethod(asyncMethod, contractType, true);
 
             if (!configured)
                 throw new Exception("Proxy not configured");


### PR DESCRIPTION
# Background

Fixes async client proxy support which have `HalibutProxyRequestOptions`.

All usage fixture tests and bad certs tests are now tested in the async and sync paths.


[SC-54458]

# Results

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
