### PR TITLE
Make IConnectionFactory support async

### DIFF
--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests.Transport
         {
             connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, GetProtocol, Substitute.For<ILog>());
             connectionFactory = Substitute.For<IConnectionFactory>();
-            connectionFactory.EstablishNewConnection(GetProtocol, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>()).Returns(connection);
+            connectionFactory.EstablishNewConnection(GetProtocol, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(connection);
         }
 
         [Test]

--- a/source/Halibut/Transport/IConnectionFactory.cs
+++ b/source/Halibut/Transport/IConnectionFactory.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
 
@@ -6,7 +7,8 @@ namespace Halibut.Transport
 {
     public interface IConnectionFactory
     {
-        IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log);
         IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
+        
+        Task<IConnection> EstablishNewConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -335,6 +335,8 @@ namespace Halibut.Transport.Proxy
         
         async Task SendConnectionCommandAsync(string host, int port, CancellationToken cancellationToken)
         {
+            // TODO - ASYNC ME UP!
+            // This stream needs to be wrapped into a TimeoutStream
             var stream = TcpClient.GetStream();
             var connectCmd = GetConnectCmd(host, port);
             var request = Encoding.ASCII.GetBytes(connectCmd);

--- a/source/Halibut/Transport/Proxy/IProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/IProxyClient.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Net.Sockets;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.Transport.Proxy
 {
@@ -90,6 +91,8 @@ namespace Halibut.Transport.Proxy
         /// port.  
         /// </remarks>
         TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout, CancellationToken cancellationToken);
+        
+        Task<TcpClient> CreateConnectionAsync(string destinationHost, int destinationPort, TimeSpan timeout, CancellationToken cancellationToken);
     }
 }
     

--- a/source/Halibut/Transport/TcpClientExtensions.cs
+++ b/source/Halibut/Transport/TcpClientExtensions.cs
@@ -18,6 +18,11 @@ namespace Halibut.Transport
         {
             ConnectWithTimeout(client, remoteUri.Host, remoteUri.Port, timeout, cancellationToken);
         }
+        
+        public static async Task ConnectWithTimeoutAsync(this TcpClient client, Uri remoteUri, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            await ConnectWithTimeoutAsync(client, remoteUri.Host, remoteUri.Port, timeout, cancellationToken);
+        }
 
         public static void ConnectWithTimeout(this TcpClient client, string host, int port, TimeSpan timeout)
         {
@@ -27,6 +32,11 @@ namespace Halibut.Transport
         public static void ConnectWithTimeout(this TcpClient client, string host, int port, TimeSpan timeout, CancellationToken cancellationToken)
         {
             Connect(client, host, port, timeout, cancellationToken).GetAwaiter().GetResult();
+        }
+        
+        public static async Task ConnectWithTimeoutAsync(this TcpClient client, string host, int port, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            await Connect(client, host, port, timeout, cancellationToken);
         }
 
         static async Task Connect(TcpClient client, string host, int port, TimeSpan timeout, CancellationToken cancellationToken)

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -56,7 +56,11 @@ namespace Halibut.Transport
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
             var ssl = new SslStream(stream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
+            
+            // TODO - ASYNC ME UP!
+            // This should take a cancellation token.
             await ssl.AuthenticateAsClientAsync(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(clientCertificate), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
+            
             await ssl.WriteAsync(MxLine, 0, MxLine.Length, cancellationToken);
             await ssl.FlushAsync(cancellationToken);
 


### PR DESCRIPTION
# Background

Makes IConnectionFactory support async, nothing calls these async methods yet.

[SC-53211]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
