### PR TITLE
Convert test fixtures to use async code path

### DIFF
--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -151,6 +151,7 @@ namespace Halibut.Tests
                     point.RetryCountLimit = 999999;
                 });
 
+                var echoCallThatShouldEventuallySucceed = Task.Run(() => echoService.SayHelloAsync("hello"));
                 while (tcpConnectionsCreatedCounter.ConnectionsCreatedCount < 5)
                 {
                     Logger.Information("TCP count is at: {Count}", tcpConnectionsCreatedCounter.ConnectionsCreatedCount);
@@ -158,7 +159,7 @@ namespace Halibut.Tests
                 }
                 clientAndService.PortForwarder.ReturnToNormalMode();
 
-                await echoService.SayHelloAsync("hello");
+                await echoCallThatShouldEventuallySucceed;
             }
         }
     }

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientDoSomeActionService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientDoSomeActionService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientDoSomeActionService
+    {
+        Task ActionAsync();
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientReadDataStreamService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientReadDataStreamService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncReadDataStreamService
+    {
+        Task<long> SendDataAsync(params DataStream[] dataStreams);
+    }
+}


### PR DESCRIPTION
This PR converts the following test fixtures to use the async code path, as per [sc-54458]:
* FailureModesFixture
* ListeningConnectRetryFixture
* ListeningTentatclesUseAPoolOfConnectionsFixture