### PR TITLE
Make many attempts to listen for web sockets

### DIFF
--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -274,6 +274,7 @@ namespace Halibut.Tests.Support
 
         public async Task<ClientAndService> Build(CancellationToken cancellationToken)
         {
+            var logger = new SerilogLoggerBuilder().Build().ForContext<LatestClientAndLatestServiceBuilder>();
             CancellationTokenSource cancellationTokenSource = new();
             
             serviceFactory ??= new DelegateServiceFactory();
@@ -333,16 +334,11 @@ namespace Halibut.Tests.Support
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
-                using var tcpPortConflictLock = await TcpPortHelper.WaitForLock(cancellationToken);
-                var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();
-                var webSocketPath = Guid.NewGuid().ToString();
-                var webSocketListeningUrl = $"https://+:{webSocketListeningPort}/{webSocketPath}";
-                var webSocketSslCertificateBindingAddress = $"0.0.0.0:{webSocketListeningPort}";
+                ;
+                var webSocketListeningInfo = await TryListenWebSocket.WebSocketListeningPort(logger, client, cancellationToken);
+                var webSocketListeningPort = webSocketListeningInfo.WebSocketListeningPort;
 
-                client.ListenWebSocket(webSocketListeningUrl);
-                tcpPortConflictLock.Dispose();
-
-                var webSocketSslCertificate = new WebSocketSslCertificateBuilder(webSocketSslCertificateBindingAddress)
+                var webSocketSslCertificate = new WebSocketSslCertificateBuilder(webSocketListeningInfo.WebSocketSslCertificateBindingAddress)
                     .WithCertificate(clientCertAndThumbprint)
                     .Build();
                 disposableCollection.Add(webSocketSslCertificate);
@@ -350,14 +346,14 @@ namespace Halibut.Tests.Support
                 serviceUri = new Uri("poll://SQ-TENTAPOLL");
                 if (service != null)
                 {
-                    portForwarder = portForwarderFactory?.Invoke(webSocketListeningPort);
+                    portForwarder = portForwarderFactory?.Invoke(webSocketListeningInfo.WebSocketListeningPort);
 
                     if (portForwarder != null)
                     {
                         webSocketListeningPort = portForwarder.ListeningPort;
                     }
 
-                    var webSocketServiceEndpointUri = new Uri($"wss://localhost:{webSocketListeningPort}/{webSocketPath}");
+                    var webSocketServiceEndpointUri = new Uri($"wss://localhost:{webSocketListeningPort}/{webSocketListeningInfo.WebSocketPath}");
                     service.Poll(serviceUri, new ServiceEndPoint(webSocketServiceEndpointUri, serviceTrustsThumbprint, httpProxyDetails));
                 }
             }

--- a/source/Halibut.Tests/Support/TryListenWebSocket.cs
+++ b/source/Halibut.Tests/Support/TryListenWebSocket.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
@@ -16,7 +17,7 @@ namespace Halibut.Tests.Support
                 {
                     return await WebSocketListeningPort(client, cancellationToken);
                 }
-                catch (Exception e)
+                catch (HttpListenerException e)
                 {
                     logger.Warning(e, "Failed to listen for websocket, trying again.");
                 }

--- a/source/Halibut.Tests/Support/TryListenWebSocket.cs
+++ b/source/Halibut.Tests/Support/TryListenWebSocket.cs
@@ -15,16 +15,16 @@ namespace Halibut.Tests.Support
             {
                 try
                 {
-                    return await WebSocketListeningPort(client, cancellationToken);
+                    return await WebSocketListeningPortAttemptOnce(client, cancellationToken);
                 }
                 catch (HttpListenerException e)
                 {
                     logger.Warning(e, "Failed to listen for websocket, trying again.");
                 }
             }
-            return await WebSocketListeningPort(client, cancellationToken);
+            return await WebSocketListeningPortAttemptOnce(client, cancellationToken);
         }
-        static async Task<ListeningWebSocket> WebSocketListeningPort(HalibutRuntime client, CancellationToken cancellationToken)
+        static async Task<ListeningWebSocket> WebSocketListeningPortAttemptOnce(HalibutRuntime client, CancellationToken cancellationToken)
         {
             using var tcpPortConflictLock = await TcpPortHelper.WaitForLock(cancellationToken);
             var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();

--- a/source/Halibut.Tests/Support/TryListenWebSocket.cs
+++ b/source/Halibut.Tests/Support/TryListenWebSocket.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Halibut.Tests.Support
+{
+    public class TryListenWebSocket
+    {
+        public static async Task<ListeningWebSocket> WebSocketListeningPort(ILogger logger, HalibutRuntime client, CancellationToken cancellationToken)
+        {
+            logger = logger.ForContext<TryListenWebSocket>();
+            for (int i = 0; i < 9; i++)
+            {
+                try
+                {
+                    return await WebSocketListeningPort(client, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    logger.Warning(e, "Failed to listen for websocket, trying again.");
+                }
+            }
+            return await WebSocketListeningPort(client, cancellationToken);
+        }
+        static async Task<ListeningWebSocket> WebSocketListeningPort(HalibutRuntime client, CancellationToken cancellationToken)
+        {
+            using var tcpPortConflictLock = await TcpPortHelper.WaitForLock(cancellationToken);
+            var webSocketListeningPort = TcpPortHelper.FindFreeTcpPort();
+            var webSocketPath = Guid.NewGuid().ToString();
+            var webSocketListeningUrl = $"https://+:{webSocketListeningPort}/{webSocketPath}";
+            var webSocketSslCertificateBindingAddress = $"0.0.0.0:{webSocketListeningPort}";
+
+            client.ListenWebSocket(webSocketListeningUrl);
+            return new ListeningWebSocket(webSocketPath, webSocketSslCertificateBindingAddress, webSocketListeningPort);
+        }
+    }
+
+    public class ListeningWebSocket
+    {
+        public string WebSocketPath { get; }
+        public string WebSocketSslCertificateBindingAddress { get; }
+        public int WebSocketListeningPort { get; }
+
+        public ListeningWebSocket(string webSocketPath, string webSocketSslCertificateBindingAddress, int webSocketListeningPort)
+        {
+            this.WebSocketPath = webSocketPath;
+            this.WebSocketSslCertificateBindingAddress = webSocketSslCertificateBindingAddress;
+            this.WebSocketListeningPort = webSocketListeningPort;
+        }
+    }
+}


### PR DESCRIPTION
# Background

Try many times to start listening on a websocket.

In an effort to avoid:

```
System.Net.HttpListenerException : The process cannot access the file because it is being used by another process
   at System.Net.HttpListener.AddAllPrefixes()
   at System.Net.HttpListener.Start()
   at Halibut.Transport.SecureWebSocketListener.Start() in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut\Transport\SecureWebSocketListener.cs:line 64
   at Halibut.HalibutRuntime.ListenWebSocket(String endpoint) in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut\HalibutRuntime.cs:line 135
   at Halibut.Tests.Support.LatestClientAndLatestServiceBuilder.<Build>d__50.MoveNext() in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut.Tests\Support\LatestClientAndLatestServiceBuilder.cs:line 346
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Halibut.Tests.Support.LatestClientAndLatestServiceBuilder.<Halibut-Tests-Support-IClientAndServiceBuilder-Build>d__49.MoveNext() in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut.Tests\Support\LatestClientAndLatestServiceBuilder.cs:line 277
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Halibut.Tests.CancellationViaClientProxyFixture.<CancellationCanBeDoneViaClientProxy>d__0.MoveNext() in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut.Tests\CancellationViaClientProxyFixture.cs:line 24
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
