### PR TITLE
Fixing race condition in unit test

### DIFF
--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -150,7 +150,7 @@ namespace Halibut.Tests.ServiceModel
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
                 .Build();
             var request = new RequestMessageBuilder(endpoint)
-                .WithServiceEndpoint(seb => seb.WithPollingRequestQueueTimeout(TimeSpan.FromMilliseconds(200)))
+                .WithServiceEndpoint(seb => seb.WithPollingRequestQueueTimeout(TimeSpan.FromMilliseconds(1000)))
                 .Build();
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
@@ -158,7 +158,7 @@ namespace Halibut.Tests.ServiceModel
             var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, CancellationToken);
             var dequeued = await sut.DequeueAsync(CancellationToken);
 
-            await Task.Delay(1000, CancellationToken);
+            await Task.Delay(2000, CancellationToken);
 
             await sut.ApplyResponse(expectedResponse, request.Destination);
 


### PR DESCRIPTION
# Background

[It was found](https://octopusdeploy.slack.com/archives/C04JFJXECS1/p1690956422930799?thread_ts=1690952140.816069&cid=C04JFJXECS1) that the `QueueAndWait_WhenRequestIsDequeued_ButPollingRequestQueueTimeoutIsReached_ShouldWaitTillRequestRespondsAndClearRequest` test would sometimes fail.

The error was always `Expected object not to be <null>` coming from this line `dequeued.Should().NotBeNull().And.Be(request);`

# Results

## Before
The only way this could return null was if there was:
- Nothing queued (which is not true in this case)
- Transfer had not yet begun, but had completed already

The second option can happen if there is a timeout. This is possible if the task for `StartQueueAndWaitAndWaitForRequestToBeQueued` executes to the point where the timeout occurs, and then calls `DequeueAsync`.

Adding a manual delay here replicated the failure 100%

## After
Since the timeout was set quite low (200ms), this increased the chance of this happening.

Because this is a 'timeout' test, we are at the mercy of the timing gods a little.

So the solution was to simply increase the timeout to 1000ms to encourage `DequeueAsync` to be called before `StartQueueAndWaitAndWaitForRequestToBeQueued` has a chance to time out.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
