### PR TITLE
Various changes to improve test stability

### DIFF
--- a/source/Halibut.Tests/BaseTest.cs
+++ b/source/Halibut.Tests/BaseTest.cs
@@ -10,6 +10,7 @@ namespace Halibut.Tests
     public class BaseTest
     {
         CancellationTokenSource? cancellationTokenSource;
+        CancellationTokenRegistration? cancellationTokenRegistration;
         public CancellationToken CancellationToken { get; private set; }
         public ILogger Logger { get; private set; } = null!;
 
@@ -20,7 +21,7 @@ namespace Halibut.Tests
             Logger.Information("Test started");
             cancellationTokenSource = new CancellationTokenSource(TestTimeoutAttribute.TestTimeoutInMilliseconds() - (int) TimeSpan.FromSeconds(5).TotalMilliseconds);
             CancellationToken = cancellationTokenSource.Token;
-            CancellationToken.Register(() =>
+            cancellationTokenRegistration = CancellationToken.Register(() =>
             {
                 Logger.Error("The test timed out.");
                 Assert.Fail("The test timed out.");
@@ -31,11 +32,8 @@ namespace Halibut.Tests
         public void TearDown()
         {
             Logger.Information("Tearing down");
-            if (cancellationTokenSource != null)
-            {
-                cancellationTokenSource.Dispose();
-                cancellationTokenSource = null;
-            }
+            cancellationTokenRegistration?.Dispose();
+            cancellationTokenSource?.Dispose();
         }
     }
 }

--- a/source/Halibut.Tests/BumpThreadPoolForAllTests.cs
+++ b/source/Halibut.Tests/BumpThreadPoolForAllTests.cs
@@ -12,8 +12,11 @@ namespace Halibut.Tests
             [OneTimeSetUp]
             public void GlobalSetup()
             {
-                ThreadPool.SetMaxThreads(Int32.MaxValue, Int32.MaxValue);
-                ThreadPool.SetMinThreads(4000, 4000);
+                var minWorkerPoolThreads = 5000;
+                var minCompletionPortThreads = 5000;
+                ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
+                ThreadPool.SetMaxThreads(Math.Max(minWorkerPoolThreads, maxWorkerThreads), Math.Max(minCompletionPortThreads, maxCompletionPortThreads));
+                ThreadPool.SetMinThreads(minWorkerPoolThreads, minCompletionPortThreads);
             }
         }
     }

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -109,7 +109,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Trace)
+                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
                        .Build(CancellationToken))

--- a/source/Halibut.Tests/LowerHalibutLimitsForAllTests.cs
+++ b/source/Halibut.Tests/LowerHalibutLimitsForAllTests.cs
@@ -8,7 +8,7 @@ namespace Halibut.Tests
     [SetUpFixture]
     public class LowerHalibutLimitsForAllTests
     {
-        public static readonly TimeSpan HalftheTcpRecieveTimeout = TimeSpan.FromSeconds(22.5);
+        public static readonly TimeSpan HalfTheTcpReceiveTimeout = TimeSpan.FromSeconds(22.5);
         
         [OneTimeSetUp]
         public static void LowerHalibutLimits()
@@ -23,8 +23,8 @@ namespace Halibut.Tests
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.ConnectionErrorRetryTimeout), TimeSpan.FromSeconds(66)); // Must always be greater than the heartbeat timeout.
             
             // Intentionally set higher than the heart beat, since some tests need to determine that the hart beat timeout applies.
-            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientSendTimeout), HalftheTcpRecieveTimeout + HalftheTcpRecieveTimeout);
-            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientReceiveTimeout), HalftheTcpRecieveTimeout + HalftheTcpRecieveTimeout);
+            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientSendTimeout), HalfTheTcpReceiveTimeout + HalfTheTcpReceiveTimeout);
+            halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientReceiveTimeout), HalfTheTcpReceiveTimeout + HalfTheTcpReceiveTimeout);
             
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientHeartbeatSendTimeout), TimeSpan.FromSeconds(15));
             halibutLimitType.ReflectionSetFieldValue(nameof(HalibutLimits.TcpClientHeartbeatReceiveTimeout), TimeSpan.FromSeconds(15));

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -15,6 +15,7 @@ using NUnit.Framework;
 
 namespace Halibut.Tests
 {
+    [Parallelizable(ParallelScope.Children)]
     public class ParallelRequestsFixture : BaseTest
     {
         [Test]

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -9,7 +9,6 @@ using Halibut.ServiceModel;
 using Halibut.Tests.Builders;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Transport.Protocol;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using NUnit.Framework;
 
 namespace Halibut.Tests.ServiceModel
@@ -236,6 +235,7 @@ namespace Halibut.Tests.ServiceModel
         }
 
         [Test]
+        [NonParallelizable]
         public async Task QueueAndWait_Can_Queue_Dequeue_Apply_VeryLargeNumberOfRequests()
         {
             // Arrange

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         Version? version = null;
         Func<int, PortForwarder>? portForwarderFactory;
         Func<HttpProxyService>? proxyFactory;
-        LogLevel halibutLogLevel;
+        LogLevel halibutLogLevel = LogLevel.Info;
         OldServiceAvailableServices availableServices = new(false, false);
         bool hasService = true;
         ForceClientProxyType? forceClientProxyType;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -36,7 +36,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         IComplexObjectService complexObjectService = new ComplexObjectService();
         IReadDataStreamService readDataStreamService = new ReadDataStreamService();
         Func<int, PortForwarder>? portForwarderFactory;
-        LogLevel halibutLogLevel;
+        LogLevel halibutLogLevel = LogLevel.Info;
         bool withTentacleServices = false;
         ILockService lockService;
         ICountingService countingService;

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -41,7 +41,7 @@ namespace Halibut.Tests.Support
         Reference<PortForwarder>? portForwarderReference;
         Func<RetryPolicy>? pollingReconnectRetryPolicy;
         Func<HttpProxyService>? proxyFactory;
-        LogLevel halibutLogLevel = LogLevel.Trace;
+        LogLevel halibutLogLevel = LogLevel.Info;
         ConcurrentDictionary<string, ILog>? clientInMemoryLoggers;
         ConcurrentDictionary<string, ILog>? serviceInMemoryLoggers;
         

--- a/source/Halibut.Tests/Support/TestCases/NetworkConditionTestCase.cs
+++ b/source/Halibut.Tests/Support/TestCases/NetworkConditionTestCase.cs
@@ -11,8 +11,8 @@ namespace Halibut.Tests.Support.TestCases
             NetworkConditionTestCase.NetworkConditionPerfect,
             NetworkConditionTestCase.NetworkCondition20MsLatency,
             NetworkConditionTestCase.NetworkCondition20MsLatencyWithLastByteArrivingLate,
-            NetworkConditionTestCase.NetworkCondition20MsLatencyWithLast2BytesArrivingLate,
-            NetworkConditionTestCase.NetworkCondition20MsLatencyWithLast3BytesArrivingLate
+            //NetworkConditionTestCase.NetworkCondition20MsLatencyWithLast2BytesArrivingLate,
+            //NetworkConditionTestCase.NetworkCondition20MsLatencyWithLast3BytesArrivingLate
         };
 
         public static NetworkConditionTestCase NetworkConditionPerfect = 
@@ -27,13 +27,13 @@ namespace Halibut.Tests.Support.TestCases
             new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(1).Build(),
                 "20ms send delay with last byte arriving late");
 
-        public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLast2BytesArrivingLate =
-            new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(2).Build(),
-                "20ms send delay with last 2 bytes arriving late");
+        //public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLast2BytesArrivingLate =
+        //    new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(2).Build(),
+        //        "20ms send delay with last 2 bytes arriving late");
 
-        public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLast3BytesArrivingLate =
-            new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(3).Build(),
-                "20ms send delay with last 3 bytes arriving late");
+        //public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLast3BytesArrivingLate =
+        //    new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(3).Build(),
+        //        "20ms send delay with last 3 bytes arriving late");
 
         public Func<int, ILogger, PortForwarder>? PortForwarderFactory { get; }
 

--- a/source/Halibut.Tests/Support/TryListenWebSocket.cs
+++ b/source/Halibut.Tests/Support/TryListenWebSocket.cs
@@ -11,7 +11,7 @@ namespace Halibut.Tests.Support
         public static async Task<ListeningWebSocket> WebSocketListeningPort(ILogger logger, HalibutRuntime client, CancellationToken cancellationToken)
         {
             logger = logger.ForContext<TryListenWebSocket>();
-            for (int i = 0; i < 9; i++)
+            for (var i = 0; i < 9; i++)
             {
                 try
                 {
@@ -20,8 +20,10 @@ namespace Halibut.Tests.Support
                 catch (HttpListenerException e)
                 {
                     logger.Warning(e, "Failed to listen for websocket, trying again.");
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
                 }
             }
+
             return await WebSocketListeningPortAttemptOnce(client, cancellationToken);
         }
         static async Task<ListeningWebSocket> WebSocketListeningPortAttemptOnce(HalibutRuntime client, CancellationToken cancellationToken)

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -39,7 +39,7 @@ namespace Halibut.Tests.Timeouts
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
                 sw.Elapsed.Should().BeGreaterThan(HalibutLimits.TcpClientReceiveTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
-                    .BeLessThan(HalibutLimits.TcpClientReceiveTimeout + LowerHalibutLimitsForAllTests.HalftheTcpRecieveTimeout, "We should be timing out on the tcp receive timeout");
+                    .BeLessThan(HalibutLimits.TcpClientReceiveTimeout + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
                 
                 echo.SayHello("A new request can be made on a new unpaused TCP connection");
             }
@@ -71,7 +71,7 @@ namespace Halibut.Tests.Timeouts
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
                 sw.Elapsed.Should().BeGreaterThan(HalibutLimits.TcpClientReceiveTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
-                    .BeLessThan(HalibutLimits.TcpClientReceiveTimeout + LowerHalibutLimitsForAllTests.HalftheTcpRecieveTimeout, "We should be timing out on the tcp receive timeout");
+                    .BeLessThan(HalibutLimits.TcpClientReceiveTimeout + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
 
                 echo.SayHello("A new request can be made on a new unpaused TCP connection");
             }
@@ -81,7 +81,8 @@ namespace Halibut.Tests.Timeouts
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task WhenThenNetworkIsPaused_WhileSendingARequestMessage_ATcpWriteTimeoutOccurs_and_FurtherRequestsCanBeMade(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            int numberOfBytesBeforePausingAStream = 1024 * 1024; // 1MB
+            var numberOfBytesBeforePausingAStream = 1024 * 1024; // 1MB
+
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
@@ -112,14 +113,14 @@ namespace Halibut.Tests.Timeouts
                     addControlMessageTimeout += HalibutLimits.TcpClientHeartbeatSendTimeout;
                 }
 
-                var expecedTimeOut = HalibutLimits.TcpClientSendTimeout // What we actually expected. 
+                var expectedTimeOut = HalibutLimits.TcpClientSendTimeout // What we actually expected. 
                                      + HalibutLimits.TcpClientSendTimeout // an extra timeout because of the dispose method of the zip stream (see below)
                                      + addControlMessageTimeout;
-                sw.Elapsed.Should().BeGreaterThan( expecedTimeOut- TimeSpan.FromSeconds(2), 
+                sw.Elapsed.Should().BeGreaterThan( expectedTimeOut- TimeSpan.FromSeconds(2), 
                         "We 'should' wait the send timeout amount of time NOT the heart beat timeout, however when an error occurs writing to the zip (deflate)" +
                                 "stream we also call dispose which again attempts to write to the stream. Thus we wait 2 times the TcpClientSendTimeout.") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
-                    .BeLessThan(expecedTimeOut + LowerHalibutLimitsForAllTests.HalftheTcpRecieveTimeout, 
+                    .BeLessThan(expectedTimeOut + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout, 
                         "We 'should' wait the send timeout amount of time, however when an error occurs writing to the zip (deflate)" +
                             "stream we also call dispose which again attempts to write to the stream. Thus we wait 2 times the TcpClientSendTimeout.");
 
@@ -141,13 +142,12 @@ namespace Halibut.Tests.Timeouts
                 echo.SayHello("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
 
                 var echoServiceTheErrorWillHappenOn = clientAndService.CreateClient<IEchoService>(IncreasePollingQueueTimeout());
-
                 
                 var sw = Stopwatch.StartNew();
                 var e = Assert.Throws<HalibutClientException>(() => echoServiceTheErrorWillHappenOn.CountBytes(DataStreamUtil.From(
                     firstSend: "hello",
                     andThenRun: portForwarderRef.Value!.PauseExistingConnections,
-                    thenSend: "All done" + Some.RandomAsciiStringOfLength(100*1024*1024)
+                    thenSend: "All done" + Some.RandomAsciiStringOfLength(10*1024*1024)
                 )));
                 AssertExceptionLooksLikeAWriteTimeout(e);
                 sw.Stop();
@@ -167,9 +167,8 @@ namespace Halibut.Tests.Timeouts
                 var expectedTimeout = HalibutLimits.TcpClientSendTimeout + addControlMessageTimeout;
                 sw.Elapsed.Should().BeGreaterThan(expectedTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
-                    .BeLessThan(expectedTimeout + LowerHalibutLimitsForAllTests.HalftheTcpRecieveTimeout, "We should be timing out on the tcp receive timeout");
-                
-                
+                    .BeLessThan(expectedTimeout + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
+
                 echo.SayHello("A new request can be made on a new unpaused TCP connection");
             }
         }

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -25,7 +25,14 @@ namespace Halibut.Tests.Transport
                 {
                     using (var counter = new PerformanceCounter("Process", "ID Process", instance, true))
                     {
-                        return pid == counter.RawValue;
+                        try
+                        {
+                            return pid == counter.RawValue;
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            return false;
+                        }
                     }
                 });
 

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -37,7 +37,7 @@ namespace Halibut.Tests
         }
         
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testAsyncAndSyncClients: true)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testAsyncAndSyncClients: true, testNetworkConditions: false)]
         public async Task LargeMessages(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
@@ -166,7 +166,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testAsyncAndSyncClients: true)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testAsyncAndSyncClients: true, testNetworkConditions: false)]
         public async Task OctopusCanSendAndReceiveComplexObjects_WithMultipleDataStreams(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase
@@ -199,7 +199,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testAsyncAndSyncClients: true)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testAsyncAndSyncClients: true, testNetworkConditions: false)]
         public async Task OctopusCanSendAndReceiveComplexObjects_WithMultipleComplexChildren(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var childPayload1 = "Child Payload #1";

--- a/source/Halibut/Transport/Caching/ResponseCache.cs
+++ b/source/Halibut/Transport/Caching/ResponseCache.cs
@@ -14,7 +14,7 @@ namespace Halibut.Transport.Caching
     /// <returns>True to allow the error response message to be cached, otherwise false.</returns>
     public delegate bool OverrideErrorResponseMessageCachingAction(ResponseMessage responseMessage);
 
-    class ResponseCache
+    class ResponseCache : IDisposable
     {
         readonly MemoryCache responseMessageCache = new("ResponseMessageCache");
 
@@ -87,6 +87,11 @@ namespace Halibut.Transport.Caching
         {
             public ServiceEndPoint EndPoint { get; set; }
             public ResponseMessage ResponseMessage { get; set; }
+        }
+
+        public void Dispose()
+        {
+            responseMessageCache?.Dispose();
         }
     }
 }


### PR DESCRIPTION
# Background

Halibut Tests are becoming very flakey. CPU and Memory usage locally was found to be very high. This PR contains a number of fixes to try and stabilise the tests including;

- Cancellation Token and Registration Memory Leak
- ResponseCache disposal
- Lower parallel tests for team city
- Reduce some tests using very large arrays of data
- Wait between retries for websocket port
- Isolate some tests that are resource intensive to run in isolation or scoped to class/item
- Made log level Info by default
- Removed 2 network condition test variations
- Increased thread pool a bit
- Stopped testing network conditions for some tests (the port forwarder is not efficient with memory usage in these scenarios)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
