### PR TITLE
Disabling this test from running on Team City as it takes far too long.

### DIFF
--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -236,6 +237,7 @@ namespace Halibut.Tests.ServiceModel
         }
 
         [Test]
+        [Ignore("This test takes way too long on Team City")]
         public async Task QueueAndWait_Can_Queue_Dequeue_Apply_VeryLargeNumberOfRequests()
         {
             // Arrange


### PR DESCRIPTION
# Background

This test is taking too long. For now, let's disable it and decide what to do about it in [sc-55623]

