### PR TITLE
Add HalibutRuntime.HandleMessageAsync

### DIFF
--- a/source/Halibut/Transport/ISecureClient.cs
+++ b/source/Halibut/Transport/ISecureClient.cs
@@ -11,6 +11,6 @@ namespace Halibut.Transport
 
         [Obsolete]
         void ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken);
-        Task ExecuteTransactionAsync(ExchangeActionWithCancellationAsync protocolHandler, CancellationToken cancellationToken);
+        Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -11,8 +11,7 @@ namespace Halibut.Transport.Protocol
 
     [Obsolete]
     public delegate void ExchangeAction(MessageExchangeProtocol protocol);
-    public delegate Task ExchangeActionAsync(MessageExchangeProtocol protocol);
-    public delegate Task ExchangeActionWithCancellationAsync(MessageExchangeProtocol protocol, CancellationToken cancellationToken);
+    public delegate Task ExchangeActionAsync(MessageExchangeProtocol protocol, CancellationToken cancellationToken);
 
     /// <summary>
     /// Implements the core message exchange protocol for both the client and server.

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -131,7 +131,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        public async Task ExecuteTransactionAsync(ExchangeActionWithCancellationAsync protocolHandler, CancellationToken cancellationToken)
+        public async Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, CancellationToken cancellationToken)
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -359,7 +359,7 @@ namespace Halibut.Transport
         {
             log.Write(EventType.Diagnostic, "Begin message exchange");
 
-            return exchangeAction(exchangeProtocolBuilder(stream, log));
+            return exchangeAction(exchangeProtocolBuilder(stream, log), cts.Token);
         }
 
         bool AcceptAnySslCertificate(object sender, X509Certificate clientCertificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -141,7 +141,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        public async Task ExecuteTransactionAsync(ExchangeActionWithCancellationAsync protocolHandler, CancellationToken cancellationToken)
+        public async Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, CancellationToken cancellationToken)
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -129,7 +129,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        public async Task ExecuteTransactionAsync(ExchangeActionWithCancellationAsync protocolHandler, CancellationToken cancellationToken)
+        public async Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, CancellationToken cancellationToken)
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -209,7 +209,7 @@ namespace Halibut.Transport
         {
             log.Write(EventType.Diagnostic, "Begin message exchange");
 
-            return exchangeAction(exchangeProtocolBuilder(stream, log));
+            return exchangeAction(exchangeProtocolBuilder(stream, log), cts.Token);
         }
 
         // ReSharper disable once UnusedParameter.Local


### PR DESCRIPTION
Add an Async overload of `HalibutRuntime.HandleMessage`, as per [sc-53211].

## How to review
I converted the usages of `ExchangeActionAsync` in the two SecureListener classes to use `ExchangeActionWithCancellationAsync` instead. The SecureListener classes can then call the exchangeAction with its CancellationToken.

When HalibutRuntime goes down the async path, the CancellationToken can then be passed to the async method from `MessageExchangeProtocol`. When it goes down the sync path, the token is ignored and nothing changes.

I _think_ this makes sense, but there's a lot of passing around tokens etc, so please confirm. :)