### PR TITLE
Reduce log level for some noisy tests

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -227,7 +227,6 @@ namespace Halibut.Tests.Diagnostics
             {
                 using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithStandardServices()
-                           .WithHalibutLoggingLevel(LogLevel.Info)
                            .Build(CancellationToken))
                 {
                     var echo = clientAndService.CreateClient<IEchoService>();

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -32,7 +32,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .NoService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService>(point =>
@@ -53,7 +52,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -109,7 +107,7 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Trace)
+                       .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
                        .Build(CancellationToken))

--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Logging;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.PortForwarding;
 using Halibut.Tests.Support.TestAttributes;
@@ -29,6 +30,7 @@ namespace Halibut.Tests
                            return portForwarder;
                        })
                        .WithEchoService()
+                       .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .Build(CancellationToken))
             {
                 clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
@@ -62,6 +64,7 @@ namespace Halibut.Tests
                            return portForwarder;
                        })
                        .WithEchoService()
+                       .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .Build(CancellationToken))
             {
                 clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
@@ -98,6 +101,7 @@ namespace Halibut.Tests
                            return portForwarder;
                        })
                        .WithEchoService()
+                       .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .Build(CancellationToken))
             {
                 clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
@@ -134,6 +138,7 @@ namespace Halibut.Tests
                            return portForwarder;
                        })
                        .WithEchoService()
+                       .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .Build(CancellationToken))
             {
                 clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -22,7 +22,6 @@ namespace Halibut.Tests
         public async Task MultipleRequestsCanBeInFlightInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                .WithHalibutLoggingLevel(LogLevel.Info)
                 .WithStandardServices()
                 .Build(CancellationToken);
 
@@ -82,7 +81,6 @@ namespace Halibut.Tests
         public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                .WithHalibutLoggingLevel(LogLevel.Info)
                 .WithStandardServices()
                 .Build(CancellationToken);
             

--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -20,7 +20,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithProxy()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -41,7 +40,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithProxy()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 await clientAndService.HttpProxy!.StopAsync(CancellationToken.None);

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -22,7 +22,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();
@@ -41,7 +40,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService, IClientCachingService>();
@@ -60,7 +58,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();
@@ -79,7 +76,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService, IClientCachingService>();
@@ -98,7 +94,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();
@@ -118,7 +113,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();
@@ -143,7 +137,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();
@@ -162,14 +155,12 @@ namespace Halibut.Tests
         {
             using (var clientAndServiceOne = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var clientOne = clientAndServiceOne.CreateClient<ICachingService>();
 
                 using var clientAndServiceTwo = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithCachingService()
-                           .WithHalibutLoggingLevel(LogLevel.Info)
                            .Build(CancellationToken);
 
                     var clientTwo = clientAndServiceTwo.CreateClient<ICachingService>();
@@ -188,7 +179,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();
@@ -207,7 +197,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 clientAndService.Client.OverrideErrorResponseMessageCaching = response => response.Error.Message.Contains("CACHE ME");
@@ -232,7 +221,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var client = clientAndService.CreateClient<ICachingService>();

--- a/source/Halibut.Tests/Tentacle/WhenCallingServicesSimilarToTheOnesInTentacle.cs
+++ b/source/Halibut.Tests/Tentacle/WhenCallingServicesSimilarToTheOnesInTentacle.cs
@@ -26,7 +26,6 @@ namespace Halibut.Tests.Tentacle
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var fileTransferService = clientAndService.CreateClient<IFileTransferService>();
@@ -60,7 +59,6 @@ namespace Halibut.Tests.Tentacle
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var fileTransferService = clientAndService.CreateClient<IFileTransferService>();
@@ -103,7 +101,6 @@ namespace Halibut.Tests.Tentacle
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var scriptService = clientAndService.CreateClient<IScriptService>();
@@ -145,7 +142,6 @@ namespace Halibut.Tests.Tentacle
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var scriptService = clientAndService.CreateClient<IScriptServiceV2>();

--- a/source/Halibut.Tests/TestPortForwarderFixture.cs
+++ b/source/Halibut.Tests/TestPortForwarderFixture.cs
@@ -19,7 +19,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService>();
@@ -39,7 +38,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
@@ -59,7 +57,6 @@ namespace Halibut.Tests
                        .WithStandardServices()
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
                        .WithProxy()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService>();

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -23,7 +23,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
@@ -42,7 +41,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var random = new Random();
@@ -65,7 +63,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var svc = clientAndService.CreateClient<IMultipleParametersTestService, IAsyncClientMultipleParametersTestService>();
@@ -85,7 +82,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 
@@ -108,7 +104,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IMultipleParametersTestService, IAsyncClientMultipleParametersTestService>();
@@ -147,7 +142,6 @@ namespace Halibut.Tests
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var progressReported = new List<int>();
@@ -172,7 +166,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase
                        .CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var service = clientAndService.CreateClient<IComplexObjectService, IAsyncClientComplexObjectService>();
@@ -224,7 +217,6 @@ namespace Halibut.Tests
             using (var clientAndService = await clientAndServiceTestCase
                        .CreateTestCaseBuilder()
                        .WithStandardServices()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var service = clientAndService.CreateClient<IComplexObjectService, IAsyncClientComplexObjectService>();

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -22,7 +22,6 @@ namespace Halibut.Tests
             var services = new SingleServiceFactory(new object(), typeof(EchoService));
 
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithServiceFactory(services)
                        .Build(CancellationToken))

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -18,7 +18,6 @@ namespace Halibut.Tests
         public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                       .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();


### PR DESCRIPTION
# Background

Reduce log level for some noisy tests.

We have some tests that purposefully create failure scenarios e.g. to test reconnects etc. Some of these create a significant amount of noise in the logs (and probably hurt the performance of the test run a bit).

This PR bumps the logging level to Fatal for those tests I've spotted so far

Also clean up `.WithHalibutLoggingLevel(LogLevel.Info)` as this is the default

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
