### PR TITLE
Putting in greater measures to fix flaky test

### DIFF
--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -122,7 +122,7 @@ namespace Halibut.Tests.ServiceModel
 
             // Act
             var stopwatch = Stopwatch.StartNew();
-            var (queueAndWaitTask, _) = await QueueAndDequeueRequest(sut, request, CancellationToken);
+            var (queueAndWaitTask, _) = await QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(sut, request, CancellationToken);
             var response = await queueAndWaitTask;
 
             // Assert
@@ -153,7 +153,7 @@ namespace Halibut.Tests.ServiceModel
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
             // Act
-            var (queueAndWaitTask, dequeued) = await QueueAndDequeueRequest(sut, request, CancellationToken);
+            var (queueAndWaitTask, dequeued) = await QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(sut, request, CancellationToken);
 
             await Task.Delay(2000, CancellationToken);
 
@@ -538,8 +538,10 @@ namespace Halibut.Tests.ServiceModel
             return task;
         }
 
-        async Task<(Task<ResponseMessage> queueAndWaitTask, RequestMessage dequeued)> QueueAndDequeueRequest(IPendingRequestQueue sut, RequestMessage request, CancellationToken cancellationToken)
+        async Task<(Task<ResponseMessage> queueAndWaitTask, RequestMessage dequeued)> QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(IPendingRequestQueue sut, RequestMessage request, CancellationToken cancellationToken)
         {
+            //For most tests, this is not a good method to use. It is a fix for some specific tests to cope with a race condition when Team City runs out of resources (and causes tests to become flaky)
+
             while (true)
             {
                 var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, cancellationToken);


### PR DESCRIPTION
# Background

Despite a [previous attempt](https://github.com/OctopusDeploy/Halibut/pull/371), the `QueueAndWait_WhenRequestIsDequeued_ButPollingRequestQueueTimeoutIsReached_ShouldWaitTillRequestRespondsAndClearRequest` test is still flaky.

Like before, the error was always Expected object not to be <null> coming from this line dequeued.Should().NotBeNull().And.Be(request);

# Results

## Before
The cause appears to still be the same. We cannot think of another reason why this would be happening.

The tricky part is that we have a separate task that does the queuing, and we have no control over when .NET schedules the task to run. In this case, it prioritises it to run completely before `DequeueAsync` can be called.

This is why we thought increasing the timeout would work, as it would encourage .NET to run the main execution path while it was waiting for the queuing task.

## After

Increasing the timeout didn't work. Since we cannot control which thread executes in which order (and that this test usually works), we decided instead to do a loop that waits until the correct condition is met.

It was noticed that the same problem may occur in the `QueueAndWait_WhenRequestIsDequeued_ButPollingRequestQueueTimeoutIsReached_AndPollingRequestMaximumMessageProcessingTimeoutIsReached_WillStopWaitingAndClearRequest` test. Although it's failure rate is lower, it has been known to fail.

So the same fix was applied there as well.

# How to review this PR
If you can think of a way to do this without a loop (or altering the `PendingRequestQueue` itself), then we would be very happy to try it.

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
