### PR TITLE
Improve TaskExtensionFixtures with timeouts, since they fail on old windows agents.

### DIFF
--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
                 triggered = true;
             });
-            await task.TimeoutAfter(TimeSpan.FromMilliseconds(300), CancellationToken.None);
+            await task.TimeoutAfter(TimeSpan.FromMilliseconds(10000), CancellationToken.None);
             triggered.Should().Be(true, "the task should have triggered");
         }
         


### PR DESCRIPTION
# Background

These test was failing on windows agents, increasing the timeout might help.

# Results

## Before
Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.When_TaskCompletesWithinTimeout_TaskCompletesSuccessfully [link](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_TestWindowsNet60onWindows2012r2/9076864?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A9076864%29%2Cid%3A2000000501)

```
System.TimeoutException : The operation has timed out.
   at Halibut.Util.AsyncEx.TaskExtensions.TimeoutAfter(Task task, TimeSpan timeout, CancellationToken cancellationToken) in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut\Util\AsyncEx\TaskExtensions.cs:line 33
   at Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.When_TaskCompletesWithinTimeout_TaskCompletesSuccessfully() in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut.Tests\Util\AsyncEx\TaskExtensionsFixture.cs:line 24
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TimeoutCommand.<>c__DisplayClass5_0.<RunTestOnSeparateThread>b__0()
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at NUnit.Framework.Internal.Commands.TimeoutCommand.Execute(TestExecutionContext context)

```

Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.When_TaskDoesNotCompleteWithinTimeout_ThrowsTimeoutException [link](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_TestWindowsNet60onWindows2016/9076863?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandPull+Request+Details=true&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)

```
Expected triggered to be True because task should have continued executing in the background, but found False.
   at FluentAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
   at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Primitives.BooleanAssertions`1.Be(Boolean expected, String because, Object[] becauseArgs)
   at Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.When_TaskDoesNotCompleteWithinTimeout_ThrowsTimeoutException() in D:\buildAgent\workDir\ce9567031fa52250\source\Halibut.Tests\Util\AsyncEx\TaskExtensionsFixture.cs:line 41
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TimeoutCommand.<>c__DisplayClass5_0.<RunTestOnSeparateThread>b__0()
   at System.Threading.Tasks.Task`1.InnerInvoke()
```

Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.When_TaskThrowsExceptionAfterTimeout_ExceptionsAreObserved [link](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_ChainFullChain/9078084?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true&expandPull+Request+Details=true&expandBuildProblemsSection=true)

```
Expected a <System.TimeoutException> to be thrown, but found <System.ApplicationException>: "
"System.ApplicationException with message "this task threw an exception after timeout cbda4c42-e507-4a0a-9013-b882963e8fed"
     at Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.<>c__DisplayClass3_0.<<When_TaskThrowsExceptionAfterTimeout_ExceptionsAreObserved>b__0>d.MoveNext() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut.Tests\Util\AsyncEx\TaskExtensionsFixture.cs:line 96
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
     at Halibut.Util.AsyncEx.TaskExtensions.<AwaitAndSwallowExceptionsWhenTimedOut>d__1.MoveNext() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Util\AsyncEx\TaskExtensions.cs:line 51
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
     at Halibut.Util.AsyncEx.TaskExtensions.<TimeoutAfter>d__0.MoveNext() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut\Util\AsyncEx\TaskExtensions.cs:line 32
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
     at Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.<>c__DisplayClass5_0`1.<<VerifyNoUnobservedExceptions>b__1>d.MoveNext() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut.Tests\Util\AsyncEx\TaskExtensionsFixture.cs:line 140
  --- End of stack trace from previous location where exception was thrown ---
     at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
     at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
     at FluentAssertions.Specialized.AsyncFunctionAssertions`2.<InvokeWithInterceptionAsync>d__13.MoveNext()
.
   at FluentAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Specialized.DelegateAssertionsBase`2.ThrowInternal[TException](Exception exception, String because, Object[] becauseArgs)
   at FluentAssertions.Specialized.AsyncFunctionAssertions`2.<ThrowAsync>d__7`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.<VerifyNoUnobservedExceptions>d__5`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Halibut.Tests.Util.AsyncEx.TaskExtensionsFixture.<When_TaskThrowsExceptionAfterTimeout_ExceptionsAreObserved>d__3.MoveNext() in C:\BuildAgent\work\ce9567031fa52250\source\Halibut.Tests\Util\AsyncEx\TaskExtensionsFixture.cs:line 93
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
```
   
## After

...

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
