### PR TITLE
Convert ConnectionManager to async

### DIFF
--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -28,7 +28,6 @@ namespace Halibut.Transport
             var connection = await TryGetExistingConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
             if (connection != null) return connection;
             
-            // 
             return await GetConnectionByCreatingItAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
         }
 

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -25,12 +25,11 @@ namespace Halibut.Transport
 
         public async Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
-            // TODO - ASYNC ME UP!
-            await Task.CompletedTask;
-
-#pragma warning disable CS0612
-            return AcquireConnection(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
-#pragma warning restore CS0612
+            var connection = await TryGetExistingConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
+            if (connection != null) return connection;
+            
+            // 
+            return await GetConnectionByCreatingItAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
         }
 
         // Connection is Lazy instantiated, so it is safe to use. If you need to wait for it to open (eg for error handling, an openConnection method is provided)
@@ -47,6 +46,30 @@ namespace Halibut.Transport
                 return openableConnection;
             }
         }
+        
+        async Task<IConnection> TryGetExistingConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            lock (activeConnections)
+            {
+                var existingConnectionFromPool = pool.Take(serviceEndpoint);
+                if (existingConnectionFromPool != null)
+                {
+                    AddConnectionToActiveConnections(serviceEndpoint, existingConnectionFromPool);
+                }
+                return existingConnectionFromPool;
+            }
+        }
+        
+        async Task<IConnection> GetConnectionByCreatingItAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            var connection = await CreateNewConnectionWithIOAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
+            lock (activeConnections)
+            {
+                AddConnectionToActiveConnections(serviceEndpoint, connection);
+            }
+            return connection;
+        }
 
         Tuple<IConnection, Action> CreateNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
@@ -57,6 +80,12 @@ namespace Halibut.Transport
                 // ReSharper disable once UnusedVariable
                 var c = lazyConnection.Value;
             });
+        }
+        
+        async Task<IConnection> CreateNewConnectionWithIOAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            var connection = await connectionFactory.EstablishNewConnectionAsync(exchangeProtocolBuilder, serviceEndpoint, log, cancellationToken);
+            return new DisposableNotifierConnection(new Lazy<IConnection>(() => connection), OnConnectionDisposed);
         }
 
         void AddConnectionToActiveConnections(ServiceEndPoint serviceEndpoint, IConnection connection)


### PR DESCRIPTION
# Background

So we can do more.


Rather than try to convert each `sync` method to `async` in place. I think it was just easier to adjust it slightly.

[SC-53211]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
