### PR TITLE
Control the Retry policy values to stop the test from being flaky

### DIFF
--- a/source/Halibut.Tests/Util/RetryPolicyFixture.cs
+++ b/source/Halibut.Tests/Util/RetryPolicyFixture.cs
@@ -36,7 +36,6 @@ namespace Halibut.Tests.Util
 
         [Test]
         [TestCase(0)]
-        [TestCase(1.0001)]
         public void InvalidMultipliersShouldThrow(double multiplier)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new RetryPolicy(multiplier, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)));

--- a/source/Halibut/Util/RetryPolicy.cs
+++ b/source/Halibut/Util/RetryPolicy.cs
@@ -10,7 +10,6 @@ namespace Halibut.Util
         internal RetryPolicy(double backoffMultiplier, TimeSpan minimumDelay, TimeSpan maximumDelay)
         {
             if (backoffMultiplier <= 0) throw new ArgumentOutOfRangeException(nameof(backoffMultiplier), "Must be greater than zero");
-            if (backoffMultiplier > 1) throw new ArgumentOutOfRangeException(nameof(backoffMultiplier), "Must be less than or equal to one");
 
             BackoffMultiplier = backoffMultiplier;
             MinimumDelay = minimumDelay;


### PR DESCRIPTION
# Background

This test has been flaky, since it measures port close time as well.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
