### PR TITLE
Add logging to dotmemory tests, to find out why they are failing

### DIFF
--- a/source/Halibut.Tests.DotMemory/Support/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests.DotMemory/Support/TestContextConnectionLog.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Halibut.Diagnostics;
+using Halibut.Logging;
+using NUnit.Framework;
+using ILog = Halibut.Diagnostics.ILog;
+
+namespace Halibut.Tests.Support.Logging
+{
+    public class TestContextConnectionLog : ILog
+    {
+        readonly string endpoint;
+        readonly string name;
+        readonly LogLevel logLevel;
+
+        public TestContextConnectionLog(string endpoint, string name, LogLevel logLevel)
+        {
+            this.endpoint = endpoint;
+            this.name = name;
+            this.logLevel = logLevel;
+        }
+
+        public void Write(EventType type, string message, params object[] args)
+        {
+            WriteInternal(new LogEvent(type, message, null, args));
+        }
+
+        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        {
+            WriteInternal(new LogEvent(type, message, ex, args));
+        }
+
+        public IList<LogEvent> GetLogs()
+        {
+            throw new NotImplementedException();
+        }
+
+        void WriteInternal(LogEvent logEvent)
+        {
+            var logEventLogLevel = GetLogLevel(logEvent);
+
+            if (logEventLogLevel >= logLevel)
+            {
+                TestContext.WriteLine(string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEventLogLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name));
+            }
+        }
+
+        static LogLevel GetLogLevel(LogEvent logEvent)
+        {
+            switch (logEvent.Type)
+            {
+                case EventType.Error:
+                    return LogLevel.Error;
+                case EventType.Diagnostic:
+                case EventType.SecurityNegotiation:
+                case EventType.MessageExchange:
+                    return LogLevel.Trace;
+                case EventType.OpeningNewConnection:
+                    return LogLevel.Debug;
+                default:
+                    return LogLevel.Info;
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests.DotMemory/Support/TestContextLogFactory.cs
+++ b/source/Halibut.Tests.DotMemory/Support/TestContextLogFactory.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Halibut.Diagnostics;
+using Halibut.Logging;
+using ILog = Halibut.Diagnostics.ILog;
+
+namespace Halibut.Tests.Support.Logging
+{
+    public class TestContextLogFactory : ILogFactory
+    {
+        readonly Func<string, ILog> loggerFactory;
+        readonly ConcurrentDictionary<string, ILog> loggers = new();
+        readonly HashSet<Uri> endpoints = new();
+        readonly HashSet<string> prefixes = new();
+
+        public TestContextLogFactory(Func<string, ILog> loggerFactory)
+        {
+            this.loggerFactory = loggerFactory;
+        }
+
+        public TestContextLogFactory(string name, LogLevel logLevel)
+        {
+            loggerFactory = uri => new TestContextConnectionLog(uri, name, logLevel);
+        }
+
+        public Uri[] GetEndpoints()
+        {
+            lock (endpoints)
+            {
+                return endpoints.ToArray();
+            }
+        }
+
+        public string[] GetPrefixes()
+        {
+            lock (prefixes)
+            {
+                return prefixes.ToArray();
+            }
+        }
+
+        public ILog ForEndpoint(Uri endpoint)
+        {
+            endpoint = NormalizeEndpoint(endpoint);
+            lock (endpoints)
+            {
+                endpoints.Add(endpoint);
+            }
+
+            return loggers.GetOrAdd(endpoint.ToString(), e => loggerFactory(e));
+        }
+
+        public ILog ForPrefix(string prefix)
+        {
+            lock (prefixes)
+            {
+                prefixes.Add(prefix);
+            }
+
+            return loggers.GetOrAdd(prefix, e => loggerFactory(e));
+        }
+
+        static Uri NormalizeEndpoint(Uri endpoint)
+        {
+            return ServiceEndPoint.IsWebSocketAddress(endpoint)
+                ? new Uri(endpoint.AbsoluteUri.ToLowerInvariant())
+                : new Uri(endpoint.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped).TrimEnd('/').ToLowerInvariant());
+        }
+    }
+}


### PR DESCRIPTION
# Background

They failed [here](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_ChainPreviousWindowsVersions/9079986?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandPull+Request+Details=true&expandBuildChangesSection=true&expandBuildTestsSection=true&expandBuildProblemsSection=true)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
