### PR TITLE
Convert WhenCallingAMethodThatDoesNotExist to test async and sync

### DIFF
--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -41,7 +41,8 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
                 });
 
-                var error = Assert.ThrowsAsync<HalibutClientException>(() => echo.SayHelloAsync("Paul"));
+                
+                var error = (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Paul"))).And;
                 error.Message.Should().Contain("the polling endpoint did not collect the request within the allowed time");
             }
         }
@@ -56,7 +57,7 @@ namespace Halibut.Tests
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
-                var ex = Assert.ThrowsAsync<ServiceInvocationHalibutClientException>(() => echo.CrashAsync());
+                var ex = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
                 ex.Message.Should().Contain("at Halibut.TestUtils.Contracts.EchoService.Crash()").And.Contain("divide by zero");
             }
         }
@@ -119,7 +120,7 @@ namespace Halibut.Tests
                 // This loop ensures (at the time) the test shows the problem.
                 for (var i = 0; i < 128; i++)
                 {
-                    Assert.ThrowsAsync<HalibutClientException>(async () => await readDataSteamService.SendDataAsync(new DataStream(10000, stream => throw new Exception("Oh noes"))));
+                    await AssertAsync.Throws<HalibutClientException>(async () => await readDataSteamService.SendDataAsync(new DataStream(10000, stream => throw new Exception("Oh noes"))));
                 }
 
                 var received = await readDataSteamService.SendDataAsync(DataStream.FromString("hello"));

--- a/source/Halibut.Tests/FriendlyHtmlPageTests.cs
+++ b/source/Halibut.Tests/FriendlyHtmlPageTests.cs
@@ -92,7 +92,7 @@ namespace Halibut.Tests
                 var listenPort = octopus.Listen();
                 logger.Information("Got port to listen on..");
                 var sw = new Stopwatch();
-                Assert.ThrowsAsync<HttpRequestException>(() =>
+                await AssertAsync.Throws<HttpRequestException>(() =>
                 {
                     logger.Information("Sending request.");
                     sw.Start();

--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -43,7 +43,7 @@ namespace Halibut.Tests
                     point.RetryCountLimit = 20;
                 });
                 
-                Assert.ThrowsAsync<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
+                await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
 
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(20);
             }
@@ -78,7 +78,7 @@ namespace Halibut.Tests
                 });
 
                 var sw = Stopwatch.StartNew();
-                Assert.ThrowsAsync<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
+                await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
                 sw.Stop();
 
                 
@@ -115,7 +115,7 @@ namespace Halibut.Tests
                 });
 
                 var sw = Stopwatch.StartNew();
-                Assert.ThrowsAsync<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
+                await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
                 sw.Stop();
 
                 // Expected ~30s since we sleep 10s _between_ each attempt.

--- a/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
+++ b/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests
                 await echoService.SayHelloAsync("Should re-use the same connection");
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "We should use the same connection since the last was healthy");
 
-                Assert.ThrowsAsync<HalibutClientException>(() => pauseCurrentTcpConnections.ActionAsync());
+                await AssertAsync.Throws<HalibutClientException>(() => pauseCurrentTcpConnections.ActionAsync());
                 // Connection should not be put back into the pool
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "This should still be using the same connection since it is on this call we break the connection.");
 

--- a/source/Halibut.Tests/Support/AssertThrowsAsync.cs
+++ b/source/Halibut.Tests/Support/AssertThrowsAsync.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Specialized;
+
+namespace Halibut.Tests.Support
+{
+    public static class AssertAsync
+    {
+        public static async Task<ExceptionAssertions<T>> Throws<T>(this Func<Task> task) where T : Exception
+        {
+            return await task.Should().ThrowAsync<T>();
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -364,6 +364,18 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TClientService>(forceClientProxyType, Client, serviceEndpoint);
             }
+            
+            public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>()
+            {
+                return CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(_ => { });
+            }
+            
+            public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
+            {
+                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint, proxyDetails);
+                modifyServiceEndpoint(serviceEndpoint);
+                return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(forceClientProxyType, Client, serviceEndpoint);
+            }
 
             public void Dispose()
             {

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -450,6 +450,16 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 throw new Exception("Modifying the service endpoint is unsupported, since it would not actually be passed on to the remote process which holds the actual client under test.");
             }
 
+            public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>()
+            {
+                return CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(_ => { });
+            }
+            
+            public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
+            {
+                throw new NotSupportedException("Not supported since the options can not be passed to the external binary.");
+            }
+
             public void Dispose()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();

--- a/source/Halibut.Tests/Support/IClientAndService.cs
+++ b/source/Halibut.Tests/Support/IClientAndService.cs
@@ -16,5 +16,7 @@ namespace Halibut.Tests.Support
         TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken);
         TClientAndService CreateClient<TService, TClientAndService>();
         TClientAndService CreateClient<TService, TClientAndService>(Action<ServiceEndPoint> modifyServiceEndpoint);
+        TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>();
+        TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint);
     }
 }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -513,12 +513,21 @@ namespace Halibut.Tests.Support
 
             public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
-                var serviceEndpoint = new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
+                var serviceEndpoint = ServiceEndpoint();
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TClientService>(forceClientProxyType, Client, serviceEndpoint);
             }
+
+            public ServiceEndPoint ServiceEndpoint()
+            {
+                return new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
+            }
             
-            
+            public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>()
+            {
+                return CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(_ => { });
+            }
+
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 var serviceEndpoint = new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientEchoServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientEchoServiceWithOptions.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientEchoServiceWithOptions
+    {
+        Task<int> LongRunningOperationAsync(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        Task<string> SayHelloAsync(string name, HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        Task<bool> CrashAsync(HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        Task<int> CountBytesAsync(DataStream stream, HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientLockServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientLockServiceWithOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientLockServiceWithOptions
+    {
+        public Task WaitForFileToBeDeletedAsync(string fileToWaitFor, string fileSignalWhenRequestIsStarted, HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -8,6 +8,7 @@ using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
@@ -16,7 +17,7 @@ namespace Halibut.Tests
     public class WhenCallingAMethodThatDoesNotExist : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncAndSyncClients: true)]
         public async Task AMethodNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var services = new SingleServiceFactory(new object(), typeof(EchoService));
@@ -26,11 +27,9 @@ namespace Halibut.Tests
                        .WithServiceFactory(services)
                        .Build(CancellationToken))
             {
-                var echo = clientAndService.CreateClient<IEchoService>();
-
-                Func<string> readAsyncCall = () => echo.SayHello("Say hello to a service that does not exist.");
-
-                readAsyncCall.Should().Throw<MethodNotFoundHalibutClientException>();
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                
+                await AssertAsync.Throws<MethodNotFoundHalibutClientException>(() => echo.SayHelloAsync("Say hello to a service that does not exist."));
             }
         }
 


### PR DESCRIPTION
# Background

Converts `WhenCallingAMethodThatDoesNotExist` to test async and sync.

[SC-54458]

Also reduces thread pool exhaustion by removing a sync wait caused by `Assert.ThrowsAsync` which amazingly is NOT async.

```
                   1 System.Threading.Monitor.Wait(Object, Int32)
                   1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
                   1 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, CancellationToken)
                   1 System.Threading.Tasks.Task.InternalWaitCore(Int32, CancellationToken)
                   1 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task)
                   1 System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task)
                   1 System.Runtime.CompilerServices.TaskAwaiter<System.Threading.Tasks.VoidTaskResult>.GetResult()
                   1 NUnit.Framework.Internal.TaskAwaitAdapter+GenericAdapter<System.Threading.Tasks.VoidTaskResult>.BlockUntilCompleted()
                   1 NUnit.Framework.Internal.MessagePumpStrategy+NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter)
                   1 NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func<Object>)
                   1 NUnit.Framework.Assert.ThrowsAsync(IResolveConstraint, AsyncTestDelegate, String, Object[])
                   1 NUnit.Framework.Assert.ThrowsAsync(Type, AsyncTestDelegate, String, Object[])
                   1 NUnit.Framework.Assert.ThrowsAsync(AsyncTestDelegate, String, Object[])
                   1 NUnit.Framework.Assert.ThrowsAsync(AsyncTestDelegate)
                   1 Halibut.Tests.WhenCallingAMethodThatDoesNotExist+<AMethodNotFoundHalibutClientExceptionShouldBeRaisedByTheClient>d__0.MoveNext()
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
