### PR TITLE
Add DiscoveryClient async methods and General Sync Cleanup

### DIFF
--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -68,12 +68,12 @@ namespace Halibut.Tests
                 {
                     Assert.Throws<TypeNotAllowedException>(() =>
                     {
-                        clientAndService.Client.CreateAsyncClient<IAmNotAllowed, IAsyncClientAmNotAllowed>(clientAndService.ServiceEndpoint());
+                        clientAndService.Client.CreateAsyncClient<IAmNotAllowed, IAsyncClientAmNotAllowed>(clientAndService.GetServiceEndPoint());
                     });
                 }
                 if (clientAndServiceTestCase.SyncOrAsync == SyncOrAsync.Sync)
                 {
-                    Assert.Throws<TypeNotAllowedException>(() => clientAndService.Client.CreateClient<IAmNotAllowed>(clientAndService.ServiceEndpoint()));
+                    Assert.Throws<TypeNotAllowedException>(() => clientAndService.Client.CreateClient<IAmNotAllowed>(clientAndService.GetServiceEndPoint()));
                 }
             }
         }

--- a/source/Halibut.Tests/Support/AssertAsync.cs
+++ b/source/Halibut.Tests/Support/AssertAsync.cs
@@ -7,9 +7,9 @@ namespace Halibut.Tests.Support
 {
     public static class AssertAsync
     {
-        public static async Task<ExceptionAssertions<T>> Throws<T>(this Func<Task> task) where T : Exception
+        public static async Task<ExceptionAssertions<T>> Throws<T>(this Func<Task> task, string because = "") where T : Exception
         {
-            return await task.Should().ThrowAsync<T>();
+            return await task.Should().ThrowAsync<T>(because);
         }
     }
 }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -486,6 +486,11 @@ namespace Halibut.Tests.Support
             public PortForwarder? PortForwarder { get; }
             public HttpProxyService? HttpProxy { get; }
 
+            public ServiceEndPoint GetServiceEndPoint()
+            {
+                return new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
+            }
+
             public TService CreateClient<TService>(CancellationToken? cancellationToken = null)
             {
                 return CreateClient<TService>(_ => { }, cancellationToken ?? CancellationToken.None);
@@ -498,13 +503,11 @@ namespace Halibut.Tests.Support
 
             public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
             {
-                var serviceEndpoint = new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
+                var serviceEndpoint = GetServiceEndPoint();
                 modifyServiceEndpoint(serviceEndpoint);
 
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService>(forceClientProxyType, Client, serviceEndpoint, cancellationToken);
             }
-
-            
 
             public TClientService CreateClient<TService, TClientService>()
             {
@@ -513,14 +516,9 @@ namespace Halibut.Tests.Support
 
             public TClientService CreateClient<TService, TClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
-                var serviceEndpoint = ServiceEndpoint();
+                var serviceEndpoint = GetServiceEndPoint();
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TClientService>(forceClientProxyType, Client, serviceEndpoint);
-            }
-
-            public ServiceEndPoint ServiceEndpoint()
-            {
-                return new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
             }
             
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>()
@@ -530,7 +528,7 @@ namespace Halibut.Tests.Support
 
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
-                var serviceEndpoint = new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails);
+                var serviceEndpoint = GetServiceEndPoint();
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(forceClientProxyType, Client, serviceEndpoint);
             }
@@ -550,7 +548,5 @@ namespace Halibut.Tests.Support
                 Try.CatchingError(() => cancellationTokenSource?.Dispose(), logError);
             }
         }
-
-        
     }
 }

--- a/source/Halibut.Tests/Support/TestAttributes/SyncAndAsyncAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/SyncAndAsyncAttribute.cs
@@ -42,7 +42,7 @@ namespace Halibut.Tests.Support.TestAttributes
 
             return new(syncOrAsync);
         }
-
+        
         public static async Task WhenAsync(this SyncOrAsyncWithoutResult syncOrAsyncWithoutResult, Func<Task> action)
         {
             if (syncOrAsyncWithoutResult.SyncOrAsync == SyncOrAsync.Async)
@@ -67,6 +67,11 @@ namespace Halibut.Tests.Support.TestAttributes
             }
 
             return new SyncOrAsyncWithResult<T>(syncOrAsync, default);
+        }
+
+        public static SyncOrAsyncWithoutResult IgnoreResult<T>(this SyncOrAsyncWithResult<T> syncOrAsyncWithResult)
+        {
+            return new SyncOrAsyncWithoutResult(syncOrAsyncWithResult.SyncOrAsync);
         }
 
         public static async Task<T> WhenAsync<T>(this SyncOrAsyncWithResult<T> syncOrAsyncWithResult, Func<Task<T>> action)

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -186,25 +186,40 @@ namespace Halibut
             pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log, cancellationToken, pollingReconnectRetryPolicy));
         }
 
+        [Obsolete]
         public ServiceEndPoint Discover(Uri uri)
         {
             return Discover(uri, CancellationToken.None);
         }
 
+        [Obsolete]
         public ServiceEndPoint Discover(Uri uri, CancellationToken cancellationToken)
         {
             return Discover(new ServiceEndPoint(uri, null), cancellationToken);
         }
 
+        public async Task<ServiceEndPoint> DiscoverAsync(Uri uri, CancellationToken cancellationToken)
+        {
+            return await DiscoverAsync(new ServiceEndPoint(uri, null), cancellationToken);
+        }
+
+        [Obsolete]
         public ServiceEndPoint Discover(ServiceEndPoint endpoint)
         {
             return Discover(endpoint, CancellationToken.None);
         }
 
+        [Obsolete]
         public ServiceEndPoint Discover(ServiceEndPoint endpoint, CancellationToken cancellationToken)
         {
             var client = new DiscoveryClient();
             return client.Discover(endpoint, cancellationToken);
+        }
+
+        public async Task<ServiceEndPoint> DiscoverAsync(ServiceEndPoint endpoint, CancellationToken cancellationToken)
+        {
+            var client = new DiscoveryClient();
+            return await client.DiscoverAsync(endpoint, cancellationToken);
         }
 
         public TService CreateClient<TService>(string endpointBaseUri, string publicThumbprint)
@@ -236,6 +251,7 @@ namespace Halibut
         {
             typeRegistry.AddToMessageContract(typeof(TService));
             var logger = logs.ForEndpoint(endpoint.BaseUri);
+#pragma warning disable CS0612
 #if HAS_REAL_PROXY
 #pragma warning disable 618
             return (TClientService)new HalibutProxy(SendOutgoingRequest, typeof(TService), typeof(TClientService), endpoint, logger, cancellationToken).GetTransparentProxy();
@@ -247,8 +263,9 @@ namespace Halibut
 #pragma warning restore 618
             return proxy;
 #endif
+#pragma warning restore CS0612
         }
-        
+
         public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint endpoint)
         {
             if (AsyncHalibutFeature.IsDisabled())

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -79,7 +79,9 @@ namespace Halibut
             var serviceFactory = this.serviceFactory ?? new NullServiceFactory();
             if (serverCertificate == null) throw new ArgumentException($"Set a server certificate with {nameof(WithServerCertificate)} before calling {nameof(Build)}", nameof(serverCertificate));
             var logFactory = this.logFactory ?? new LogFactory();
-            var queueFactory = this.queueFactory ?? new DefaultPendingRequestQueueFactory(logFactory);
+#pragma warning disable CS0612
+            var queueFactory = this.queueFactory ?? (asyncHalibutFeature.IsEnabled() ? new PendingRequestQueueFactoryAsync(logFactory) : new DefaultPendingRequestQueueFactory(logFactory));
+#pragma warning restore CS0612
             var trustProvider = this.trustProvider ?? new DefaultTrustProvider();
             var typeRegistry = this.typeRegistry ?? new TypeRegistry();
 

--- a/source/Halibut/ServiceModel/DefaultPendingRequestQueueFactory.cs
+++ b/source/Halibut/ServiceModel/DefaultPendingRequestQueueFactory.cs
@@ -3,6 +3,7 @@ using Halibut.Diagnostics;
 
 namespace Halibut.ServiceModel
 {
+    [Obsolete]
     class DefaultPendingRequestQueueFactory : IPendingRequestQueueFactory
     {
         readonly ILogFactory logFactory;

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -11,6 +11,8 @@ namespace Halibut.ServiceModel
 #if HAS_REAL_PROXY
     using System.Runtime.Remoting.Messaging;
     using System.Runtime.Remoting.Proxies;
+
+    [Obsolete]
     class HalibutProxy : RealProxy
     {
         readonly Func<RequestMessage, MethodInfo, CancellationToken, ResponseMessage> messageRouter;
@@ -82,6 +84,7 @@ namespace Halibut.ServiceModel
             return request;
         }
 #else
+    [Obsolete]
     public class HalibutProxy : DispatchProxy
     {
         Func<RequestMessage, MethodInfo, CancellationToken, ResponseMessage> messageRouter;

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -8,6 +8,7 @@ using Halibut.Util.AsyncEx;
 
 namespace Halibut.ServiceModel
 {
+    [Obsolete]
     public class PendingRequestQueue : IPendingRequestQueue
     {
         readonly List<PendingRequest> queue = new();

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -33,6 +33,7 @@ namespace Halibut.Transport
 
         // Connection is Lazy instantiated, so it is safe to use. If you need to wait for it to open (eg for error handling, an openConnection method is provided)
         // For existing open connections, the openConnection method does nothing
+        [Obsolete]
         Tuple<IConnection, Action> GetConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
             lock (activeConnections)
@@ -70,6 +71,7 @@ namespace Halibut.Transport
             return connection;
         }
 
+        [Obsolete]
         Tuple<IConnection, Action> CreateNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
             var lazyConnection = new Lazy<IConnection>(() => connectionFactory.EstablishNewConnection(exchangeProtocolBuilder, serviceEndpoint, log, cancellationToken));

--- a/source/Halibut/Transport/IConnectionFactory.cs
+++ b/source/Halibut/Transport/IConnectionFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
@@ -7,6 +8,7 @@ namespace Halibut.Transport
 {
     public interface IConnectionFactory
     {
+        [Obsolete]
         IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
         
         Task<IConnection> EstablishNewConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -16,7 +16,7 @@ namespace Halibut.Transport
         readonly Thread thread;
         readonly CancellationToken cancellationToken;
         bool working;
-        Func<RetryPolicy> CreateRetryPolicy;
+        readonly Func<RetryPolicy> createRetryPolicy;
 
         [Obsolete("Use the overload that provides a logger. This remains for backwards compatibility.")]
         public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, Func<RetryPolicy> createRetryPolicy)
@@ -36,7 +36,7 @@ namespace Halibut.Transport
             this.handleIncomingRequest = handleIncomingRequest;
             this.log = log;
             this.cancellationToken = cancellationToken;
-            CreateRetryPolicy = createRetryPolicy;
+            this.createRetryPolicy = createRetryPolicy;
             thread = new Thread(ExecutePollingLoop);
             thread.Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
             thread.IsBackground = true;
@@ -53,9 +53,10 @@ namespace Halibut.Transport
             working = false;
         }
 
+        // TODO: ASYNC ME UP!
         void ExecutePollingLoop(object ignored)
         {
-            var retry = CreateRetryPolicy();
+            var retry = createRetryPolicy();
             var sleepFor = TimeSpan.Zero;
             while (working)
             {

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -185,6 +185,7 @@ namespace Halibut.Transport.Proxy
         /// to make a pass through connection to the specified destination host on the specified
         /// port.  
         /// </remarks>
+        [Obsolete]
         public TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout)
         {
             return CreateConnection(destinationHost, destinationPort, timeout, CancellationToken.None);
@@ -206,6 +207,7 @@ namespace Halibut.Transport.Proxy
         /// to make a pass through connection to the specified destination host on the specified
         /// port.  
         /// </remarks>
+        [Obsolete]
         public TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout, CancellationToken cancellationToken)
         {
             try
@@ -296,7 +298,7 @@ namespace Halibut.Transport.Proxy
             }
         }
 
-
+        [Obsolete]
         void SendConnectionCommand(string host, int port)
         {
             var stream = TcpClient.GetStream();
@@ -416,6 +418,7 @@ namespace Halibut.Transport.Proxy
             throw new ProxyException(msg, false);
         }
 
+        [Obsolete]
         void WaitForData(NetworkStream stream)
         {
             var sleepTime = 0;

--- a/source/Halibut/Transport/Proxy/IProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/IProxyClient.cs
@@ -72,8 +72,9 @@ namespace Halibut.Transport.Proxy
         /// to make a pass through connection to the specified destination host on the specified
         /// port.  
         /// </remarks>
+        [Obsolete]
         TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout);
-        
+
         /// <summary>
         /// Creates a remote TCP connection through a proxy server to the destination host on the destination port.
         /// </summary>
@@ -90,6 +91,7 @@ namespace Halibut.Transport.Proxy
         /// to make a pass through connection to the specified destination host on the specified
         /// port.  
         /// </remarks>
+        [Obsolete]
         TcpClient CreateConnection(string destinationHost, int destinationPort, TimeSpan timeout, CancellationToken cancellationToken);
         
         Task<TcpClient> CreateConnectionAsync(string destinationHost, int destinationPort, TimeSpan timeout, CancellationToken cancellationToken);

--- a/source/Halibut/Transport/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/RewindableBufferStream.cs
@@ -107,7 +107,7 @@ namespace Halibut.Transport
         /// <param name="count"><inheritdoc/></param>
         /// <param name="cancellationToken"><inheritdoc/></param>
         /// <returns><inheritdoc/></returns>
-        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             count = ReduceReadCountToBufferSize(count);
             var rewoundCount = ReadFromRewindBuffer(buffer, offset, count);

--- a/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
+++ b/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
@@ -8,8 +8,8 @@ namespace Halibut.Transport.Streams
 {
     public class ErrorRecordingStream : Stream
     {
-        Stream innerStream;
-        bool closeInner;
+        readonly Stream innerStream;
+        readonly bool closeInner;
 
         public ErrorRecordingStream(Stream innerStream, bool closeInner) : base()
         {
@@ -17,8 +17,8 @@ namespace Halibut.Transport.Streams
             this.closeInner = closeInner;
         }
 
-        public List<Exception> ReadExceptions { get; } = new List<Exception>();
-        public List<Exception> WriteExceptions { get; } = new List<Exception>();
+        public List<Exception> ReadExceptions { get; } = new();
+        public List<Exception> WriteExceptions { get; } = new();
 
         public bool WasTheEndOfStreamEncountered { get; private set; } = false;
 
@@ -43,7 +43,7 @@ namespace Halibut.Transport.Streams
             
         }
 
-        public async override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {
@@ -82,7 +82,7 @@ namespace Halibut.Transport.Streams
             }
         }
         
-        public async override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {

--- a/source/Halibut/Transport/TcpClientExtensions.cs
+++ b/source/Halibut/Transport/TcpClientExtensions.cs
@@ -9,11 +9,13 @@ namespace Halibut.Transport
 {
     public static class TcpClientExtensions
     {
+        [Obsolete]
         public static void ConnectWithTimeout(this TcpClient client, Uri remoteUri, TimeSpan timeout)
         {
             ConnectWithTimeout(client, remoteUri.Host, remoteUri.Port, timeout, CancellationToken.None);
         }
 
+        [Obsolete]
         public static void ConnectWithTimeout(this TcpClient client, Uri remoteUri, TimeSpan timeout, CancellationToken cancellationToken)
         {
             ConnectWithTimeout(client, remoteUri.Host, remoteUri.Port, timeout, cancellationToken);
@@ -24,11 +26,13 @@ namespace Halibut.Transport
             await ConnectWithTimeoutAsync(client, remoteUri.Host, remoteUri.Port, timeout, cancellationToken);
         }
 
+        [Obsolete]
         public static void ConnectWithTimeout(this TcpClient client, string host, int port, TimeSpan timeout)
         {
             ConnectWithTimeout(client, host, port, timeout, CancellationToken.None);
         }
 
+        [Obsolete]
         public static void ConnectWithTimeout(this TcpClient client, string host, int port, TimeSpan timeout, CancellationToken cancellationToken)
         {
             Connect(client, host, port, timeout, cancellationToken).GetAwaiter().GetResult();
@@ -38,7 +42,7 @@ namespace Halibut.Transport
         {
             await Connect(client, host, port, timeout, cancellationToken);
         }
-
+        
         static async Task Connect(TcpClient client, string host, int port, TimeSpan timeout, CancellationToken cancellationToken)
         {
             try

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -23,6 +23,7 @@ namespace Halibut.Transport
             this.clientCertificate = clientCertificate;
         }
 
+        [Obsolete]
         public IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
             log.Write(EventType.OpeningNewConnection, $"Opening a new connection to {serviceEndpoint.BaseUri}");
@@ -69,6 +70,7 @@ namespace Halibut.Transport
             return new SecureConnection(client, ssl, exchangeProtocolBuilder, log);
         }
 
+        [Obsolete]
         internal static TcpClient CreateConnectedTcpClient(ServiceEndPoint endPoint, ILog log, CancellationToken cancellationToken)
         {
             TcpClient client;

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -21,6 +21,7 @@ namespace Halibut.Transport
             this.clientCertificate = clientCertificate;
         }
 
+        [Obsolete]
         public IConnection EstablishNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
             log.Write(EventType.OpeningNewConnection, "Opening a new connection");
@@ -57,7 +58,7 @@ namespace Halibut.Transport
             return new SecureConnection(client, stream, exchangeProtocolBuilder, log);
         }
 
-        
+        [Obsolete]
         ClientWebSocket CreateConnectedClient(ServiceEndPoint serviceEndpoint, CancellationToken cancellationToken)
         {
             if (!serviceEndpoint.IsWebSocketEndpoint)


### PR DESCRIPTION
# Background

Add async methods for the DiscoveryClient
Mark sync methods/classes as Obsolete where an async version exists


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
