### PR TITLE
Fix a compatibility issue with async Halibut and older Halibut Services e.g. 4.4.8

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.SampleProgram.Base.Utils;
 

--- a/source/Halibut.TestUtils.CompatBinary.Base/Halibut.TestUtils.CompatBinary.Base.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Halibut.TestUtils.CompatBinary.Base.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <LangVersion>9.0</LangVersion>
@@ -16,11 +16,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- Earlier versions contain bugs that can cause Halibut to hang
+        <!-- Earlier versions < 5.0.205 contain bugs that can cause Halibut to hang
             See https://github.com/OctopusDeploy/Halibut/commit/cf9cb8a4478b59f95b35c2606d4352c364d3dcb2
             It is probably best to never test versions earlier than this, since those tests will be unreliable.
+            4.4.8 is the earliest version with HalibutRuntimeBuilder and without a critical RCE vulnerability.
         -->
-        <PackageReference Include="Halibut" Version="5.0.205" />
+        <PackageReference Include="Halibut" Version="4.4.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/source/Halibut.TestUtils.CompatBinary.v4_4_8/Halibut.TestUtils.CompatBinary.v4_4_8.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v4_4_8/Halibut.TestUtils.CompatBinary.v4_4_8.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
-        <RootNamespace>Halibut.TestUtils.Contracts</RootNamespace>
+        <RootNamespace>Halibut.TestUtils.SampleProgram.v4_4_8</RootNamespace>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
@@ -13,10 +14,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Halibut" Version="4.4.8">
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+        <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.Base\Halibut.TestUtils.CompatBinary.Base.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Halibut" Version="4.4.8" />
     </ItemGroup>
 
 </Project>

--- a/source/Halibut.TestUtils.CompatBinary.v4_4_8/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v4_4_8/Program.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Halibut.TestUtils.SampleProgram.Base;
+
+namespace Halibut.TestUtils.SampleProgram.v4_4_8
+{
+    public class Program
+    {
+        public static async Task<int> Main()
+        {
+           return await BackwardsCompatProgramBase.Main();
+        }
+    }
+}

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\Halibut\Halibut.csproj" />
     <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v5_0_236\Halibut.TestUtils.CompatBinary.v5_0_236.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v6_0_658\Halibut.TestUtils.CompatBinary.v6_0_658.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Halibut.TestUtils.CompatBinary.v4_4_8\Halibut.TestUtils.CompatBinary.v4_4_8.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryPath.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryPath.cs
@@ -14,6 +14,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             var projectName = $"Halibut.TestUtils.CompatBinary.v{onDiskVersion}";
             var executable = Path.Combine(upAt.FullName, projectName, assemblyDir.Parent.Parent.Name, assemblyDir.Parent.Name, assemblyDir.Name, projectName);
             executable = AddExeForWindows(executable);
+
             if (!File.Exists(executable))
             {
                 throw new Exception("Could not executable at path:\n" +

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousVersions.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousVersions.cs
@@ -6,9 +6,20 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
     {
         // The earliest release with a stable WebSocket implementation
         static readonly Version v6_0_658_WebSocket_Stability_Fixes = new("6.0.658");
-        
+
+        // The earliest release with a stable streams where communication won't hang sometimes on net6.0
+        static readonly Version v5_0_236_Stable_Streams = new("5.0.236");
+
         // The last release with meaningful changes prior to Script Service V2
         public static readonly HalibutVersions v5_0_236_Used_In_Tentacle_6_3_417 = new(new Version("5.0.236"), pollingOverWebSocketServiceVersion: v6_0_658_WebSocket_Stability_Fixes);
+        
+#if NETFRAMEWORK
+        public static readonly HalibutVersions v4_4_8 = new(new Version("4.4.8"), pollingOverWebSocketServiceVersion: v6_0_658_WebSocket_Stability_Fixes);
+#else
+        // A net6.0 client causes an older halibut service without buffer over-read changes to be prone to hanging or erroring when reading the stream.
+        // This instability means we cannot really have automated tests for net6.0 and older these older Halibut Services
+        public static readonly HalibutVersions v4_4_8 = new(new Version("4.4.8"), pollingOverWebSocketServiceVersion: v6_0_658_WebSocket_Stability_Fixes, pollingServiceVersion: v5_0_236_Stable_Streams, listeningServiceVersion: v5_0_236_Stable_Streams);
+#endif
     }
 
     public class HalibutVersion

--- a/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
@@ -56,6 +56,7 @@ namespace Halibut.Tests.Support.TestAttributes
                         ClientAndServiceTestVersion.Latest(),
                         ClientAndServiceTestVersion.ClientOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ClientVersion),
                         ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ServiceVersion),
+                        ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v4_4_8.ServiceVersion),
                     },
                     serviceConnectionTypes.ToArray(),
                     testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
@@ -47,6 +47,7 @@ namespace Halibut.Tests.Support.TestAttributes
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] {
                         ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ServiceVersion),
+                        ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v4_4_8.ServiceVersion),
                     },
                     serviceConnectionTypes.ToArray(),
                     testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
-using Halibut.Logging;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;

--- a/source/Halibut.sln
+++ b/source/Halibut.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.Contracts
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v6_0_658", "Halibut.TestUtils.CompatBinary.v6_0_658\Halibut.TestUtils.CompatBinary.v6_0_658.csproj", "{B47CEB1B-F37A-4596-9DB1-FB12FA98B16C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v4_4_8", "Halibut.TestUtils.CompatBinary.v4_4_8\Halibut.TestUtils.CompatBinary.v4_4_8.csproj", "{80042E24-9461-47D1-9AC5-E414E4DBF821}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -70,18 +72,6 @@ Global
 		{65BD1243-FCB9-40C6-A926-8B47E10904AA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{65BD1243-FCB9-40C6-A926-8B47E10904AA}.Release|x86.ActiveCfg = Release|Any CPU
 		{65BD1243-FCB9-40C6-A926-8B47E10904AA}.Release|x86.Build.0 = Release|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Debug|x86.Build.0 = Debug|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Release|x86.ActiveCfg = Release|Any CPU
-		{66014922-3A83-42A2-8C23-D327160175C9}.Release|x86.Build.0 = Release|Any CPU
 		{BBC31D50-5170-49D9-A42D-625768705B7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BBC31D50-5170-49D9-A42D-625768705B7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BBC31D50-5170-49D9-A42D-625768705B7B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -166,6 +156,18 @@ Global
 		{B47CEB1B-F37A-4596-9DB1-FB12FA98B16C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B47CEB1B-F37A-4596-9DB1-FB12FA98B16C}.Release|x86.ActiveCfg = Release|Any CPU
 		{B47CEB1B-F37A-4596-9DB1-FB12FA98B16C}.Release|x86.Build.0 = Release|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Debug|x86.Build.0 = Debug|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Release|x86.ActiveCfg = Release|Any CPU
+		{80042E24-9461-47D1-9AC5-E414E4DBF821}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -90,7 +90,7 @@ namespace Halibut.Transport.Protocol
         async Task SendIdentityMessageAsync(string identityLine, CancellationToken cancellationToken)
         {
             // The identity line and the additional empty line must be sent together as a single write operation when using a stream to mimic the 
-            // buffering behaviour of the StreamWriter. When sent ass 2 writes to the Stream, old Halibut Services e.g. 4.4.8 will often fail when reading the identity line.
+            // buffering behaviour of the StreamWriter. When sent as 2 writes to the Stream, old Halibut Services e.g. 4.4.8 will often fail when reading the identity line.
             await stream.WriteControlLineAsync(identityLine + StreamExtensionMethods.ControlMessageNewLine, cancellationToken);
             await stream.FlushAsync(cancellationToken);
         }

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -89,8 +89,9 @@ namespace Halibut.Transport.Protocol
 
         async Task SendIdentityMessageAsync(string identityLine, CancellationToken cancellationToken)
         {
-            await stream.WriteControlLineAsync(identityLine, cancellationToken);
-            await stream.WriteEmptyControlLineAsync(cancellationToken);
+            // The identity line and the additional empty line must be sent together as a single write operation when using a stream to mimic the 
+            // buffering behaviour of the StreamWriter. When sent ass 2 writes to the Stream, old Halibut Services e.g. 4.4.8 will often fail when reading the identity line.
+            await stream.WriteControlLineAsync(identityLine + StreamExtensionMethods.ControlMessageNewLine, cancellationToken);
             await stream.FlushAsync(cancellationToken);
         }
 

--- a/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
@@ -8,18 +8,13 @@ namespace Halibut.Transport.Streams
     public static class StreamExtensionMethods
     {
         // The NewLine and Encoding must not be changed as it will break backward compatibility.
-        static readonly string NewLine = "\r\n";
+        public static readonly string ControlMessageNewLine = "\r\n";
         static readonly Encoding Encoding = new UTF8Encoding(false);
 
         public static async Task WriteControlLineAsync(this Stream stream, string s, CancellationToken cancellationToken)
         {
-            var bytes = Encoding.GetBytes(s + NewLine);
+            var bytes = Encoding.GetBytes(s + ControlMessageNewLine);
             await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
-        }
-
-        public static async Task WriteEmptyControlLineAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            await stream.WriteControlLineAsync(string.Empty, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
# Background

Fix a compatibility issue with async Halibut and older Halibut Services e.g. 4.4.8

Added 4.4.8 as a Compatibility Test

# Results

`4.4.8` may not be reliable. Locally net48 seems reliable but net6.0 suffers from a lot of test failures (sync and async) where the 4.4.8 Service hangs and doesn't process requests.

This could make our tests runs always red and very unreliable! However, a change was introduced in async Halibut that caused these old runtimes to fail!! We need test coverage, but it may be very difficult to get reliable coverage!!

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/bf451730-4a7c-4c9d-98fe-70b0d59a4e0a)

On net6.0 there are quite a number of tests locally that will fail with an output like below! The service just doesn't do anything!

Muting the failures in Windows net60 and Linux net60 does give us green

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/a6194b6f-8de5-4df7-91d0-198feb5a911c)

```
[UsageFixture] 21:18:58.269 +10:00 Test started
    [TestContextConnectionLog] 21:18:58.269 +10:00           Client: Info: listen://[::]:50798/  48 Listener started
    [PortForwarder] 21:18:58.270 +10:00 Listening on "127.0.0.1:50799"
    [PortForwarder] 21:18:58.270 +10:00 Forwarding to https://localhost:50798/
    [HalibutRuntimeBuilder] 21:18:58.378 +10:00 Mode is: serviceonly
    [HalibutRuntimeBuilder] 21:18:58.422 +10:00 Will poll: https://localhost:50799
    [HalibutRuntimeBuilder] 21:18:58.422 +10:00 Not using an Http Proxy
    [HalibutRuntimeBuilder] 21:18:58.534 +10:00 RunningAndReady
    [HalibutRuntimeBuilder] 21:18:58.534 +10:00 Will Now sleep
    [HalibutRuntimeBuilder] 21:18:58.535 +10:00 Will die when the following file can be locked or is deleted 'C:\Users\natha\AppData\Local\testhost\Temp\75ae7b82-6226-4ff8-b912-7566534cb643\compat-bin-lock'.
    [TestContextConnectionLog] 21:19:00.616 +10:00           Client: Info: listen://[::]:50798/  77 Accepted TCP client: [::1]:50933
    [HalibutRuntimeBuilder] 21:19:00.827 +10:00  ExternalService: Security: https://localhost:50799/  4 Secure connection established. Server at [::ffff:127.0.0.1]:50799 identified by thumbprint: 76225C0717A16C1D0BA4A7FFA76519D286D8A248, using protocol Tls12
    [TestContextConnectionLog] 21:19:00.864 +10:00           Client: Info: listen://[::]:50798/  193 Client at [::1]:50933 authenticated as 4098EC3A2FC2B92B97339D3831BA230CC1DD590F
    [LatestClientAndPreviousServiceVersionBuilder+ClientAndService] 21:19:45.875 +10:00 Dispose called
    [TestContextConnectionLog] 21:19:45.876 +10:00           Client: Info: listen://[::]:50798/  279 Listener stopped
````

## Before

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/ab138daf-318b-44c3-ac55-967de1289e24)

```
[UsageFixture] 21:00:13.939 +10:00 Test started
[HalibutRuntimeBuilder] 21:00:14.138 +10:00 Mode is: serviceonly
[HalibutRuntimeBuilder] 21:00:14.214 +10:00 Not using an Http Proxy
[HalibutRuntimeBuilder] 21:00:14.295 +10:00  ExternalService: ListenerStarted: listen://[::]:63595/  1 Listener started
[HalibutRuntimeBuilder] 21:00:14.317 +10:00 Listening on port: 63595
[HalibutRuntimeBuilder] 21:00:14.318 +10:00 RunningAndReady
[HalibutRuntimeBuilder] 21:00:14.318 +10:00 Will Now sleep
[PortForwarder] 21:00:14.318 +10:00 Listening on "127.0.0.1:63600"
[PortForwarder] 21:00:14.318 +10:00 Forwarding to https://localhost:63595/
[HalibutRuntimeBuilder] 21:00:14.320 +10:00 Will die when the following file can be locked or is deleted 'C:\Users\natha\AppData\Local\Octopus\Temp\ab8e26a3-3db9-45b2-80a1-588bca409878\compat-bin-lock'.
[HalibutRuntimeBuilder] 21:00:16.387 +10:00  ExternalService: ListenerAcceptedClient: listen://[::]:63595/  4 Accepted TCP client: [::1]:63645
[TestContextConnectionLog] 21:00:16.665 +10:00           Client: Info: https://localhost:63600/  133 Secure connection established. Server at [::ffff:127.0.0.1]:63600 identified by thumbprint: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D, using protocol Tls12
[HalibutRuntimeBuilder] 21:00:16.718 +10:00  ExternalService: Security: listen://[::]:63595/  6 Client at [::1]:63645 authenticated as 76225C0717A16C1D0BA4A7FFA76519D286D8A248
[HalibutRuntimeBuilder] 21:00:16.817 +10:00  ExternalService: Error:System.IO.InvalidDataException: Found invalid data while decoding.
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.IO.Compression.Inflater.DecodeDynamicBlockHeader()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.IO.Compression.Inflater.Decode()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.IO.Compression.Inflater.Inflate(Byte[] bytes, Int32 offset, Int32 length)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.IO.BinaryReader.FillBuffer(Int32 numBytes)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.IO.BinaryReader.ReadInt32()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Newtonsoft.Json.Bson.BsonDataReader.ReadNormal()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Newtonsoft.Json.Bson.BsonDataReader.Read()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Halibut.Transport.Protocol.MessageSerializer.ReadMessage[T](Stream stream)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Halibut.Transport.Protocol.MessageExchangeStream.Receive[T]()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Halibut.Transport.Protocol.MessageExchangeProtocol.ProcessClientRequests(Func`2 incomingRequestProcessor)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Halibut.Transport.Protocol.MessageExchangeProtocol.<ExchangeAsServerAsync>d__12.MoveNext()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00 --- End of stack trace from previous location where exception was thrown ---
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[HalibutRuntimeBuilder] 21:00:16.817 +10:00    at Halibut.Transport.SecureListener.<ExecuteRequest>d__23.MoveNext() listen://[::]:63595/  6 Unhandled error when handling request from client: [::1]:63645
[TestContextConnectionLog] 21:00:16.819 +10:00           Client: Error: https://localhost:63600/  210 The remote host at https://localhost:63600/ reset the connection. This may mean that the expected listening service does not trust the thumbprint 76225C0717A16C1D0BA4A7FFA76519D286D8A248 or was shut down.
[LatestClientAndPreviousServiceVersionBuilder+ClientAndService] 21:00:16.819 +10:00 Dispose called

```

## After

🟢 tests for async halibut where they previously  failed with `Found invalid data while decoding.` against `4.4.8`

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
