### PR TITLE
WhenCancellingARequestForAPollingTentacle is only supported in sync

### DIFF
--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests
         public class AndTheRequestIsStillQueued : BaseTest
         {
             [Test]
-            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncAndSyncClients: false)]
             public async Task TheRequestShouldBeCancelled(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 var cancellationTokenSource = new CancellationTokenSource();
@@ -53,7 +53,7 @@ namespace Halibut.Tests
         public class AndTheRequestHasBeenDequeuedButNoResponseReceived : BaseTest
         {
             [Test]
-            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncAndSyncClients: false)]
             public async Task TheRequestShouldNotBeCancelled(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 var calls = new List<DateTime>();


### PR DESCRIPTION
# Background

[SC-54458]

`CancallationToken`s passed to proxy creation is only support in sync. In the new Async code the token can only be passed by `HalibutProxyRequestOptions`


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
