### PR TITLE
Convert test fixtures to use async code path

### DIFF
--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientLockService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientLockService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientLockService
+    {
+        Task WaitForFileToBeDeletedAsync(string fileToWaitFor, string fileSignalWhenRequestIsStarted);
+    }
+}


### PR DESCRIPTION
This PR converts the following fixtures to test the async code path, as part of [sc-51287]:
* PollingClientConnectionHandlingFixture
* PollingTentacleDequeuesRequestsInOrderFixture