### PR TITLE
Reduce the length of the names of the tests

### DIFF
--- a/source/Halibut.Tests/Support/TestCases/NetworkConditionTestCase.cs
+++ b/source/Halibut.Tests/Support/TestCases/NetworkConditionTestCase.cs
@@ -21,11 +21,11 @@ namespace Halibut.Tests.Support.TestCases
 
         public static NetworkConditionTestCase NetworkCondition20MsLatency = 
             new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).Build(), 
-                "20ms send delay");
+                "20ms SendDelay");
 
         public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLastByteArrivingLate =
             new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(1).Build(),
-                "20ms send delay with last byte arriving late");
+                "20ms SendDelay last byte arrives late");
 
         //public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLast2BytesArrivingLate =
         //    new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(2).Build(),
@@ -48,7 +48,7 @@ namespace Halibut.Tests.Support.TestCases
 
         public override string ToString()
         {
-            return $"Network Condition: '{NetworkConditionDescription}'";
+            return $"Network: '{NetworkConditionDescription}'";
         }
     }
 }


### PR DESCRIPTION
# Background

Because they are becoming longer than what rider will show.

# Before

<img width="694" alt="image" src="https://github.com/OctopusDeploy/Halibut/assets/7076477/7082f05c-dd98-40a2-b0fb-690a77d1df49">

# After

<img width="683" alt="image" src="https://github.com/OctopusDeploy/Halibut/assets/7076477/17762c38-5d54-4b27-bf22-c476a3a5cade">

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
