### PR TITLE
Convert WhenCallingServicesSimilarToTheOnesInTentacle to use async code path

### DIFF
--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientCapabilitiesServiceV2.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientCapabilitiesServiceV2.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts.Capabilities;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientCapabilitiesServiceV2
+    {
+        public Task<CapabilitiesResponseV2> GetCapabilitiesAsync();
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientFileTransferService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientFileTransferService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientFileTransferService
+    {
+        Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload);
+        Task<DataStream> DownloadFileAsync(string remotePath);
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientScriptService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientScriptService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientScriptService
+    {
+        Task<ScriptTicket> StartScriptAsync(StartScriptCommand command);
+        Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request);
+        Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command);
+        Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command);
+    }
+}

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientScriptServiceV2.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientScriptServiceV2.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientScriptServiceV2
+    {
+        Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command);
+        Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request);
+        Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command);
+        Task CompleteScriptAsync(CompleteScriptCommandV2 command);
+    }
+}


### PR DESCRIPTION
This PR converts the `WhenCallingServicesSimilarToTheOnesInTentacle` test class to exercise the async code paths, as part of [sc-54458]

NB: Further async-friendly improvements can be made in these tests once `DataStream` is converted to be async, but that is outside the scope of this PR.