### PR TITLE
Convert ParallelRequestsFixture to run in sync & async

### DIFF
--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -73,7 +73,7 @@ namespace Halibut.Tests
             }
 
             [Test]
-            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false)]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false, testAsyncAndSyncClients: false)]
             public async Task SendMessagesToTentacleInParallelAsync(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 var builder = clientAndServiceTestCase.CreateTestCaseBuilder();

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -10,142 +10,248 @@ using Halibut.Logging;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
 namespace Halibut.Tests
 {
-    [Parallelizable(ParallelScope.Children)]
-    public class ParallelRequestsFixture : BaseTest
+    public static class ParallelRequestsFixture
     {
-        [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false,
-            testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
-            )]
-        public async Task MultipleRequestsCanBeInFlightInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
+        public class AsyncParallelRequestFixture : BaseTest
         {
-            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                .WithStandardServices()
-                .Build(CancellationToken);
-
-            var lockService = clientAndService.CreateClient<ILockService>();
-
-            int threadCount = 64;
-            long threadCompletionCount = 0;
-            var threads = new List<Thread>();
-            var exceptions = new ConcurrentBag<Exception>();
-
-            var lockFile = Path.GetTempFileName();
-            var requestStartedFilePathBase = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-            var requestStartedFilePaths = new ConcurrentBag<string>();
-            Logger.Information($"Lock file: {lockFile}");
-            Logger.Information($"Request started files: {requestStartedFilePathBase}");
-            
-            for (var i = 0; i < threadCount; i++)
+            [Test]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false, testAsyncAndSyncClients: false)]
+            public async Task MultipleRequestsCanBeInFlightInParallelAsync(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                int iteration = i;
-                var thread = new Thread(() =>
+                var builder = clientAndServiceTestCase.CreateTestCaseBuilder().WithStandardServices();
+                if (!clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousClient())
                 {
-                    // Gotta handle exceptions when running in a 
-                    // Thread, or you're gonna have a bad time.
-                    try
-                    {
-                        var requestStartedPath = $"{requestStartedFilePathBase}-{iteration}";
-                        requestStartedFilePaths.Add(requestStartedPath);
-                        lockService.WaitForFileToBeDeleted(lockFile, requestStartedPath);
-                        Interlocked.Increment(ref threadCompletionCount);
-                    }
-                    catch (Exception e)
-                    {
-                        exceptions.Add(e);
-                    }
-                });
-                thread.Start();
-                threads.Add(thread);
+                    builder = builder.WithForcingClientProxyType(ForceClientProxyType.AsyncClient);
+                }
+                using var clientAndService = await builder.Build(CancellationToken);
+
+                var lockService = clientAndService.CreateAsyncClient<ILockService, IAsyncClientLockService>();
+
+                int threadCount = 64;
+                long threadCompletionCount = 0;
+                var threads = new List<Task>();
+
+                var lockFile = Path.GetTempFileName();
+                var requestStartedFilePathBase = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                var requestStartedFilePaths = new ConcurrentBag<string>();
+                Logger.Information($"Lock file: {lockFile}");
+                Logger.Information($"Request started files: {requestStartedFilePathBase}");
+
+                for (var i = 0; i < threadCount; i++)
+                {
+                    int iteration = i;
+                    var thread = Task.Run(async () =>
+                        {
+                            // Gotta handle exceptions when running in a 
+                            // Thread, or you're gonna have a bad time.
+
+                            var requestStartedPath = $"{requestStartedFilePathBase}-{iteration}";
+                            requestStartedFilePaths.Add(requestStartedPath);
+                            await lockService.WaitForFileToBeDeletedAsync(lockFile, requestStartedPath);
+                            Interlocked.Increment(ref threadCompletionCount);
+                        }
+                    );
+                    threads.Add(thread);
+                }
+
+                // Wait for all requests to be started
+                await Wait.For(() => Task.FromResult(requestStartedFilePaths.All(File.Exists)), CancellationToken);
+
+                Interlocked.Read(ref threadCompletionCount).Should().Be(0);
+
+                // Let the remote calls complete
+                File.Delete(lockFile);
+
+                await Task.WhenAll(threads);
+
+                Interlocked.Read(ref threadCompletionCount).Should().Be(threadCount);
             }
 
-            // Wait for all requests to be started
-            await Wait.For(() => Task.FromResult(requestStartedFilePaths.All(File.Exists)), CancellationToken);
-
-            Interlocked.Read(ref threadCompletionCount).Should().Be(0);
-            exceptions.Should().BeEmpty();
-            
-            // Let the remote calls complete
-            File.Delete(lockFile);
-
-            WaitForAllThreads(threads);
-            
-            Interlocked.Read(ref threadCompletionCount).Should().Be(threadCount);
-            exceptions.Should().BeEmpty();
-        }
-
-        [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling:false, testWebSocket: false, testNetworkConditions: false, 
-            testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
-            )]
-        public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
-        {
-            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                .WithStandardServices()
-                .Build(CancellationToken);
-            
-            var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();
-
-            var dataStreams = CreateDataStreams();
-
-            var messagesAreSentTheSameTimeSemaphore = new SemaphoreSlim(0, dataStreams.Length);
-
-            int threadCount = 64;
-            int threadCompletionCount = 0;
-            var threads = new List<Thread>();
-            var exceptions = new ConcurrentBag<Exception>();
-            for (var i = 0; i < threadCount; i++)
+            [Test]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false)]
+            public async Task SendMessagesToTentacleInParallelAsync(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                var thread = new Thread(() =>
+                var builder = clientAndServiceTestCase.CreateTestCaseBuilder();
+                if (!clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousClient())
                 {
-                    // Gotta handle exceptions when running in a 
-                    // Thread, or you're gonna have a bad time.
-                    try
+                    builder = builder.WithForcingClientProxyType(ForceClientProxyType.AsyncClient);
+                }
+                
+                using var clientAndService = await builder
+                    .WithStandardServices()
+                    .Build(CancellationToken);
+
+                var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService, IAsyncReadDataStreamService>();
+
+                var dataStreams = SyncParallelRequestsFixture.CreateDataStreams();
+
+                var messagesAreSentTheSameTimeSemaphore = new SemaphoreSlim(0, dataStreams.Length);
+
+                int threadCount = 64;
+                int threadCompletionCount = 0;
+                var threads = new List<Task>();
+                for (var i = 0; i < threadCount; i++)
+                {
+                    var thread = Task.Run(async () =>
                     {
-                        messagesAreSentTheSameTimeSemaphore.Wait(CancellationToken);
-                        var received = readDataSteamService.SendData(dataStreams);
+                        // Gotta handle exceptions when running in a 
+                        // Thread, or you're gonna have a bad time.
+                        await messagesAreSentTheSameTimeSemaphore.WaitAsync(CancellationToken);
+                        var received = await readDataSteamService.SendDataAsync(dataStreams);
                         received.Should().Be(5 * dataStreams.Length);
                         Interlocked.Increment(ref threadCompletionCount);
-                    }
-                    catch (Exception e)
+                        
+                    });
+                    threads.Add(thread);
+                }
+
+                messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
+
+                await Task.WhenAll(threads);
+                
+                threadCompletionCount.Should().Be(threadCount);
+            }
+        }
+        
+        
+        [Parallelizable(ParallelScope.Children)]
+        public class SyncParallelRequestsFixture : BaseTest
+        {
+            [Test]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false,
+                testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
+            )]
+            public async Task MultipleRequestsCanBeInFlightInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
+            {
+                using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                    .WithStandardServices()
+                    .Build(CancellationToken);
+
+                var lockService = clientAndService.CreateClient<ILockService>();
+
+                int threadCount = 64;
+                long threadCompletionCount = 0;
+                var threads = new List<Thread>();
+                var exceptions = new ConcurrentBag<Exception>();
+
+                var lockFile = Path.GetTempFileName();
+                var requestStartedFilePathBase = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                var requestStartedFilePaths = new ConcurrentBag<string>();
+                Logger.Information($"Lock file: {lockFile}");
+                Logger.Information($"Request started files: {requestStartedFilePathBase}");
+
+                for (var i = 0; i < threadCount; i++)
+                {
+                    int iteration = i;
+                    var thread = new Thread(() =>
                     {
-                        exceptions.Add(e);
-                    }
-                });
-                thread.Start();
-                threads.Add(thread);
+                        // Gotta handle exceptions when running in a 
+                        // Thread, or you're gonna have a bad time.
+                        try
+                        {
+                            var requestStartedPath = $"{requestStartedFilePathBase}-{iteration}";
+                            requestStartedFilePaths.Add(requestStartedPath);
+                            lockService.WaitForFileToBeDeleted(lockFile, requestStartedPath);
+                            Interlocked.Increment(ref threadCompletionCount);
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions.Add(e);
+                        }
+                    });
+                    thread.Start();
+                    threads.Add(thread);
+                }
+
+                // Wait for all requests to be started
+                await Wait.For(() => Task.FromResult(requestStartedFilePaths.All(File.Exists)), CancellationToken);
+
+                Interlocked.Read(ref threadCompletionCount).Should().Be(0);
+                exceptions.Should().BeEmpty();
+
+                // Let the remote calls complete
+                File.Delete(lockFile);
+
+                WaitForAllThreads(threads);
+
+                Interlocked.Read(ref threadCompletionCount).Should().Be(threadCount);
+                exceptions.Should().BeEmpty();
             }
 
-            messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
-
-            WaitForAllThreads(threads);
-            exceptions.Should().BeEmpty();
-            threadCompletionCount.Should().Be(threadCount);
-        }
-
-        static DataStream[] CreateDataStreams()
-        {
-            // Lots of DataStreams since they are handled in a special way, and we have had threading issues
-            // with these previously.
-            var dataStreams = new DataStream[128];
-            for (var i = 0; i < dataStreams.Length; i++)
+            [Test]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false,
+                testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
+            )]
+            public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                dataStreams[i] = DataStream.FromString("Hello");
+                using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                    .WithStandardServices()
+                    .Build(CancellationToken);
+
+                var readDataSteamService = clientAndService.CreateClient<IReadDataStreamService>();
+
+                var dataStreams = CreateDataStreams();
+
+                var messagesAreSentTheSameTimeSemaphore = new SemaphoreSlim(0, dataStreams.Length);
+
+                int threadCount = 64;
+                int threadCompletionCount = 0;
+                var threads = new List<Thread>();
+                var exceptions = new ConcurrentBag<Exception>();
+                for (var i = 0; i < threadCount; i++)
+                {
+                    var thread = new Thread(() =>
+                    {
+                        // Gotta handle exceptions when running in a 
+                        // Thread, or you're gonna have a bad time.
+                        try
+                        {
+                            messagesAreSentTheSameTimeSemaphore.Wait(CancellationToken);
+                            var received = readDataSteamService.SendData(dataStreams);
+                            received.Should().Be(5 * dataStreams.Length);
+                            Interlocked.Increment(ref threadCompletionCount);
+                        }
+                        catch (Exception e)
+                        {
+                            exceptions.Add(e);
+                        }
+                    });
+                    thread.Start();
+                    threads.Add(thread);
+                }
+
+                messagesAreSentTheSameTimeSemaphore.Release(dataStreams.Length);
+
+                WaitForAllThreads(threads);
+                exceptions.Should().BeEmpty();
+                threadCompletionCount.Should().Be(threadCount);
             }
 
-            return dataStreams;
-        }
-
-        void WaitForAllThreads(List<Thread> threads)
-        {
-            foreach (var thread in threads)
+            public static DataStream[] CreateDataStreams()
             {
-                thread.Join();
+                // Lots of DataStreams since they are handled in a special way, and we have had threading issues
+                // with these previously.
+                var dataStreams = new DataStream[128];
+                for (var i = 0; i < dataStreams.Length; i++)
+                {
+                    dataStreams[i] = DataStream.FromString("Hello");
+                }
+
+                return dataStreams;
+            }
+
+            void WaitForAllThreads(List<Thread> threads)
+            {
+                foreach (var thread in threads)
+                {
+                    thread.Join();
+                }
             }
         }
     }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -333,6 +333,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             }
 
             public HalibutRuntime Client { get; }
+            public ServiceEndPoint ServiceEndPoint => new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint, proxyDetails);
+
             public PortForwarder? PortForwarder { get; }
             public HttpProxyService? HttpProxy { get; }
 
@@ -348,7 +350,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             public TService CreateClient<TService>(Action<ServiceEndPoint> modifyServiceEndpoint, CancellationToken cancellationToken)
             {
-                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint, proxyDetails);
+                var serviceEndpoint = ServiceEndPoint;
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService>(forceClientProxyType, Client, serviceEndpoint, cancellationToken);
             }
@@ -375,6 +377,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint, proxyDetails);
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(forceClientProxyType, Client, serviceEndpoint);
+            }
+
+            public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
+            {
+                return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -389,6 +389,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             /// This is the ProxyClient
             /// </summary>
             public HalibutRuntime Client { get; }
+
+            public ServiceEndPoint ServiceEndPoint => new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+
             public HalibutRuntime ProxyClient => Client;
             public PortForwarder? PortForwarder { get; }
             public HttpProxyService? HttpProxy { get; }
@@ -406,7 +409,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     throw new Exception("Setting the connect cancellation token to anything other than none is unsupported, since it would not actually be passed on to the remote process which holds the actual client under test.");
                 }
 
-                var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint);
+                var serviceEndpoint = ServiceEndPoint;
                 return ProxyClient.CreateClient<TService>(serviceEndpoint, cancellationToken??CancellationToken.None);
             }
 
@@ -458,6 +461,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 throw new NotSupportedException("Not supported since the options can not be passed to the external binary.");
+            }
+            
+            public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
+            {
+                return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/Support/IClientAndService.cs
+++ b/source/Halibut.Tests/Support/IClientAndService.cs
@@ -9,6 +9,7 @@ namespace Halibut.Tests.Support
     public interface IClientAndService : IDisposable
     {
         HalibutRuntime Client { get; }
+        ServiceEndPoint ServiceEndPoint { get; }
         PortForwarder? PortForwarder { get; }
         HttpProxyService? HttpProxy { get; }
         TService CreateClient<TService>(CancellationToken? cancellationToken = null);
@@ -18,5 +19,6 @@ namespace Halibut.Tests.Support
         TClientAndService CreateClient<TService, TClientAndService>(Action<ServiceEndPoint> modifyServiceEndpoint);
         TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>();
         TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint);
+        TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>();
     }
 }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -482,6 +482,8 @@ namespace Halibut.Tests.Support
             }
 
             public HalibutRuntime Client { get; }
+            public ServiceEndPoint ServiceEndPoint => GetServiceEndPoint();
+
             public HalibutRuntime? Service { get; }
             public PortForwarder? PortForwarder { get; }
             public HttpProxyService? HttpProxy { get; }
@@ -531,6 +533,11 @@ namespace Halibut.Tests.Support
                 var serviceEndpoint = GetServiceEndPoint();
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(forceClientProxyType, Client, serviceEndpoint);
+            }
+            
+            public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
+            {
+                return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
             }
 
             public void Dispose()

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
@@ -13,18 +13,19 @@ namespace Halibut.Tests.Support.TestAttributes
         public LatestClientAndPreviousServiceVersionsTestCasesAttribute(bool testWebSocket = true, 
             bool testNetworkConditions = true,
             bool testListening = true,
+            bool testPolling = true,
             bool testAsyncAndSyncClients = true
             ) :
             base(
                 typeof(LatestClientAndPreviousServiceVersionsTestCases),
                 nameof(LatestClientAndPreviousServiceVersionsTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testAsyncAndSyncClients })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients })
         {
         }
         
         static class LatestClientAndPreviousServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testAsyncAndSyncClients)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling,  bool testAsyncAndSyncClients)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -36,6 +37,11 @@ namespace Halibut.Tests.Support.TestAttributes
                 if (!testListening)
                 {
                     serviceConnectionTypes.Remove(ServiceConnectionType.Listening);
+                }
+                
+                if (!testPolling)
+                {
+                    serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
                 
                 ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];


### PR DESCRIPTION
# Background

[SC-54458]

The tests are written twice for sync and again for async.

The reason for this is if we try to use the async test proxy over a sync call we will cause thread pool exhaustion.
Also if we try to use threads in the 'async parallel tests' we are not actually testing what we want to test. Since it should be the case we can, without making threads, run lots of parallel requests.

Eventually when everything is actually async this async side of the test should be changed to show that hundreds of concurrent requests can be made. Since everything is async, we wont have thread pool exhaustion.

# How to review this PR

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
