### PR TITLE
Making timeout stream more network related

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -96,12 +96,9 @@ namespace Halibut.Tests.Diagnostics
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
                     
-                    exception.Message.Should().ContainAny(new[]
-                    {
-                        "Unable to read data from the transport connection: Connection timed out.",
-                        "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."
-                        
-                    });
+                    exception.Message.Should().ContainAny(
+                        "Unable to read data from the transport connection: Connection timed out.", 
+                        "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
                 }
             }
 

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -177,12 +177,11 @@ namespace Halibut.Tests.Timeouts
 
         static void AssertExceptionLooksLikeAWriteTimeout(HalibutClientException? e)
         {
-            
             e.Message.Should().ContainAny(
-        "Unable to write data to the transport connection: Connection timed out.",
-                    " Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
+                "Unable to write data to the transport connection: Connection timed out.",
+                " Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
         }
-        
+
         static void AssertExceptionMessageLooksLikeAReadTimeout(HalibutClientException? e)
         {
             e.Message.Should().ContainAny(

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -97,7 +97,7 @@ namespace Halibut.Tests.Transport.Streams
 
                 actualException.Should().NotBeNull().And.BeOfType<IOException>();
                 actualException!.Message.Should().ContainAny(
-                    "Unable to write data to the transport connection: Connection timed out.",
+                    "Unable to read data to the transport connection: Connection timed out.",
                     "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
@@ -223,7 +223,7 @@ namespace Halibut.Tests.Transport.Streams
                 actualException.Should().NotBeNull().And.BeOfType<IOException>();
                 actualException!.Message.Should().ContainAny(
                     "Unable to write data to the transport connection: Connection timed out.",
-                    "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+                    "Unable to write data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
             }

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -79,7 +79,7 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task ReadAsyncShouldTimeout_AndLookLikeANetworkTimeoutException()
+        public async Task ReadAsyncShouldTimeout_AndThrowExceptionThatLooksLikeANetworkTimeoutException()
         {
             var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
 
@@ -96,7 +96,9 @@ namespace Halibut.Tests.Transport.Streams
                 stopWatch.Stop();
 
                 actualException.Should().NotBeNull().And.BeOfType<IOException>();
-                actualException!.Message.Should().Be("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+                actualException!.Message.Should().ContainAny(
+                    "Unable to write data to the transport connection: Connection timed out.",
+                    "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
             }
@@ -193,7 +195,7 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteAsyncShouldTimeout_AndLookLikeANetworkTimeoutException()
+        public async Task WriteAsyncShouldTimeout_AndThrowExceptionThatLooksLikeANetworkTimeoutException()
         {
             var (disposables, sut, _) = await BuildTcpClientAndTcpListener(
                 CancellationToken, 
@@ -219,7 +221,9 @@ namespace Halibut.Tests.Transport.Streams
                 stopWatch.Stop();
 
                 actualException.Should().NotBeNull().And.BeOfType<IOException>();
-                actualException!.Message.Should().Be("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+                actualException!.Message.Should().ContainAny(
+                    "Unable to write data to the transport connection: Connection timed out.",
+                    "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
             }

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -97,7 +97,7 @@ namespace Halibut.Tests.Transport.Streams
 
                 actualException.Should().NotBeNull().And.BeOfType<IOException>();
                 actualException!.Message.Should().ContainAny(
-                    "Unable to read data to the transport connection: Connection timed out.",
+                    "Unable to read data from the transport connection: Connection timed out.",
                     "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
@@ -223,7 +223,7 @@ namespace Halibut.Tests.Transport.Streams
                 actualException.Should().NotBeNull().And.BeOfType<IOException>();
                 actualException!.Message.Should().ContainAny(
                     "Unable to write data to the transport connection: Connection timed out.",
-                    "Unable to write data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+                    "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
             }

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 namespace Halibut.Tests.Transport.Streams
 {
     [TestTimeout(timeoutInSeconds: 20)]
-    public class TimeoutStreamFixture : BaseTest
+    public class NetworkTimeoutStreamFixture : BaseTest
     {
         [Test]
         public async Task ReadShouldPassThrough()
@@ -79,7 +79,7 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task ReadAsyncShouldTimeout()
+        public async Task ReadAsyncShouldTimeout_AndLookLikeANetworkTimeoutException()
         {
             var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
 
@@ -95,8 +95,8 @@ namespace Halibut.Tests.Transport.Streams
                 
                 stopWatch.Stop();
 
-                actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
-                actualException!.Message.Should().Be("The ReadAsync operation timed out after 00:00:05.");
+                actualException.Should().NotBeNull().And.BeOfType<IOException>();
+                actualException!.Message.Should().Be("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
             }
@@ -193,7 +193,7 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteAsyncShouldTimeout()
+        public async Task WriteAsyncShouldTimeout_AndLookLikeANetworkTimeoutException()
         {
             var (disposables, sut, _) = await BuildTcpClientAndTcpListener(
                 CancellationToken, 
@@ -218,8 +218,8 @@ namespace Halibut.Tests.Transport.Streams
 
                 stopWatch.Stop();
 
-                actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
-                actualException!.Message.Should().Be("The WriteAsync operation timed out after 00:00:05.");
+                actualException.Should().NotBeNull().And.BeOfType<IOException>();
+                actualException!.Message.Should().Be("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
             }
@@ -299,7 +299,7 @@ namespace Halibut.Tests.Transport.Streams
             var clientStream = client.GetStream();
             disposableCollection.Add(clientStream);
 
-            var sut = new TimeoutStream(clientStream);
+            var sut = new NetworkTimeoutStream(clientStream);
             disposableCollection.Add(sut);
 
             while (performServiceWriteFunc == null)

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -31,7 +31,7 @@ namespace Halibut.Transport.Protocol
 
         public MessageExchangeStream(Stream stream, IMessageSerializer serializer, AsyncHalibutFeature asyncHalibutFeature, ILog log)
         {
-            this.stream = asyncHalibutFeature.IsEnabled() ? new RewindableBufferStream(new TimeoutStream(stream), HalibutLimits.RewindableBufferStreamSize) : new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
+            this.stream = asyncHalibutFeature.IsEnabled() ? new RewindableBufferStream(new NetworkTimeoutStream(stream), HalibutLimits.RewindableBufferStreamSize) : new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
             this.log = log;
             this.serializer = serializer;
 

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using System;
 using System.IO;
+using System.Net.Sockets;
 using System.Runtime.Remoting;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,11 +9,11 @@ using Halibut.Util;
 
 namespace Halibut.Transport.Streams
 {
-    class TimeoutStream : Stream
+    class NetworkTimeoutStream : Stream
     {
         readonly Stream inner;
 
-        public TimeoutStream(Stream inner)
+        public NetworkTimeoutStream(Stream inner)
         {
             this.inner = inner;
         }
@@ -114,7 +115,8 @@ namespace Halibut.Transport.Streams
             {
                 if (timeoutCancellationTokenSource.IsCancellationRequested)
                 {
-                    throw new OperationCanceledException($"The {methodName} operation timed out after {TimeSpan.FromMilliseconds(timeout)}.", innerException);
+                    var socketException = new SocketException(10060);
+                    throw new IOException($"Unable to read data from the transport connection: {socketException.Message}.", socketException);
                 }
 
                 if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
# Background

Tests [were failing](https://build.octopushq.com/buildConfiguration/OctopusDeploy_Halibut_ChainFullChain/9106734) on master due to a poison merge.

# Results

## Before

These were happening because more tests were being turned on to use async, which caused the async JSON serialization paths to fire, which then caused the async timeout code paths to be hit.

The exceptions being thrown from the async timeouts did not align with the synchronous versions.

## After

We made the `TimeoutStream` throw the same type of exception that would be thrown when the same network timeout was thrown during synchronous code.

We renamed it to `NetworkTimeoutStream` to help make it obvious why it was here, and to validate the types of exceptions now being thrown from it.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
