### PR TITLE
Make DataStream and IDataSTreamReceiver  async.

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ServiceFactoryFactory.cs
@@ -4,6 +4,7 @@ using Halibut.TestUtils.Contracts.Tentacle.Services;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using FileTransferService = Halibut.TestUtils.SampleProgram.Base.Services.FileTransferService;
 
 namespace Halibut.TestUtils.SampleProgram.Base
 {

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/FileTransferService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/FileTransferService.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Octopus.Tentacle.Contracts;
 
-namespace Halibut.TestUtils.Contracts.Tentacle.Services
+namespace Halibut.TestUtils.SampleProgram.Base.Services
 {
     public class FileTransferService : IFileTransferService
     {

--- a/source/Halibut.Tests/DataStreamFixture.cs
+++ b/source/Halibut.Tests/DataStreamFixture.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         [Obsolete]
-        public async Task ASyncDataStreamWriterCanStillBeUsed(ClientAndServiceTestCase clientAndServiceTestCase)
+        public async Task SyncDataStreamWriterCanStillBeUsed(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()

--- a/source/Halibut.Tests/DataStreamFixture.cs
+++ b/source/Halibut.Tests/DataStreamFixture.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
+using Halibut.TestUtils.Contracts;
+using Halibut.Transport.Streams;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class DataStreamFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
+        [Obsolete]
+        public async Task ASyncDataStreamWriterCanStillBeUsed(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .Build(CancellationToken))
+            {
+                
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+
+                var data = new byte[1337];
+                new Random().NextBytes(data);
+
+                for (var i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
+                {
+                    // Note that the DataStream is only given a sync writer.
+                    var count = await echo.CountBytesAsync(new DataStream(data.Length, stream => stream.Write(data, 0, data.Length)));
+                    count.Should().Be(data.Length);
+                }
+            }
+        }
+        
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncAndSyncClients: false)]
+        public async Task AsyncDataStreamsAreUsedWhenInAsync(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .AsLatestClientAndLatestServiceBuilder()
+                       .WithForcingClientProxyType(ForceClientProxyType.AsyncClient)
+                       .Build(CancellationToken))
+            {
+                var echo = clientAndService.Client.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(clientAndService.GetServiceEndPoint());
+
+                var data = new byte[1337];
+                new Random().NextBytes(data);
+
+                for (var i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
+                {
+                    var count = await echo.CountBytesAsync(new DataStream(data.Length, 
+                        _ => throw new Exception("You have no power here Gandalf the sync"), 
+                        async (stream, ct) => await stream.WriteByteArrayAsync(data, ct)
+                        )
+                    );
+                    count.Should().Be(data.Length);
+                }
+            }
+        }
+        
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        public async Task AsyncDataStreamsCanBeUsedInSyncAndAsync(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+
+                var data = new byte[1337];
+                new Random().NextBytes(data);
+
+                for (var i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
+                {
+                    // Note this only has a async writer.
+                    var count = await echo.CountBytesAsync(new DataStream(data.Length,
+                            async (stream, ct) => await stream.WriteByteArrayAsync(data, ct))
+                    );
+                    count.Should().Be(data.Length);
+                }
+            }
+        }
+
+        [Test]
+        public async Task ASyncDataStreamWriter_CanBeUsedInAsync()
+        {
+            var data = new byte[1337];
+            new Random().NextBytes(data);
+            var ds = new DataStream(data.Length, stream => stream.Write(data, 0, data.Length));
+            using var memoryStream = new MemoryStream();
+            await ((IDataStreamInternal) ds).TransmitAsync(memoryStream, CancellationToken);
+            memoryStream.ToArray().Should().BeEquivalentTo(data);
+        }
+    }
+}

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -192,7 +192,14 @@ namespace Halibut.Tests.Diagnostics
                 {
                     var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
 
-                    var dataStream = new DataStream(10, _ => new FileStream("DoesNotExist2497546", FileMode.Open).Dispose());
+                    var dataStream = new DataStream(10, 
+                        _ => new FileStream("DoesNotExist2497546", FileMode.Open).Dispose(), 
+                        async (_, _) =>
+                            {
+                                await Task.CompletedTask;
+                                new FileStream("DoesNotExist2497546", FileMode.Open).Dispose();
+                                
+                            });
 
                     (await AssertAsync.Throws<HalibutClientException>(async () => await echo.CountBytesAsync(dataStream)))
                         .And
@@ -212,7 +219,13 @@ namespace Halibut.Tests.Diagnostics
                 {
                     var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
 
-                    var dataStream = new DataStream(10, _ => throw new FileNotFoundException());
+                    var dataStream = new DataStream(10, 
+                        _ => throw new FileNotFoundException(), 
+                        async (_, _) =>
+                        {
+                            await Task.CompletedTask.ConfigureAwait(false);
+                            throw new FileNotFoundException();
+                        });
 
                     (await AssertAsync.Throws<HalibutClientException>(() => echo.CountBytesAsync(dataStream)))
                         .And

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -120,7 +121,14 @@ namespace Halibut.Tests
                 // This loop ensures (at the time) the test shows the problem.
                 for (var i = 0; i < 128; i++)
                 {
-                    await AssertAsync.Throws<HalibutClientException>(async () => await readDataSteamService.SendDataAsync(new DataStream(10000, stream => throw new Exception("Oh noes"))));
+                    await AssertAsync.Throws<HalibutClientException>(async () => await readDataSteamService.SendDataAsync(
+                        new DataStream(10000, 
+                            stream => throw new Exception("Oh noes"), 
+                            async (_, _) =>
+                                {
+                                    await Task.CompletedTask;
+                                    throw new Exception("Oh noes");
+                                })));
                 }
 
                 var received = await readDataSteamService.SendDataAsync(DataStream.FromString("hello"));

--- a/source/Halibut.Tests/LocalDataStreamFixture.cs
+++ b/source/Halibut.Tests/LocalDataStreamFixture.cs
@@ -1,33 +1,41 @@
 ﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Tests.Support.TestAttributes;
 using NUnit.Framework;
 
 namespace Halibut.Tests
 {
-    public class LocalDataStreamFixture
+    public class LocalDataStreamFixture : BaseTest
     {
         [Test]
-        public void ShouldUseInMemoryReceiverLocallyToRead()
+        [SyncAndAsync]
+        public async Task ShouldUseInMemoryReceiverLocallyToRead(SyncOrAsync syncOrAsync)
         {
             const string input = "Hello World!";
             var dataStream = DataStream.FromString(input);
 
             string result = null;
-            dataStream.Receiver().Read(stream => result = ReadStreamAsString(stream));
+            await syncOrAsync
+                .WhenSync(() => dataStream.Receiver().Read(stream => result = ReadStreamAsString(stream)))
+                .WhenAsync(async () => await dataStream.Receiver().ReadAsync(async (stream, _) => result = await ReadStreamAsStringAsync(stream), CancellationToken));
 
             result.Should().Be(input);
         }
 
         [Test]
-        public void ShouldUseInMemoryReceiverLocallyToSaveToFile()
+        [SyncAndAsync]
+        public async Task ShouldUseInMemoryReceiverLocallyToSaveToFile(SyncOrAsync syncOrAsync)
         {
             const string input = "We all live in a yellow submarine";
             var dataStream = DataStream.FromString(input);
             var filePath = Path.GetTempFileName();
-
             try
             {
-                dataStream.Receiver().SaveTo(filePath);
+                await syncOrAsync
+                    .WhenSync(() => dataStream.Receiver().SaveTo(filePath))
+                    .WhenAsync(async () => await dataStream.Receiver().SaveToAsync(filePath, CancellationToken));
 
                 File.ReadAllText(filePath).Should().Be(input);
             }
@@ -36,12 +44,21 @@ namespace Halibut.Tests
                File.Delete(filePath);
             }
         }
+        
 
         static string ReadStreamAsString(Stream stream)
         {
             using (var reader = new StreamReader(stream))
             {
                 return reader.ReadToEnd();
+            }
+        }
+        
+        static Task<string> ReadStreamAsStringAsync(Stream stream)
+        {
+            using (var reader = new StreamReader(stream))
+            {
+                return reader.ReadToEndAsync();
             }
         }
     }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -6,6 +6,7 @@ using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
 using Halibut.Tests.Support.Logging;
+using Halibut.Tests.TestServices;
 using Halibut.Tests.TestServices.AsyncSyncCompat;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.Contracts.Tentacle.Services;
@@ -15,6 +16,7 @@ using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.TestPortForwarder;
 using Serilog.Extensions.Logging;
+using ICachingService = Halibut.TestUtils.Contracts.ICachingService;
 
 namespace Halibut.Tests.Support.BackwardsCompatibility
 {

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -7,6 +7,7 @@ using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
 using Halibut.Tests.Support.Logging;
+using Halibut.Tests.TestServices;
 using Halibut.Tests.TestServices.AsyncSyncCompat;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.Contracts.Tentacle.Services;

--- a/source/Halibut.Tests/Support/Streams/LimitedNumberOfBytesPerReadStream.cs
+++ b/source/Halibut.Tests/Support/Streams/LimitedNumberOfBytesPerReadStream.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Transport
+{
+    /// <summary>
+    /// Each read will not read more than the specified number of bytes.
+    ///
+    /// Useful when testing that code actually deals with a read that doesn't return everything in
+    /// one read operation.
+    /// </summary>
+    public class LimitedNumberOfBytesPerReadStream : Stream
+    {
+        readonly Stream baseStream;
+        readonly int maxNumberOfBytesToReadAtATime;
+
+        public LimitedNumberOfBytesPerReadStream(Stream baseStream, int maxNumberOfBytesToReadAtATime)
+        {
+            this.baseStream = baseStream;
+            this.maxNumberOfBytesToReadAtATime = maxNumberOfBytesToReadAtATime;
+        }
+
+        public override void Flush() => baseStream.Flush();
+        
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            count = ReduceReadCountToBufferSize(count);
+            return baseStream.Read(buffer, offset, count);
+        }
+        
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            count = ReduceReadCountToBufferSize(count);
+            return await baseStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => baseStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => baseStream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            baseStream.Write(buffer, offset, count);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await baseStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override bool CanTimeout => baseStream.CanTimeout;
+        
+        public override int ReadTimeout
+        {
+            get => baseStream.ReadTimeout;
+            set => baseStream.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => baseStream.WriteTimeout;
+            set => baseStream.WriteTimeout = value;
+        }
+
+        public override long Length => baseStream.Length;
+
+        public override long Position
+        {
+            get => baseStream.Position;
+            set => baseStream.Position = value;
+        }
+        
+
+        private int ReduceReadCountToBufferSize(int count)
+        {
+            return Math.Min(maxNumberOfBytesToReadAtATime, count);
+        }
+    }
+}

--- a/source/Halibut.Tests/TestServices/FileTransferService.cs
+++ b/source/Halibut.Tests/TestServices/FileTransferService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using Octopus.Tentacle.Contracts;
+
+namespace Halibut.Tests.TestServices
+{
+    public class FileTransferService : IFileTransferService
+    {
+        public UploadResult UploadFile(string remotePath, DataStream upload)
+        {
+            upload.Receiver().SaveTo(remotePath);
+
+            return new UploadResult(remotePath, Guid.NewGuid().ToString(), upload.Length);
+        }
+
+        public DataStream DownloadFile(string remotePath)
+        {
+            return new DataStream(
+                new FileInfo(remotePath).Length,
+                writer =>
+                {
+                    using (var stream = new FileStream(remotePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    {
+                        stream.CopyTo(writer);
+                        writer.Flush();
+                    }
+                },
+                async (writer, ct) =>
+                {
+                    using (var stream = new FileStream(remotePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    {
+                        await stream.CopyToAsync(writer);
+                        await writer.FlushAsync(ct);
+                    }
+                });
+        }
+    }
+}

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -157,7 +157,7 @@ namespace Halibut.Tests.Timeouts
                 
                 // It is not clear why listening doesn't seem to wait to send a control message here.
                 var addControlMessageTimeout = TimeSpan.Zero;
-                if (clientAndServiceTestCase.ServiceConnectionType == ServiceConnectionType.Listening)
+                if (clientAndServiceTestCase.ServiceConnectionType == ServiceConnectionType.Listening && clientAndServiceTestCase.SyncOrAsync == SyncOrAsync.Sync)
                 {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -302,14 +302,14 @@ namespace Halibut.Tests.Transport.Protocol
             }
         }
         
-        async Task<T> ReadMessage<T>(MessageSerializerTestCase testCase, MessageSerializer messageSerializer, RewindableBufferStream RewindableBufferStream)
+        async Task<T> ReadMessage<T>(MessageSerializerTestCase testCase, MessageSerializer messageSerializer, RewindableBufferStream rewindableBufferStream)
         {
             if (testCase.SyncOrAsync == SyncOrAsync.Async)
             {
-                return await messageSerializer.ReadMessageAsync<T>(RewindableBufferStream, CancellationToken);
+                return await messageSerializer.ReadMessageAsync<T>(rewindableBufferStream, CancellationToken);
             }
 
-            return messageSerializer.ReadMessage<T>(RewindableBufferStream);
+            return messageSerializer.ReadMessage<T>(rewindableBufferStream);
         }
 
         async Task WriteMessage(MessageSerializerTestCase testCase, MessageSerializer messageSerializer, Stream stream, string message)

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -302,14 +302,14 @@ namespace Halibut.Tests.Transport.Protocol
             }
         }
         
-        async Task<T> ReadMessage<T>(MessageSerializerTestCase testCase, MessageSerializer messageSerializer, RewindableBufferStream rewindableBufferStream)
+        async Task<T> ReadMessage<T>(MessageSerializerTestCase testCase, MessageSerializer messageSerializer, RewindableBufferStream RewindableBufferStream)
         {
             if (testCase.SyncOrAsync == SyncOrAsync.Async)
             {
-                return await messageSerializer.ReadMessageAsync<T>(rewindableBufferStream, CancellationToken);
+                return await messageSerializer.ReadMessageAsync<T>(RewindableBufferStream, CancellationToken);
             }
 
-            return messageSerializer.ReadMessage<T>(rewindableBufferStream);
+            return messageSerializer.ReadMessage<T>(RewindableBufferStream);
         }
 
         async Task WriteMessage(MessageSerializerTestCase testCase, MessageSerializer messageSerializer, Stream stream, string message)

--- a/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Util;
+using Halibut.Transport;
+using Halibut.Transport.Streams;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Transport.Streams
+{
+    public class StreamExtensionMethodsFixture : BaseTest
+    {
+        public class FunForTheNetworkLongs : IEnumerable<long>
+        {
+            public IEnumerator<long> GetEnumerator()
+            {
+                yield return 0;
+                yield return 1;
+                yield return int.MaxValue;
+                yield return int.MinValue;
+                
+                yield return int.MaxValue + 1L;
+                yield return int.MinValue - 1L;
+                
+                yield return long.MaxValue;
+                yield return long.MinValue;
+                yield return 44093703243L; // 101001000100001100001000010001001011 It looks sort of interesting, maybe we will mess it up when we transmit it.
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        /// <summary>
+        /// The BinaryWriter is what Halibut used when code was sync, so we need to match that.
+        /// </summary>
+        /// <param name="l"></param>
+        [Test]
+        public async Task WriteLongAsyncMatchesBinaryWriter([ValuesOfType(typeof(FunForTheNetworkLongs))] long l)
+        {
+            using var memoryStream = new MemoryStream();
+            await memoryStream.WriteLongAsync(l, CancellationToken);
+            var result = memoryStream.ToArray();
+            result.Should().BeEquivalentTo(BytesFromBinaryWriter(l));
+        }
+        
+        [Test]
+        public async Task WriteLongAsyncWorksWithReadInt64Async([ValuesOfType(typeof(FunForTheNetworkLongs))] long l)
+        {
+            using var memoryStream = new MemoryStream();
+            await memoryStream.WriteLongAsync(l, CancellationToken);
+            memoryStream.WriteString("Random stuff");
+            memoryStream.Position = 0;
+            var res = await memoryStream.ReadInt64Async(CancellationToken);
+            res.Should().Be(l);
+        }
+        
+        /// <summary>
+        /// The BinaryWriter is what Halibut used when code was sync, so we need to match that.
+        /// </summary>
+        /// <param name="l"></param>
+        [Test]
+        public async Task ReadInt64AsyncWorkWithBinaryWriter([ValuesOfType(typeof(FunForTheNetworkLongs))] long l)
+        {
+            using var memoryStream = new MemoryStream();
+            using var binaryWriter = new BinaryWriter(memoryStream);
+            binaryWriter.Write(l);
+            binaryWriter.Flush();
+            memoryStream.WriteString("Random stuff");
+            memoryStream.Position = 0;
+            var res = await memoryStream.ReadInt64Async(CancellationToken);
+            res.Should().Be(l);
+        }
+
+        [Test]
+        public async Task ReadBytesAsyncWillKeepReadingUntilItHasReadEnoughBytes(
+            [Values(1,2,3, 7, 21)] int readSize)
+        {
+            using var memoryStream = new MemoryStream();
+            memoryStream.WriteString("ReadBytesAsyncWillReadUntilItHasReadEnoughBytes");
+            memoryStream.Position = 0;
+
+            var limitedReadingStream = new LimitedNumberOfBytesPerReadStream(memoryStream, readSize);
+
+            var bytes = await limitedReadingStream.ReadBytesAsync(29, CancellationToken);
+
+            Encoding.UTF8.GetString(bytes).Should().Be("ReadBytesAsyncWillReadUntilIt");
+        }
+        
+        [Test]
+        public async Task ReadBytesAsyncWillStopReadingIfTheEndIsReached()
+        {
+            using var memoryStream = new MemoryStream();
+            memoryStream.WriteString("not enough");
+            memoryStream.Position = 0;
+            
+            await AssertAsync.Throws<EndOfStreamException>(async () => await memoryStream.ReadBytesAsync(1000, CancellationToken));
+        }
+
+        byte[] BytesFromBinaryWriter(long l)
+        {
+            using var memoryStream = new MemoryStream();
+            using var binaryWriter = new BinaryWriter(memoryStream);
+            binaryWriter.Write(l);
+            binaryWriter.Flush();
+            return memoryStream.ToArray();
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/DataStreamUtil.cs
+++ b/source/Halibut.Tests/Util/DataStreamUtil.cs
@@ -8,14 +8,23 @@ namespace Halibut.Tests.Util
         {
             var helloBytes = firstSend.GetBytesUtf8();
             var allDoneBytes = thenSend.GetBytesUtf8();
-            return new DataStream(helloBytes.Length + allDoneBytes.Length, stream =>
-            {
-                stream.Write(helloBytes, 0, helloBytes.Length);
-                stream.Flush();
-                andThenRun();
-                stream.Write(allDoneBytes, 0, allDoneBytes.Length);
-                stream.Flush();
-            });
+            return new DataStream(helloBytes.Length + allDoneBytes.Length,
+                stream =>
+                {
+                    stream.Write(helloBytes, 0, helloBytes.Length);
+                    stream.Flush();
+                    andThenRun();
+                    stream.Write(allDoneBytes, 0, allDoneBytes.Length);
+                    stream.Flush();
+                },
+                async (stream, ct) =>
+                {
+                    await stream.WriteAsync(helloBytes, 0, helloBytes.Length, ct);
+                    await stream.FlushAsync(ct);
+                    andThenRun();
+                    await stream.WriteAsync(allDoneBytes, 0, allDoneBytes.Length, ct);
+                    await stream.FlushAsync(ct);
+                });
         }
     }
 }

--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -128,8 +128,7 @@ namespace Halibut
                     await writer.FlushAsync();
                 });
         }
-
-        // TODO test
+        
         public static DataStream FromStreamAsync(Stream source, Func<int, CancellationToken, Task> updateProgress)
         {
             updateProgress ??= (_, _) => Task.CompletedTask;

--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Transport.Protocol;
 using Newtonsoft.Json;
 
@@ -9,18 +11,38 @@ namespace Halibut
     public class DataStream : IEquatable<DataStream>, IDataStreamInternal
     {
         readonly Action<Stream> writer;
+        readonly Func<Stream, CancellationToken, Task> writerAsync;
         IDataStreamReceiver receiver;
 
         [JsonConstructor]
         public DataStream()
         {
         }
-
-        public DataStream(long length, Action<Stream> writer)
+        
+        public DataStream(long length, Action<Stream> writer, Func<Stream, CancellationToken, Task> writerAsync)
         {
             Length = length;
             Id = Guid.NewGuid();
             this.writer = writer;
+            this.writerAsync = writerAsync;
+        }
+
+        [Obsolete]
+        public DataStream(long length, Action<Stream> writer)
+            : this(
+                length,
+                writer,
+                async (stream, ct) =>
+                {
+                    await Task.CompletedTask;
+                    writer(stream);
+                })
+        {
+        }
+
+        public DataStream(long length, Func<Stream, CancellationToken, Task> writerAsync)
+            : this(length, stream => writerAsync(stream, CancellationToken.None).GetAwaiter().GetResult(), writerAsync)
+        {
         }
 
         [JsonProperty("id")]
@@ -38,9 +60,9 @@ namespace Halibut
             // exceptions with MemoryStream.
             var maxMemoryStreamLength = int.MaxValue;
             if (Length >= maxMemoryStreamLength)
-                return new TemporaryFileDataStreamReceiver(writer);
+                return new TemporaryFileDataStreamReceiver(writer, writerAsync);
             else
-                return new InMemoryDataStreamReceiver(writer);
+                return new InMemoryDataStreamReceiver(writer, writerAsync);
         }
 
         public bool Equals(DataStream other)
@@ -75,7 +97,12 @@ namespace Halibut
 
         public static DataStream FromBytes(byte[] data)
         {
-            return new DataStream(data.Length, stream => stream.Write(data, 0, data.Length));
+            return new DataStream(data.Length, 
+                stream => stream.Write(data, 0, data.Length), 
+                async (stream, ct) =>
+                    {
+                        await stream.WriteAsync(data, 0, data.Length, ct);
+                    });
         }
 
         public static DataStream FromString(string text)
@@ -85,18 +112,48 @@ namespace Halibut
 
         public static DataStream FromString(string text, Encoding encoding)
         {
-            return new DataStream(encoding.GetByteCount(text), stream =>
+            return new DataStream(encoding.GetByteCount(text), 
+                stream =>
             {
                 var writer = new StreamWriter(stream, encoding);
                 writer.Write(text);
                 writer.Flush();
-            });
+            },
+                async (stream, ct) =>
+                {
+                    var writer = new StreamWriter(stream, encoding);
+                    // TODO - ASYNC ME UP!
+                    // Writer does not support taking a cancellation token, should we do something else here?
+                    await writer.WriteAsync(text);
+                    await writer.FlushAsync();
+                });
+        }
+
+        // TODO test
+        public static DataStream FromStreamAsync(Stream source, Func<int, CancellationToken, Task> updateProgress)
+        {
+            updateProgress ??= (_, _) => Task.CompletedTask;
+
+            return FromStream(source, 
+                i => updateProgress(i, CancellationToken.None).GetAwaiter().GetResult(),
+                updateProgress);
         }
 
         public static DataStream FromStream(Stream source, Action<int> updateProgress)
         {
-            var streamer = new StreamingDataStream(source, updateProgress ?? ((progress) => { }));
-            return new DataStream(source.Length, streamer.CopyAndReportProgress);
+            updateProgress ??= _ => { };
+
+            return FromStream(source, updateProgress, (i, token) =>
+            {
+                updateProgress(i);
+                return Task.CompletedTask;
+            });
+        }
+        
+        public static DataStream FromStream(Stream source, Action<int> updateProgress, Func<int, CancellationToken, Task> updateProgressAsync)
+        {
+            var streamer = new StreamingDataStream(source, updateProgress, updateProgressAsync);
+            return new DataStream(source.Length, streamer.CopyAndReportProgress, streamer.CopyAndReportProgressAsync);
         }
 
         public static DataStream FromStream(Stream source)
@@ -109,11 +166,13 @@ namespace Halibut
             const int BufferSize = 84000;
             readonly Stream source;
             readonly Action<int> updateProgress;
+            readonly Func<int, CancellationToken, Task> updateProgressAsync;
 
-            public StreamingDataStream(Stream source, Action<int> updateProgress)
+            public StreamingDataStream(Stream source, Action<int> updateProgress, Func<int, CancellationToken, Task> updateProgressAsync)
             {
                 this.source = source;
                 this.updateProgress = updateProgress;
+                this.updateProgressAsync = updateProgressAsync;
             }
 
             public void CopyAndReportProgress(Stream destination)
@@ -149,6 +208,40 @@ namespace Halibut
 
                 destination.Flush();
             }
+            
+            public async Task CopyAndReportProgressAsync(Stream destination, CancellationToken cancellationToken)
+            {
+                var readBuffer = new byte[BufferSize];
+                var writeBuffer = new byte[BufferSize];
+
+                var progress = 0;
+                
+                var totalLength = source.Length;
+                long copiedSoFar = 0;
+                source.Seek(0, SeekOrigin.Begin);
+
+                var count = await source.ReadAsync(readBuffer, 0, BufferSize, cancellationToken);
+                while (count > 0)
+                {
+                    Swap(ref readBuffer, ref writeBuffer);
+                    var asyncResult = destination.BeginWrite(writeBuffer, 0, count, null, null);
+                    count = await source.ReadAsync(readBuffer, 0, BufferSize, cancellationToken);
+                    destination.EndWrite(asyncResult);
+
+                    copiedSoFar += count;
+
+                    var progressNow = (int)((double)copiedSoFar / totalLength * 100.00);
+                    if (progressNow == progress)
+                        continue;
+                    await updateProgressAsync(progressNow, cancellationToken);
+                    progress = progressNow;
+                }
+
+                if (progress != 100)
+                    updateProgress(100);
+
+                await destination.FlushAsync(cancellationToken);
+            }
 
             static void Swap<T>(ref T x, ref T y)
             {
@@ -161,6 +254,11 @@ namespace Halibut
         void IDataStreamInternal.Transmit(Stream stream)
         {
             writer(stream);
+        }
+
+        async Task IDataStreamInternal.TransmitAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            await writerAsync(stream, cancellationToken);
         }
 
         void IDataStreamInternal.Received(IDataStreamReceiver attachedReceiver)

--- a/source/Halibut/IDataStreamInternal.cs
+++ b/source/Halibut/IDataStreamInternal.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut
 {
@@ -7,5 +9,6 @@ namespace Halibut
     {
         void Received(IDataStreamReceiver receiver);
         void Transmit(Stream stream);
+        Task TransmitAsync(Stream stream, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/IDataStreamReceiver.cs
+++ b/source/Halibut/IDataStreamReceiver.cs
@@ -1,11 +1,15 @@
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut
 {
     public interface IDataStreamReceiver
     {
         void SaveTo(string filePath);
+        Task SaveToAsync(string filePath, CancellationToken cancellationToken);
         void Read(Action<Stream> reader);
+        Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/InMemoryDataStreamReceiver.cs
+++ b/source/Halibut/Transport/Protocol/InMemoryDataStreamReceiver.cs
@@ -1,15 +1,19 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.Transport.Protocol
 {
     public class InMemoryDataStreamReceiver : IDataStreamReceiver
     {
         readonly Action<Stream> writer;
+        readonly Func<Stream, CancellationToken, Task> writerAsync;
 
-        public InMemoryDataStreamReceiver(Action<Stream> writer)
+        public InMemoryDataStreamReceiver(Action<Stream> writer, Func<Stream, CancellationToken, Task> writerAsync)
         {
             this.writer = writer;
+            this.writerAsync = writerAsync;
         }
 
         public void SaveTo(string filePath)
@@ -17,6 +21,14 @@ namespace Halibut.Transport.Protocol
             using (var file = new FileStream(filePath, FileMode.Create))
             {
                 writer(file);
+            }
+        }
+        
+        public async Task SaveToAsync(string filePath, CancellationToken cancellationToken)
+        {
+            using (var file = new FileStream(filePath, FileMode.Create))
+            {
+                await writerAsync(file, cancellationToken);
             }
         }
 
@@ -27,6 +39,16 @@ namespace Halibut.Transport.Protocol
                 writer(stream);
                 stream.Seek(0, SeekOrigin.Begin);
                 reader(stream);
+            }
+        }
+        
+        public async Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken)
+        {
+            using (var stream = new MemoryStream())
+            {
+                await writerAsync(stream, cancellationToken);
+                stream.Seek(0, SeekOrigin.Begin);
+                await readerAsync(stream, cancellationToken);
             }
         }
     }

--- a/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
+++ b/source/Halibut/Transport/Protocol/TemporaryFileDataStreamReceiver.cs
@@ -1,15 +1,19 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.Transport.Protocol
 {
     public class TemporaryFileDataStreamReceiver : IDataStreamReceiver
     {
         readonly Action<Stream> writer;
+        readonly Func<Stream, CancellationToken, Task> writerAsync;
 
-        public TemporaryFileDataStreamReceiver(Action<Stream> writer)
+        public TemporaryFileDataStreamReceiver(Action<Stream> writer, Func<Stream, CancellationToken, Task> writerAsync)
         {
             this.writer = writer;
+            this.writerAsync = writerAsync;
         }
 
         public void SaveTo(string filePath)
@@ -17,6 +21,14 @@ namespace Halibut.Transport.Protocol
             using (var file = new FileStream(filePath, FileMode.Create))
             {
                 writer(file);
+            }
+        }
+
+        public async Task SaveToAsync(string filePath, CancellationToken cancellationToken)
+        {
+            using (var file = new FileStream(filePath, FileMode.Create))
+            {
+                await writerAsync(file, cancellationToken);
             }
         }
 
@@ -30,6 +42,25 @@ namespace Halibut.Transport.Protocol
                     writer(fileStream);
                     fileStream.Seek(0, SeekOrigin.Begin);
                     reader(fileStream);
+                }
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+        }
+
+        public async Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken)
+        {
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 65536))
+                {
+                    await writerAsync(fileStream, cancellationToken);
+                    fileStream.Seek(0, SeekOrigin.Begin);
+                    await readerAsync(fileStream, cancellationToken);
                 }
             }
             finally

--- a/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +30,72 @@ namespace Halibut.Transport.Streams
             // Keep the same behaviour as ReadByte, which returns -1 if at the end of the stream
             if (count == 0) return -1;
             return b[0];
+        }
+        
+        /// <summary>
+        /// Writes a long to a stream in the same way that BinaryWriter does.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="value"></param>
+        /// <param name="cancellationToken"></param>
+        public static async Task WriteLongAsync(this Stream stream, long value, CancellationToken cancellationToken)
+        {
+            // An exact copy of:
+            // System.IO.BinaryWriter.Write(long)
+            var buffer = new byte[8];
+            buffer[0] = (byte) value;
+            buffer[1] = (byte) (value >> 8);
+            buffer[2] = (byte) (value >> 16);
+            buffer[3] = (byte) (value >> 24);
+            buffer[4] = (byte) (value >> 32);
+            buffer[5] = (byte) (value >> 40);
+            buffer[6] = (byte) (value >> 48);
+            buffer[7] = (byte) (value >> 56);
+            await stream.WriteAsync(buffer, 0, 8, cancellationToken);
+        }
+        
+        /// <summary>
+        /// Net48 does not have a method which just writes all bytes of an array to a stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="bytes"></param>
+        /// <param name="cancellationToken"></param>
+        public static async Task WriteByteArrayAsync(this Stream stream, byte[] bytes, CancellationToken cancellationToken)
+        {
+            await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+        }
+        
+        public static async Task<byte[]> ReadBytesAsync(this Stream stream, int countToRead, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[countToRead];
+            int readSoFar = 0;
+            while (buffer.Length > readSoFar)
+            {
+                int readLastTime = await stream.ReadAsync(buffer, readSoFar, buffer.Length - readSoFar, cancellationToken);
+                if (readLastTime == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                readSoFar += readLastTime;
+            }
+
+            return buffer;
+        }
+        
+        /// <summary>
+        /// Reads a long (well Int64) from a stream in the same way as BinaryWriter does.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static async Task<long> ReadInt64Async(this Stream stream, CancellationToken cancellationToken)
+        {
+            var buffer = await ReadBytesAsync(stream, 8, cancellationToken);
+            // A copy of System.IO.BinaryReader.ReadInt64
+            // ReSharper disable RedundantCast
+            return (long) (uint) ((int) buffer[4] | (int) buffer[5] << 8 | (int) buffer[6] << 16 | (int) buffer[7] << 24) << 32 | (long) (uint) ((int) buffer[0] | (int) buffer[1] << 8 | (int) buffer[2] << 16 | (int) buffer[3] << 24);
+            // ReSharper restore RedundantCast
         }
     }
 }


### PR DESCRIPTION
# Background

[SC-53211]

Makes DataStream IDataSTreamReceiver  async.

DataStream can not be given an async writer, which will be used in async modes.

DataStream has a new constructor which can take both a async/sync writers. The DataStream's current ctor which takes only a sync writer will continue work and will result in async code calling sync code. This has been marked as obsolete.



# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
