### PR TITLE
HttpProxy Disposal and Pausing + ProxyFixture Tests + HttpProxyClient Async Timeout Bugs

### DIFF
--- a/source/Halibut.TestProxy/CancellationTokenExtensionMethods.cs
+++ b/source/Halibut.TestProxy/CancellationTokenExtensionMethods.cs
@@ -19,5 +19,21 @@ namespace Halibut.TestProxy
 
             return tcs.Task;
         }
+
+        public static Task AsTask(this CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<VoidResult>();
+
+            IDisposable registration = null;
+            registration = cancellationToken.Register(() =>
+            {
+                tcs.TrySetCanceled();
+                registration?.Dispose();
+            }, useSynchronizationContext: false);
+
+            return tcs.Task;
+        }
+
+        private struct VoidResult { }
     }
 }

--- a/source/Halibut.TestProxy/HttpProxyService.cs
+++ b/source/Halibut.TestProxy/HttpProxyService.cs
@@ -43,7 +43,7 @@ namespace Halibut.TestProxy
 
         public async Task StartAsync()
         {
-            var _ = Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 try
                 {
@@ -52,6 +52,12 @@ namespace Halibut.TestProxy
                 catch (Exception ex)
                 {
                     logger.LogError(ex, "An error has occurred running the HTTP proxy service");
+                }
+                finally
+                {
+                    // Ensure that StartAsync can complete,
+                    // regardless of whether there was an error or not
+                    started = true;
                 }
             });
 
@@ -192,8 +198,9 @@ namespace Halibut.TestProxy
             }
             finally
             {
-                await reader.CompleteAsync();
-                await writer.CompleteAsync();
+                await Task.WhenAll(
+                    reader.CompleteAsync().AsTask(),
+                    writer.CompleteAsync().AsTask());
             }
         }
 

--- a/source/Halibut.TestProxy/HttpProxyService.cs
+++ b/source/Halibut.TestProxy/HttpProxyService.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 #if !NET5_0_OR_GREATER
@@ -26,11 +25,14 @@ namespace Halibut.TestProxy
 
     record HttpProxyConnectionRequest(ProxyEndpoint Endpoint, string HttpVersion);
 
-    public class HttpProxyService : BackgroundService
+    public class HttpProxyService : IDisposable
     {
         readonly HttpProxyOptions options;
         readonly ILogger<HttpProxyService> logger;
         readonly IProxyConnectionService proxyConnectionService;
+        readonly CancellationTokenSource cancellationTokenSource = new();
+        bool pauseNewConnections = false;
+        bool started = false;
 
         public HttpProxyService(HttpProxyOptions options, ILoggerFactory loggerFactory)
         {
@@ -39,17 +41,39 @@ namespace Halibut.TestProxy
             this.logger = loggerFactory.CreateLogger<HttpProxyService>();
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        public async Task StartAsync()
         {
+            var _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await StartInternalAsync();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error has occurred running the HTTP proxy service");
+                }
+            });
+
+            while (!started)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationTokenSource.Token);
+            }
+        }
+
+        public async Task StartInternalAsync()
+        {
+            var cancellationToken = cancellationTokenSource.Token;
+
             var listener = await TcpListenerHelpers.GetTcpListener(options.Listen);
             listener.Start();
             Endpoint = (IPEndPoint)listener.LocalEndpoint;
-
+            started = true;
             logger.LogInformation("Listening for HTTP proxy requests on {Listen}", listener.Server.LocalEndPoint);
 
             try
             {
-                while (!stoppingToken.IsCancellationRequested)
+                while (!cancellationToken.IsCancellationRequested)
                 {
                     try
                     {
@@ -57,27 +81,38 @@ namespace Halibut.TestProxy
 
 #if DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS
                         using var socketCancellationTokenSource = new CancellationTokenSource();
-                        using (stoppingToken.Register(() =>
-                               {
-                                   try
-                                   {
-                                       socketCancellationTokenSource.Cancel();
-                                   }
-                                   catch
-                                   {
-                                   }
-
-                               }))
+                        using (cancellationToken.Register(() => Try.CatchingError(() => socketCancellationTokenSource.Cancel(), _ => { })))
                         {
                             var cancelTask = socketCancellationTokenSource.Token.AsTask<TcpClient?>();
-                            var actionTask = Task.Run(() => listener.AcceptTcpClientAsync(), stoppingToken);
+                            var actionTask = Task.Run(async () =>
+                            {
+                                using var _ = cancellationToken.Register(() => Try.CatchingError(() =>
+                                {
+                                    listener.Stop();
+                                    logger.LogInformation($"Stopped listening for HTTP proxy requests");
+                                }, _ => { }));
+                                return await listener.AcceptTcpClientAsync();
+                            }, cancellationToken);
 
                             client = await (await Task.WhenAny(actionTask, cancelTask).ConfigureAwait(false)).ConfigureAwait(false);
                         }
 #else
-                    client = await listener.AcceptTcpClientAsync(stoppingToken);
+                        client = await listener.AcceptTcpClientAsync(cancellationToken);
 #endif
-                        _ = Task.Run(async () => await HandleProxyRequest(client!, stoppingToken), stoppingToken);
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        logger.LogInformation($"Accepted HTTP proxy request from {client.Client.RemoteEndPoint}");
+
+                        _ = Task.Run(async () =>
+                        {
+                            if (pauseNewConnections)
+                            {
+                                logger.LogInformation($"Pausing HTTP proxy request from {client.Client.RemoteEndPoint}");
+                                await Task.Delay(-1, cancellationToken);
+                            }
+
+                            await HandleProxyRequest(client!, cancellationToken);
+                        }, cancellationToken);
                     }
                     catch (OperationCanceledException)
                     {
@@ -88,6 +123,8 @@ namespace Halibut.TestProxy
             finally
             {
                 listener.Stop();
+                listener = null;
+                logger.LogInformation($"Stopped listening for HTTP proxy requests");
             }
         }
 
@@ -95,63 +132,69 @@ namespace Halibut.TestProxy
 
         async Task HandleProxyRequest(TcpClient client, CancellationToken cancellationToken)
         {
-        if (cancellationToken.IsCancellationRequested) return;
+            if (cancellationToken.IsCancellationRequested) return;
 
-        var stream = client.GetStream();
-        if (client.Client.RemoteEndPoint is not IPEndPoint sourceRemoteEndpoint)
-        {
-            throw new InvalidOperationException($"{client.Client.RemoteEndPoint} is not an {nameof(IPEndPoint)}");
-        }
-
-        var sourceEndpoint = new ProxyEndpoint(sourceRemoteEndpoint.Address.ToString(), sourceRemoteEndpoint.Port);
-
-        // Set up some pipes to handle reading and replying to the connect request
-        var reader = PipeReader.Create(stream, new StreamPipeReaderOptions(leaveOpen: true));
-        var writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
-
-        try
-        {
-            HttpProxyConnectionRequest? connectionRequest = null;
-            try
+            var stream = client.GetStream();
+            if (client.Client.RemoteEndPoint is not IPEndPoint sourceRemoteEndpoint)
             {
-                connectionRequest = await ParseConnectionRequest(sourceEndpoint, reader, cancellationToken);
+                throw new InvalidOperationException($"{client.Client.RemoteEndPoint} is not an {nameof(IPEndPoint)}");
             }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error has occurred parsing CONNECT request from {SourceEndpoint}", sourceEndpoint);
-                await SendConnectResponse(sourceEndpoint, "1.0", 400, "Bad request", writer, cancellationToken);
-                return;
-            }
+
+            var sourceEndpoint = new ProxyEndpoint(sourceRemoteEndpoint.Address.ToString(), sourceRemoteEndpoint.Port);
+
+            // Set up some pipes to handle reading and replying to the connect request
+            var reader = PipeReader.Create(stream, new StreamPipeReaderOptions(leaveOpen: true));
+            var writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
 
             try
             {
-                await CreateProxyConnectionAndForward(client, connectionRequest, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError("An error has occurred establishing proxy connection: {SourceEndpoint} <-> {DestinationEndpoint}. Error: {ErrorMessage}", sourceEndpoint, connectionRequest!.Endpoint, ex.Message);
-                await SendConnectResponse(sourceEndpoint, connectionRequest.HttpVersion, 502, "Bad gateway", writer, cancellationToken);
-                return;
-            }
+                HttpProxyConnectionRequest? connectionRequest = null;
 
-            try
-            {
-                await SendConnectResponse(sourceEndpoint, connectionRequest.HttpVersion, 200, "Connection established", writer, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error has occurred responding to CONNECT request: {SourceEndpoint} <-> {DestinationEndpoint}", sourceEndpoint, connectionRequest!.Endpoint);
-                return;
-            }
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    logger.LogInformation("Parsing Connection Request");
+                    connectionRequest = await ParseConnectionRequest(sourceEndpoint, reader, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error has occurred parsing CONNECT request from {SourceEndpoint}", sourceEndpoint);
+                    await SendConnectResponse(sourceEndpoint, "1.0", 400, "Bad request", writer, cancellationToken);
+                    return;
+                }
 
-            logger.LogInformation("CONNECT request successful: {SourceEndpoint} -> {DestinationEndpoint}", sourceEndpoint, connectionRequest.Endpoint);
-        }
-        finally
-        {
-            await reader.CompleteAsync();
-            await writer.CompleteAsync();
-        }
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    logger.LogInformation("Creating Proxy Connection Forwarder");
+                    await CreateProxyConnectionAndForward(client, connectionRequest, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError("An error has occurred establishing proxy connection: {SourceEndpoint} <-> {DestinationEndpoint}. Error: {ErrorMessage}", sourceEndpoint, connectionRequest!.Endpoint, ex.Message);
+                    await SendConnectResponse(sourceEndpoint, connectionRequest.HttpVersion, 502, "Bad gateway", writer, cancellationToken);
+                    return;
+                }
 
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    logger.LogInformation("Sending Connect Response");
+                    await SendConnectResponse(sourceEndpoint, connectionRequest.HttpVersion, 200, "Connection established", writer, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An error has occurred responding to CONNECT request: {SourceEndpoint} <-> {DestinationEndpoint}", sourceEndpoint, connectionRequest!.Endpoint);
+                    return;
+                }
+
+                logger.LogInformation("CONNECT request successful: {SourceEndpoint} -> {DestinationEndpoint}", sourceEndpoint, connectionRequest.Endpoint);
+            }
+            finally
+            {
+                await reader.CompleteAsync();
+                await writer.CompleteAsync();
+            }
         }
 
         async Task CreateProxyConnectionAndForward(TcpClient client, HttpProxyConnectionRequest connectionRequest, CancellationToken cancellationToken)
@@ -236,12 +279,20 @@ namespace Halibut.TestProxy
             message = outputMessage.ToString();
             return message.Length != 0;
         }
-
-        public override void Dispose()
+        
+        public void PauseNewConnections()
         {
-            proxyConnectionService.Dispose();
+            pauseNewConnections = true;
+            logger.LogInformation("Pausing new HTTP Proxy connections");
+        }
 
-            base.Dispose();
+        public void Dispose()
+        {
+            logger.LogInformation("Starting Disposal");
+            Try.CatchingError(() => cancellationTokenSource.Cancel(), e => logger.LogWarning(e, "Error cancelling cancellationTokenSource"));
+            Try.CatchingError(() => cancellationTokenSource.Dispose(), e => logger.LogWarning(e, "Error disposing of cancellationTokenSource"));
+            Try.CatchingError(() => proxyConnectionService.Dispose(), e => logger.LogWarning(e, "Error disposing of proxyConnectionService"));
+            logger.LogInformation("Finished Disposal");
         }
     }
 }

--- a/source/Halibut.TestProxy/ProxyConnection.cs
+++ b/source/Halibut.TestProxy/ProxyConnection.cs
@@ -35,7 +35,7 @@ namespace Halibut.TestProxy
 
             var sourceEndpoint = new ProxyEndpoint(sourceRemoteEndpoint.Address.ToString(), sourceRemoteEndpoint.Port);
             var destination = new TcpClient(destinationEndpoint.Hostname, destinationEndpoint.Port);
-            var tunnel = new TcpTunnel(source, destination);
+            var tunnel = new TcpTunnel(source, destination, logger);
             tunnels!.Add(tunnel);
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/source/Halibut.TestProxy/TcpTunnel.cs
+++ b/source/Halibut.TestProxy/TcpTunnel.cs
@@ -31,7 +31,7 @@ namespace Halibut.TestProxy
                 var fromStreamTask = fromStream.CopyToAsync(toWriter, cancellationToken);
                 var toStreamTask = toStream.CopyToAsync(fromWriter, cancellationToken);
 
-                await Task.WhenAny(fromStreamTask, toStreamTask);
+                await Task.WhenAny(fromStreamTask, toStreamTask, cancellationToken.AsTask());
             }
             catch (Exception)
             {
@@ -40,6 +40,10 @@ namespace Halibut.TestProxy
             {
                 await fromWriter.CompleteAsync();
                 await toWriter.CompleteAsync();
+                fromStream.Close();
+                toStream.Close();
+                fromClient.Close();
+                toClient.Close();
             }
         }
 

--- a/source/Halibut.TestProxy/TcpTunnel.cs
+++ b/source/Halibut.TestProxy/TcpTunnel.cs
@@ -3,6 +3,7 @@ using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Halibut.TestProxy
 {
@@ -10,12 +11,14 @@ namespace Halibut.TestProxy
     {
         readonly TcpClient fromClient;
         readonly TcpClient toClient;
+        readonly ILogger _logger;
         bool disposedValue;
 
-        public TcpTunnel(TcpClient fromClient, TcpClient toClient)
+        public TcpTunnel(TcpClient fromClient, TcpClient toClient, ILogger logger)
         {
             this.fromClient = fromClient;
             this.toClient = toClient;
+            _logger = logger;
         }
 
         public async Task Tunnel(CancellationToken cancellationToken)
@@ -38,12 +41,14 @@ namespace Halibut.TestProxy
             }
             finally
             {
-                await fromWriter.CompleteAsync();
-                await toWriter.CompleteAsync();
-                fromStream.Close();
-                toStream.Close();
-                fromClient.Close();
-                toClient.Close();
+                await Task.WhenAll(
+                    fromWriter.CompleteAsync().AsTask(),
+                    toWriter.CompleteAsync().AsTask());
+                
+                Try.CatchingError(() => fromStream.Close(), e => { _logger.LogWarning("Error closing fromStream"); });
+                Try.CatchingError(() => toStream.Close(), e => { _logger.LogWarning("Error closing toStream"); });
+                Try.CatchingError(() => fromClient.Close(), e => { _logger.LogWarning("Error closing fromClient"); });
+                Try.CatchingError(() => toClient.Close(), e => { _logger.LogWarning("Error closing toClient");});
             }
         }
 

--- a/source/Halibut.TestProxy/Try.cs
+++ b/source/Halibut.TestProxy/Try.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Halibut.TestProxy
+{
+    public static class Try
+    {
+        public static void CatchingError(Action tryThisAction, Action<Exception> onFailure)
+        {
+            try
+            {
+                tryThisAction();
+            }
+            catch (Exception e)
+            {
+                onFailure(e);
+            }
+        }
+
+        public static async Task<Exception?> CatchingError(Func<Task> tryThisAction)
+        {
+            try
+            {
+                await tryThisAction();
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+
+            return null;
+        }
+    }
+}

--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
-using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
@@ -17,7 +15,7 @@ namespace Halibut.Tests
         [Test]
         [LatestAndPreviousClientAndServiceVersionsTestCases(testWebSocket: false)]
         // PollingOverWebSockets does not support (or use) ProxyDetails if provided.
-        public async Task OctopusCanSendMessagesToTentacle_WithEchoService_AndAProxy(ClientAndServiceTestCase clientAndServiceTestCase)
+        public async Task ClientCanSendMessagesToService_WhenUsingAProxy(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
@@ -25,33 +23,67 @@ namespace Halibut.Tests
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
-                (await echo.SayHelloAsync("Deploy package A")).Should().Be("Deploy package A...");
+                (await echo.SayHelloAsync("Hello")).Should().Be("Hello...");
 
                 for (var i = 0; i < 5; i++)
                 {
-                    (await echo.SayHelloAsync($"Deploy package A {i}")).Should().Be($"Deploy package A {i}...");
+                    (await echo.SayHelloAsync($"Hello {i}")).Should().Be($"Hello {i}...");
                 }
             }
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false, testWebSocket: false, 
-            testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
-            // This doesn't work in async.
-            )]
-        // PollingOverWebSockets does not support (or use) ProxyDetails if provided.
-        public async Task OctopusCanNotSendMessagesToTentacle_WithEchoService_AndABrokenProxy(ClientAndServiceTestCase clientAndServiceTestCase)
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
+        public async Task ClientTimesOutConnectingToAProxy_WhenTheProxyIsUnavailable(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithHalibutLoggingLevel(LogLevel.Trace)
                        .WithStandardServices()
                        .WithProxy()
                        .Build(CancellationToken))
             {
-                await clientAndService.HttpProxy!.StopAsync(CancellationToken.None);
+                clientAndService.HttpProxy!.Dispose();
 
-                var echo = clientAndService.CreateClient<IEchoService>();
-                Func<string> action = () => echo.SayHello("Deploy package A");
-                action.Should().Throw<HalibutClientException>();
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>(point =>
+                {
+                    point.TcpClientConnectTimeout = TimeSpan.FromSeconds(5);
+                    point.RetryCountLimit = 2;
+                    point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
+                });
+
+                Func<Task<string>> action = async () => await echo.SayHelloAsync("Hello");
+                (await action.Should().ThrowAsync<HalibutClientException>()).And.Message.Should().ContainAny(
+                    "No connection could be made because the target machine actively refused it",
+                    "the polling endpoint did not collect the request within the allowed time",
+                    "Connection refused");
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
+        public async Task ClientTimesOutConnectingToAProxy_WhenTheProxyHangsDuringConnect(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithHalibutLoggingLevel(LogLevel.Trace)
+                       .WithStandardServices()
+                       .WithProxy()
+                       .Build(CancellationToken))
+            {
+                clientAndService.HttpProxy!.PauseNewConnections();
+
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>(point =>
+                {
+                    point.TcpClientConnectTimeout = TimeSpan.FromSeconds(5);
+                    point.RetryCountLimit = 2;
+                    point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
+                });
+                
+
+                Func<Task<string>> action = async () => await echo.SayHelloAsync("Hello");
+                (await action.Should().ThrowAsync<HalibutClientException>()).And.Message.Should().ContainAny(
+                    "No connection could be made because the target machine actively refused it",
+                    "the polling endpoint did not collect the request within the allowed time",
+                    "A timeout while waiting for the proxy server at"); ;
             }
         }
     }

--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
+using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
@@ -51,11 +52,11 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
                 });
 
-                Func<Task<string>> action = async () => await echo.SayHelloAsync("Hello");
-                (await action.Should().ThrowAsync<HalibutClientException>()).And.Message.Should().ContainAny(
-                    "No connection could be made because the target machine actively refused it",
-                    "the polling endpoint did not collect the request within the allowed time",
-                    "Connection refused");
+                (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello")))
+                    .And.Message.Should().ContainAny(
+                        "No connection could be made because the target machine actively refused it",
+                        "the polling endpoint did not collect the request within the allowed time",
+                        "Connection refused");
             }
         }
 
@@ -77,13 +78,13 @@ namespace Halibut.Tests
                     point.RetryCountLimit = 2;
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
                 });
-                
 
-                Func<Task<string>> action = async () => await echo.SayHelloAsync("Hello");
-                (await action.Should().ThrowAsync<HalibutClientException>()).And.Message.Should().ContainAny(
-                    "No connection could be made because the target machine actively refused it",
-                    "the polling endpoint did not collect the request within the allowed time",
-                    "A timeout while waiting for the proxy server at"); ;
+                (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello")))
+                    .And.Message.Should().ContainAny(
+                        "No connection could be made because the target machine actively refused it",
+                        "the polling endpoint did not collect the request within the allowed time",
+                        "A timeout while waiting for the proxy server at");
+                ;
             }
         }
     }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -206,7 +206,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             if (proxy != null)
             {
-                await proxy.StartAsync(cancellationTokenSource.Token);
+                await proxy.StartAsync();
                 proxyDetails = new ProxyDetails("localhost", proxy.Endpoint.Port, ProxyType.HTTP);
             }
 
@@ -387,7 +387,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public void Dispose()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();
-                logger.Information("Dispose called");
+                
+                logger.Information("****** ****** ****** ****** ****** ****** ******");
+                logger.Information("****** CLIENT AND SERVICE DISPOSE CALLED  ******");
+                logger.Information("*     Subsequent errors should be ignored      *");
+                logger.Information("****** ****** ****** ****** ****** ****** ******");
+
                 Action<Exception> logError = e => logger.Warning(e, "Ignoring error in dispose");
                 
                 Try.CatchingError(() => cancellationTokenSource?.Cancel(), logError);

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -268,7 +268,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             if (httpProxy != null)
             {
-                await httpProxy.StartAsync(cancellationTokenSource.Token);
+                await httpProxy.StartAsync();
                 httpProxyDetails = new ProxyDetails("localhost", httpProxy.Endpoint!.Port, ProxyType.HTTP);
             }
 
@@ -471,7 +471,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public void Dispose()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();
-                logger.Information("Dispose called");
+                
+                logger.Information("****** ****** ****** ****** ****** ****** ******");
+                logger.Information("****** CLIENT AND SERVICE DISPOSE CALLED  ******");
+                logger.Information("*     Subsequent errors should be ignored      *");
+                logger.Information("****** ****** ****** ****** ****** ****** ******");
+
                 Action<Exception> logError = e => logger.Warning(e, "Ignoring error in dispose");
                 
                 Try.CatchingError(() => cancellationTokenSource?.Cancel(), logError);

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -318,7 +318,7 @@ namespace Halibut.Tests.Support
 
             if (httpProxy != null)
             {
-                await httpProxy.StartAsync(cancellationTokenSource.Token);
+                await httpProxy.StartAsync();
                 httpProxyDetails = new ProxyDetails("localhost", httpProxy.Endpoint.Port, ProxyType.HTTP);
             }
 
@@ -543,7 +543,12 @@ namespace Halibut.Tests.Support
             public void Dispose()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();
-                logger.Information("Dispose called");
+
+                logger.Information("****** ****** ****** ****** ****** ****** ******");
+                logger.Information("****** CLIENT AND SERVICE DISPOSE CALLED  ******");
+                logger.Information("*     Subsequent errors should be ignored      *");
+                logger.Information("****** ****** ****** ****** ****** ****** ******");
+
                 Action<Exception> logError = e => logger.Warning(e, "Ignoring error in dispose");
 
                 Try.CatchingError(() => cancellationTokenSource?.Cancel(), logError);

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -365,7 +365,7 @@ namespace Halibut.Transport.Proxy
             {
                 var bytes = await stream.ReadAsync(response, 0, TcpClient.ReceiveBufferSize, cancellationToken);
                 sbuilder.Append(Encoding.UTF8.GetString(response, 0, bytes));
-            } while (await stream.DataAvailable(cancellationToken));
+            } while (stream.DataAvailable);
 
             ParseResponse(sbuilder.ToString());
             
@@ -435,7 +435,7 @@ namespace Halibut.Transport.Proxy
         async Task WaitForDataAsync(NetworkTimeoutStream stream, CancellationToken cancellationToken)
         {
             var sleepTime = 0;
-            while (!await stream.DataAvailable(cancellationToken))
+            while (!stream.DataAvailable)
             {
                 await Task.Delay(WAIT_FOR_DATA_INTERVAL, cancellationToken);
                 sleepTime += WAIT_FOR_DATA_INTERVAL;

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -33,6 +33,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Transport.Proxy.Exceptions;
+using Halibut.Transport.Streams;
 
 namespace Halibut.Transport.Proxy
 {
@@ -231,6 +232,7 @@ namespace Halibut.Transport.Proxy
                     // attempt to open the connection
                     log.Write(EventType.Diagnostic, "Connecting to proxy at {0}:{1}", ProxyHost, ProxyPort);
                     TcpClient.ConnectWithTimeout(ProxyHost, ProxyPort, timeout, cancellationToken);
+                    log.Write(EventType.Diagnostic, "Connected to proxy at {0}:{1}", ProxyHost, ProxyPort);
                 }
 
                 //  send connection command to proxy host for the specified destination host and port
@@ -276,6 +278,7 @@ namespace Halibut.Transport.Proxy
                     // attempt to open the connection
                     log.Write(EventType.Diagnostic, "Connecting to proxy at {0}:{1}", ProxyHost, ProxyPort);
                     await TcpClient.ConnectWithTimeoutAsync(ProxyHost, ProxyPort, timeout, cancellationToken);
+                    log.Write(EventType.Diagnostic, "Connected to proxy at {0}:{1}", ProxyHost, ProxyPort);
                 }
 
                 //  send connection command to proxy host for the specified destination host and port
@@ -337,9 +340,7 @@ namespace Halibut.Transport.Proxy
         
         async Task SendConnectionCommandAsync(string host, int port, CancellationToken cancellationToken)
         {
-            // TODO - ASYNC ME UP!
-            // This stream needs to be wrapped into a TimeoutStream
-            var stream = TcpClient.GetStream();
+            var stream = new NetworkTimeoutStream(TcpClient.GetStream());
             var connectCmd = GetConnectCmd(host, port);
             var request = Encoding.ASCII.GetBytes(connectCmd);
 
@@ -364,7 +365,7 @@ namespace Halibut.Transport.Proxy
             {
                 var bytes = await stream.ReadAsync(response, 0, TcpClient.ReceiveBufferSize, cancellationToken);
                 sbuilder.Append(Encoding.UTF8.GetString(response, 0, bytes));
-            } while (stream.DataAvailable);
+            } while (await stream.DataAvailable(cancellationToken));
 
             ParseResponse(sbuilder.ToString());
             
@@ -431,12 +432,12 @@ namespace Halibut.Transport.Proxy
             }
         }
         
-        async Task WaitForDataAsync(NetworkStream stream, CancellationToken cancellationToken)
+        async Task WaitForDataAsync(NetworkTimeoutStream stream, CancellationToken cancellationToken)
         {
             var sleepTime = 0;
-            while (!stream.DataAvailable)
+            while (!await stream.DataAvailable(cancellationToken))
             {
-                await Task.Delay(WAIT_FOR_DATA_TIMEOUT, cancellationToken);
+                await Task.Delay(WAIT_FOR_DATA_INTERVAL, cancellationToken);
                 sleepTime += WAIT_FOR_DATA_INTERVAL;
                 if (sleepTime > WAIT_FOR_DATA_TIMEOUT)
                     throw new ProxyException(string.Format("A timeout while waiting for the proxy server at {0} on port {1} to respond.", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient)), true);

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -84,9 +84,7 @@ namespace Halibut.Transport.Streams
 
         async Task<T> WrapWithCancellationAndTimeout<T>(
             Func<CancellationToken, Task<T>> action,
-            int timeout, 
             bool isRead,
-            string methodName, 
             CancellationToken cancellationToken)
         {
             using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
@@ -107,7 +105,6 @@ namespace Halibut.Transport.Streams
                     {
                         inner.Close();
                     }
-                    catch { }
 
                     ThrowMeaningfulException();
                 }
@@ -201,23 +198,17 @@ namespace Halibut.Transport.Streams
             set => inner.Position = value;
         }
 
-        public async Task<bool> DataAvailable(CancellationToken cancellationToken)
+        public bool DataAvailable
         {
-            if (inner is NetworkStream networkStream)
+            get
             {
-                return await WrapWithCancellationAndTimeout(
-                    async ct =>
-                    {
-                        await Task.CompletedTask;
-                        return networkStream.DataAvailable;
-                    },
-                    CanTimeout ? WriteTimeout : int.MaxValue,
-                    false,
-                    nameof(WriteAsync),
-                    cancellationToken);
-            }
+                if (inner is NetworkStream networkStream)
+                {
+                    return networkStream.DataAvailable;
+                }
 
-            throw new NotSupportedException($"{nameof(DataAvailable)} is only available when wrapping a {nameof(NetworkStream)}");
+                throw new NotSupportedException($"{nameof(DataAvailable)} is only available when wrapping a {nameof(NetworkStream)}");
+            }
         }
     }
 }

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -200,5 +200,24 @@ namespace Halibut.Transport.Streams
             get => inner.Position;
             set => inner.Position = value;
         }
+
+        public async Task<bool> DataAvailable(CancellationToken cancellationToken)
+        {
+            if (inner is NetworkStream networkStream)
+            {
+                return await WrapWithCancellationAndTimeout(
+                    async ct =>
+                    {
+                        await Task.CompletedTask;
+                        return networkStream.DataAvailable;
+                    },
+                    CanTimeout ? WriteTimeout : int.MaxValue,
+                    false,
+                    nameof(WriteAsync),
+                    cancellationToken);
+            }
+
+            throw new NotSupportedException($"{nameof(DataAvailable)} is only available when wrapping a {nameof(NetworkStream)}");
+        }
     }
 }

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -84,7 +84,9 @@ namespace Halibut.Transport.Streams
 
         async Task<T> WrapWithCancellationAndTimeout<T>(
             Func<CancellationToken, Task<T>> action,
+            int timeout, 
             bool isRead,
+            string methodName, 
             CancellationToken cancellationToken)
         {
             using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -105,6 +105,7 @@ namespace Halibut.Transport.Streams
                     {
                         inner.Close();
                     }
+                    catch { }
 
                     ThrowMeaningfulException();
                 }


### PR DESCRIPTION
# Background

Made the HttpProxy Dispose more consistently and added the ability to Pause new connections

Additional tests in ProxyFixture to cover connecting timeouts and connected but the Connect phase has stalled

Wrapped the stream int the HttpProxyClient in a NetworkTimeoutStream for consistent cancellation and timeouts across frameworks

Fixed a bug in the HttpProxyClient around read timeouts for the new Async methods

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
