### PR TITLE
Enable hang dump for long running builds.

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -113,7 +113,8 @@ class Build : NukeBuild
                     .EnableNoRestore()
                     .EnableBlameCrash()
                     .SetBlameCrashDumpType("full")
-                    .SetBlameHangTimeout(TimeSpan.FromMinutes(30).TotalMilliseconds.ToString())
+                    .EnableBlameHang()
+                    .SetBlameHangTimeout(TimeSpan.FromMinutes(20).TotalMilliseconds.ToString())
                     .SetBlameHangDumpType("full"));
 
             });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -112,6 +112,7 @@ class Build : NukeBuild
                     .EnableNoBuild()
                     .EnableNoRestore()
                     .EnableBlameCrash()
+                    .SetBlameHangTimeout(TimeSpan.FromMinutes(30).TotalMilliseconds.ToString())
                     .SetBlameCrashDumpType("full"));
 
             });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -112,8 +112,9 @@ class Build : NukeBuild
                     .EnableNoBuild()
                     .EnableNoRestore()
                     .EnableBlameCrash()
+                    .SetBlameCrashDumpType("full")
                     .SetBlameHangTimeout(TimeSpan.FromMinutes(30).TotalMilliseconds.ToString())
-                    .SetBlameCrashDumpType("full"));
+                    .SetBlameHangDumpType("full"));
 
             });
     }


### PR DESCRIPTION
# Background

[SC-53909] Enable blame hang dump for out builds, with this we might find out why the tests hang on net48 sometimes.

<img width="390" alt="image" src="https://github.com/OctopusDeploy/Halibut/assets/7076477/35dd1837-7307-4992-8487-c34e7daf6599">

Assume 20 minutes is well enough time after the last test case, which I assume to mean after the last `[Test]` was run.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
