### PR TITLE
Zero length read does not mean the end of stream was found

### DIFF
--- a/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
@@ -114,6 +114,22 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
+        public async Task ReadingIntoAZeroLengthArrayIsNotAEndOfStream()
+        {
+            int counter = 0;
+            var errorRecordingStream = new ErrorRecordingStream(new MemoryStream("hello".GetBytesUtf8()), true);
+
+            await errorRecordingStream.ReadAsync(new byte[0], 0, 0);
+            await errorRecordingStream.ReadAsync(new byte[100], 1, 0);
+            errorRecordingStream.Read(new byte[0], 0, 0);
+            errorRecordingStream.Read(new byte[100], 1, 0);
+
+
+            errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(false);
+            errorRecordingStream.ReadExceptions.Count.Should().Be(0);
+        }
+        
+        [Test]
         public void WriteErrorsFromUnderlyingStreamAreRecorded()
         {
             int counter = 0;

--- a/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
+++ b/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
@@ -32,7 +32,7 @@ namespace Halibut.Transport.Streams
             try
             {
                 int read = innerStream.Read(buffer, offset, count);
-                if (read == 0) WasTheEndOfStreamEncountered = true;
+                if (read == 0 && count != 0) WasTheEndOfStreamEncountered = true;
                 return read;
             }
             catch (Exception e)
@@ -48,7 +48,7 @@ namespace Halibut.Transport.Streams
             try
             {
                 int read = await innerStream.ReadAsync(buffer, offset, count, cancellationToken);
-                if (read == 0) WasTheEndOfStreamEncountered = true;
+                if (read == 0 && count != 0) WasTheEndOfStreamEncountered = true;
                 return read;
             }
             catch (Exception e)


### PR DESCRIPTION
# Background

We have never seen this cause an error however we should implement our stream wrappers correctly. This fixes the error recording stream.

https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.read?view=net-7.0

<img width="737" alt="image" src="https://github.com/OctopusDeploy/Halibut/assets/7076477/1233af60-06ad-42a8-b6f3-2a3bf58e3677">

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
