### PR TITLE
Make PollingClient support async

### DIFF
--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -187,12 +187,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             var clientBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(clientCertAndThumbprint.Certificate2)
+                .WithAsyncHalibutFeatureEnabledIfForcingAsync(forceClientProxyType)
                 .WithLogFactory(new TestContextLogFactory("Client", halibutLogLevel));
-
-            if (forceClientProxyType == ForceClientProxyType.AsyncClient)
-            {
-                clientBuilder = clientBuilder.WithAsyncHalibutFeatureEnabled();
-            }
 
             var client = clientBuilder.Build();
             client.Trust(serviceCertAndThumbprint.Thumbprint);

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -7,6 +7,7 @@ using Halibut.TestProxy;
 using Halibut.Tests.Support.Logging;
 using Halibut.Tests.TestServices.AsyncSyncCompat;
 using Halibut.Transport.Proxy;
+using Halibut.Util;
 using Octopus.TestPortForwarder;
 using Serilog.Extensions.Logging;
 
@@ -164,7 +165,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return WithForcingClientProxyType(forceClientProxyType);
         }
-        
+
+        public IClientAndServiceBuilder WithServiceAsyncHalibutFeatureEnabled()
+        {
+            throw new NotSupportedException("The service is external and so can not be made to use async");
+        }
+
         public LatestClientAndPreviousServiceVersionBuilder WithForcingClientProxyType(ForceClientProxyType forceClientProxyType)
         {
             this.forceClientProxyType = forceClientProxyType;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -11,6 +11,7 @@ using Halibut.Tests.TestServices.AsyncSyncCompat;
 using Halibut.TestUtils.Contracts;
 using Halibut.TestUtils.Contracts.Tentacle.Services;
 using Halibut.Transport.Proxy;
+using Halibut.Util;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
@@ -42,6 +43,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         bool withTentacleServices = false;
         ILockService lockService;
         ICountingService countingService;
+        AsyncHalibutFeature serviceAsyncHalibutFeature = AsyncHalibutFeature.Disabled;
 
         PreviousClientVersionAndLatestServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
@@ -219,6 +221,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             throw new Exception("Not supported");
         }
 
+        public IClientAndServiceBuilder WithServiceAsyncHalibutFeatureEnabled()
+        {
+            this.serviceAsyncHalibutFeature = AsyncHalibutFeature.Enabled;
+            return this;
+        }
+
         public async Task<ClientAndService> Build(CancellationToken cancellationToken)
         {
             CancellationTokenSource cancellationTokenSource = new();
@@ -258,6 +266,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             var service = new HalibutRuntimeBuilder()
                 .WithServiceFactory(serviceFactory)
                 .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
+                .WithAsyncHalibutFeature(serviceAsyncHalibutFeature)
                 .WithLogFactory(new TestContextLogFactory("Tentacle", halibutLogLevel))
                 .Build();
 

--- a/source/Halibut.Tests/Support/EnvironmentVariableReaderHelper.cs
+++ b/source/Halibut.Tests/Support/EnvironmentVariableReaderHelper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Castle.Core.Internal;
+
+namespace Halibut.Tests.Support
+{
+    public class EnvironmentVariableReaderHelper
+    {
+        public static bool EnvironmentVariableAsBool(string envVar, bool defaultValue)
+        {
+            var value = Environment.GetEnvironmentVariable(envVar);
+            if (string.IsNullOrEmpty(value))
+            {
+                return defaultValue;
+            }
+
+            return value!.Equals("true");
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/EnvironmentVariableReaderHelper.cs
+++ b/source/Halibut.Tests/Support/EnvironmentVariableReaderHelper.cs
@@ -8,7 +8,7 @@ namespace Halibut.Tests.Support
         public static bool EnvironmentVariableAsBool(string envVar, bool defaultValue)
         {
             var value = Environment.GetEnvironmentVariable(envVar);
-            if (string.IsNullOrEmpty(value))
+            if (string.IsNullOrWhiteSpace(value))
             {
                 return defaultValue;
             }

--- a/source/Halibut.Tests/Support/HalibutRuntimeBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutRuntimeBuilderExtensionMethods.cs
@@ -1,0 +1,16 @@
+﻿namespace Halibut.Tests.Support
+{
+    public static class HalibutRuntimeBuilderExtensionMethods
+    {
+
+        public static HalibutRuntimeBuilder WithAsyncHalibutFeatureEnabledIfForcingAsync(this HalibutRuntimeBuilder halibutRuntimeBuilder, ForceClientProxyType? forceClientProxyType)
+        {
+            if (forceClientProxyType == ForceClientProxyType.AsyncClient)
+            {
+                return halibutRuntimeBuilder.WithAsyncHalibutFeatureEnabled();
+            }
+
+            return halibutRuntimeBuilder;
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/HalibutRuntimeBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutRuntimeBuilderExtensionMethods.cs
@@ -2,7 +2,6 @@
 {
     public static class HalibutRuntimeBuilderExtensionMethods
     {
-
         public static HalibutRuntimeBuilder WithAsyncHalibutFeatureEnabledIfForcingAsync(this HalibutRuntimeBuilder halibutRuntimeBuilder, ForceClientProxyType? forceClientProxyType)
         {
             if (forceClientProxyType == ForceClientProxyType.AsyncClient)

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -17,5 +17,6 @@ namespace Halibut.Tests.Support
         IClientAndServiceBuilder WithCachingService();
         IClientAndServiceBuilder NoService();
         IClientAndServiceBuilder WithForcingClientProxyType(ForceClientProxyType forceClientProxyType);
+        IClientAndServiceBuilder WithServiceAsyncHalibutFeatureEnabled();
     }
 }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -32,6 +32,7 @@ namespace Halibut.Tests.Support
         readonly CertAndThumbprint clientCertAndThumbprint;
         string serviceTrustsThumbprint;
         ForceClientProxyType? forceClientProxyType;
+        AsyncHalibutFeature serviceAsyncHalibutFeature = AsyncHalibutFeature.Disabled;
         
         
         bool hasService = true;
@@ -279,7 +280,13 @@ namespace Halibut.Tests.Support
         {
             return WithForcingClientProxyType(forceClientProxyType);
         }
-        
+
+        public IClientAndServiceBuilder WithServiceAsyncHalibutFeatureEnabled()
+        {
+            serviceAsyncHalibutFeature = AsyncHalibutFeature.Enabled;
+            return this;
+        }
+
         public LatestClientAndLatestServiceBuilder WithForcingClientProxyType(ForceClientProxyType forceClientProxyType)
         {
             this.forceClientProxyType = forceClientProxyType;
@@ -318,7 +325,7 @@ namespace Halibut.Tests.Support
                 var serviceBuilder = new HalibutRuntimeBuilder()
                     .WithServiceFactory(serviceFactory)
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
-                    .WithAsyncHalibutFeatureEnabledIfForcingAsync(forceClientProxyType)
+                    .WithAsyncHalibutFeature(serviceAsyncHalibutFeature)
                     .WithLogFactory(BuildServiceLogger());
 
                 if(pollingReconnectRetryPolicy != null) serviceBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -306,12 +306,8 @@ namespace Halibut.Tests.Support
                 .WithLogFactory(octopusLogFactory)
                 .WithPendingRequestQueueFactory(factory)
                 .WithTrustProvider(clientTrustProvider)
+                .WithAsyncHalibutFeatureEnabledIfForcingAsync(forceClientProxyType)
                 .WithOnUnauthorizedClientConnect(clientOnUnauthorizedClientConnect);
-
-            if (forceClientProxyType == ForceClientProxyType.AsyncClient)
-            {
-                clientBuilder = clientBuilder.WithAsyncHalibutFeatureEnabled();
-            }
 
             var client = clientBuilder.Build();
             client.Trust(clientTrustsThumbprint);
@@ -322,12 +318,8 @@ namespace Halibut.Tests.Support
                 var serviceBuilder = new HalibutRuntimeBuilder()
                     .WithServiceFactory(serviceFactory)
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
+                    .WithAsyncHalibutFeatureEnabledIfForcingAsync(forceClientProxyType)
                     .WithLogFactory(BuildServiceLogger());
-                
-                if (forceClientProxyType == ForceClientProxyType.AsyncClient)
-                {
-                    serviceBuilder = serviceBuilder.WithAsyncHalibutFeatureEnabled();
-                }
 
                 if(pollingReconnectRetryPolicy != null) serviceBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);
                 service = serviceBuilder.Build();

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -323,6 +323,11 @@ namespace Halibut.Tests.Support
                     .WithServiceFactory(serviceFactory)
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                     .WithLogFactory(BuildServiceLogger());
+                
+                if (forceClientProxyType == ForceClientProxyType.AsyncClient)
+                {
+                    serviceBuilder = serviceBuilder.WithAsyncHalibutFeatureEnabled();
+                }
 
                 if(pollingReconnectRetryPolicy != null) serviceBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);
                 service = serviceBuilder.Build();

--- a/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
@@ -15,18 +16,19 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testNetworkConditions = true,
             bool testListening = true,
             bool testPolling = true,
-            bool testAsyncAndSyncClients = true
+            bool testAsyncAndSyncClients = true,
+            bool testAsyncServicesAsWell = false // False means only the sync service will be tested.
             ) :
             base(
                 typeof(LatestAndPreviousClientAndServiceVersionsTestCases),
                 nameof(LatestAndPreviousClientAndServiceVersionsTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients})
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, testAsyncServicesAsWell})
         {
         }
         
         static class LatestAndPreviousClientAndServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, bool testAsyncServicesAsWell)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -51,6 +53,12 @@ namespace Halibut.Tests.Support.TestAttributes
                     clientProxyTypesToTest = ForceClientProxyTypeValues.All;
                 }
                 
+                var serviceAsyncHalibutFeatureTestCases = AsyncHalibutFeatureValues.All().ToList();
+                if (!testAsyncServicesAsWell)
+                {
+                    serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Enabled);
+                }
+                
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] {
                         ClientAndServiceTestVersion.Latest(),
@@ -60,7 +68,8 @@ namespace Halibut.Tests.Support.TestAttributes
                     },
                     serviceConnectionTypes.ToArray(),
                     testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
-                    clientProxyTypesToTest
+                    clientProxyTypesToTest,
+                    serviceAsyncHalibutFeatureTestCases
                     );
 
                 return builder.Build().GetEnumerator();

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Linq;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
@@ -19,18 +20,19 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testListening = true,
             bool testPolling = true,
             bool testAsyncAndSyncClients = true,
+            bool testAsyncServicesAsWell = false, // False means only the sync service will be tested.
             params object[] additionalParameters
             ) :
             base(
                 typeof(LatestClientAndLatestServiceTestCases),
                 nameof(LatestClientAndLatestServiceTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, additionalParameters })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, additionalParameters, testAsyncServicesAsWell})
         {
         }
 
         static class LatestClientAndLatestServiceTestCases
         {
-            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, object[] additionalParameters)
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, object[] additionalParameters, bool testAsyncServicesAsWell)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -54,12 +56,19 @@ namespace Halibut.Tests.Support.TestAttributes
                 {
                     clientProxyTypesToTest = ForceClientProxyTypeValues.All;
                 }
+                
+                var serviceAsyncHalibutFeatureTestCases = AsyncHalibutFeatureValues.All().ToList();
+                if (!testAsyncServicesAsWell)
+                {
+                    serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Enabled);
+                }
 
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] { ClientAndServiceTestVersion.Latest() },
                     serviceConnectionTypes.ToArray(),
                     testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
-                    clientProxyTypesToTest
+                    clientProxyTypesToTest,
+                    serviceAsyncHalibutFeatureTestCases
                 );
                 
                 foreach (var clientAndServiceTestCase in builder.Build())

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestCases;
+using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
@@ -14,18 +15,19 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testNetworkConditions = true,
             bool testListening = true,
             bool testPolling = true,
-            bool testAsyncAndSyncClients = true
+            bool testAsyncAndSyncClients = true,
+            bool testAsyncServicesAsWell = false // False means only the sync service will be tested.
             ) :
             base(
                 typeof(LatestClientAndPreviousServiceVersionsTestCases),
                 nameof(LatestClientAndPreviousServiceVersionsTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, testAsyncServicesAsWell})
         {
         }
         
         static class LatestClientAndPreviousServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling,  bool testAsyncAndSyncClients)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling,  bool testAsyncAndSyncClients, bool testAsyncServicesAsWell)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -50,6 +52,13 @@ namespace Halibut.Tests.Support.TestAttributes
                     clientProxyTypesToTest = ForceClientProxyTypeValues.All;
                 }
 
+                var serviceAsyncHalibutFeatureTestCases = AsyncHalibutFeatureValues.All().ToList();
+                if (!testAsyncServicesAsWell)
+                {
+                    serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Enabled);
+                }
+                
+
                 var builder = new ClientAndServiceTestCasesBuilder(
                     new[] {
                         ClientAndServiceTestVersion.ServiceOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ServiceVersion),
@@ -57,7 +66,8 @@ namespace Halibut.Tests.Support.TestAttributes
                     },
                     serviceConnectionTypes.ToArray(),
                     testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
-                    clientProxyTypesToTest
+                    clientProxyTypesToTest,
+                    serviceAsyncHalibutFeatureTestCases
                 );
 
                 return builder.Build().GetEnumerator();

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestVersion.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestVersion.cs
@@ -69,6 +69,26 @@ namespace Halibut.Tests.Support.TestCases
 
             throw new Exception("Invalid client and service version.");
         }
+        
+        public string ToShortString(ServiceConnectionType serviceConnectionType)
+        {
+            if (IsLatest())
+            {
+                return "v:Latest";
+            }
+
+            if (IsPreviousClient())
+            {
+                return $"vClient:{ClientVersion!.ForServiceConnectionType(serviceConnectionType)}";
+            }
+
+            if (IsPreviousService())
+            {
+                return $"vService:{ServiceVersion!.ForServiceConnectionType(serviceConnectionType)}";
+            }
+
+            throw new Exception("Invalid client and service version.");
+        }
 
         public override string ToString()
         {

--- a/source/Halibut.Tests/Support/TestCases/NetworkConditionTestCase.cs
+++ b/source/Halibut.Tests/Support/TestCases/NetworkConditionTestCase.cs
@@ -17,15 +17,18 @@ namespace Halibut.Tests.Support.TestCases
 
         public static NetworkConditionTestCase NetworkConditionPerfect = 
             new (null, 
+                "Perfect", 
                 "Perfect");
 
         public static NetworkConditionTestCase NetworkCondition20MsLatency = 
             new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).Build(), 
-                "20ms SendDelay");
+                "20ms SendDelay",
+                "20msLatency");
 
         public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLastByteArrivingLate =
             new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(1).Build(),
-                "20ms SendDelay last byte arrives late");
+                "20ms SendDelay last byte arrives late",
+                "20msLatency&LastByteLate");
 
         //public static NetworkConditionTestCase NetworkCondition20MsLatencyWithLast2BytesArrivingLate =
         //    new ((i, logger) => PortForwarderBuilder.ForwardingToLocalPort(i, logger).WithSendDelay(TimeSpan.FromMilliseconds(20)).WithNumberOfBytesToDelaySending(2).Build(),
@@ -38,17 +41,25 @@ namespace Halibut.Tests.Support.TestCases
         public Func<int, ILogger, PortForwarder>? PortForwarderFactory { get; }
 
         public string NetworkConditionDescription { get; }
+        
+        public string ShortNetworkConditionDescription { get; }
 
-        public NetworkConditionTestCase(Func<int, ILogger, PortForwarder>? portForwarderFactory, string networkConditionDescription)
+        public NetworkConditionTestCase(Func<int, ILogger, PortForwarder>? portForwarderFactory, string networkConditionDescription, string shortNetworkConditionDescription)
         {
             PortForwarderFactory = portForwarderFactory;
 
             NetworkConditionDescription = networkConditionDescription;
+            ShortNetworkConditionDescription = shortNetworkConditionDescription;
         }
 
         public override string ToString()
         {
             return $"Network: '{NetworkConditionDescription}'";
+        }
+        
+        public string ToShortString()
+        {
+            return $"Net: '{ShortNetworkConditionDescription}'";
         }
     }
 }

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -26,7 +26,7 @@ namespace Halibut.Tests
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
                 (await echo.SayHelloAsync("Deploy package A")).Should().Be("Deploy package A...");
-
+                
                 for (var i = 0; i < clientAndServiceTestCase.RecommendedIterations; i++)
                 {
                     (await echo.SayHelloAsync($"Deploy package A {i}")).Should().Be($"Deploy package A {i}...");
@@ -98,7 +98,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task SupportsDifferentServiceContractMethods(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
@@ -168,7 +168,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
+        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task OctopusCanSendAndReceiveComplexObjects_WithMultipleDataStreams(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests
     public class WhenCallingAMethodThatDoesNotExist : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task AMethodNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var services = new SingleServiceFactory(new object(), typeof(EchoService));

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -14,7 +14,7 @@ namespace Halibut.Tests
     public class WhenCallingAServiceThatDoesNotExist : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -183,7 +183,7 @@ namespace Halibut
             {
                 client = new SecureClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, log, connectionManager);
             }
-            pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log, cancellationToken, pollingReconnectRetryPolicy));
+            pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log, cancellationToken, pollingReconnectRetryPolicy, AsyncHalibutFeature));
         }
 
         [Obsolete]

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -68,6 +68,12 @@ namespace Halibut
             asyncHalibutFeature = AsyncHalibutFeature.Enabled;
             return this;
         }
+        
+        public HalibutRuntimeBuilder WithAsyncHalibutFeature(AsyncHalibutFeature asyncHalibutFeature)
+        {
+            asyncHalibutFeature = this.asyncHalibutFeature;
+            return this;
+        }
 
         internal HalibutRuntimeBuilder WithPollingReconnectRetryPolicy(Func<RetryPolicy> pollingReconnectRetryPolicy)
         {

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -48,6 +48,7 @@ namespace Halibut.Transport
                 pollingClientLoopThread = new Thread(ExecutePollingLoop!);
                 pollingClientLoopThread.Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
                 pollingClientLoopThread.IsBackground = true;
+                pollingClientLoopThread.Start();
             }
             else
             {

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -59,16 +59,11 @@ namespace Halibut.Transport
         public void Dispose()
         {
             working = false;
-            try
-            {
-                workingCancellationTokenSource.Cancel();
-            }
-            catch
-            {
-            }
+            workingCancellationTokenSource.Cancel();
 
             try
             {
+                // Lets not worry about double dispose.
                 workingCancellationTokenSource.Dispose();
             }
             catch
@@ -118,15 +113,19 @@ namespace Halibut.Transport
             }
         }
 
+        /// <summary>
+        /// Runs ExecutePollingLoopAsync but catches any exception that falls out of it, log here
+        /// rather than let it be unobserved. We are not expecting an exception but just in case.
+        /// </summary>
         async Task ExecutePollingLoopAsyncCatchingExceptions(CancellationToken cancellationToken)
         {
             try
             {
                 await ExecutePollingLoopAsync(cancellationToken);
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                // We may get errors about the workingCancellationTokenSource being used when it is disposed, we don't care about that.
+                log.Write(EventType.Diagnostic, $"PollingClient stopped with an exception: {e}");
             }
         }
         async Task ExecutePollingLoopAsync(CancellationToken cancellationToken)

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -1,5 +1,7 @@
+#nullable enable
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
@@ -13,47 +15,66 @@ namespace Halibut.Transport
         readonly ILog log;
         readonly ISecureClient secureClient;
         readonly Uri subscription;
-        readonly Thread thread;
-        readonly CancellationToken cancellationToken;
+        Thread? pollingClientLoopThread;
         bool working;
+
+        Task? pollingClientLoopTask;
+        readonly CancellationTokenSource workingCancellationTokenSource;
+        readonly CancellationToken cancellationToken;
+        
         readonly Func<RetryPolicy> createRetryPolicy;
+        readonly AsyncHalibutFeature asyncHalibutFeature;
+        
 
-        [Obsolete("Use the overload that provides a logger. This remains for backwards compatibility.")]
-        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, Func<RetryPolicy> createRetryPolicy)
-            : this(subscription, secureClient, handleIncomingRequest, null, createRetryPolicy)
-        {
-        }
-
-        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, ILog log, Func<RetryPolicy> createRetryPolicy)
-            : this(subscription, secureClient, handleIncomingRequest, log, CancellationToken.None, createRetryPolicy)
-        {
-        }
-
-        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, ILog log, CancellationToken cancellationToken, Func<RetryPolicy> createRetryPolicy)
+        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, ILog log, CancellationToken cancellationToken, Func<RetryPolicy> createRetryPolicy, AsyncHalibutFeature asyncHalibutFeature)
         {
             this.subscription = subscription;
             this.secureClient = secureClient;
             this.handleIncomingRequest = handleIncomingRequest;
             this.log = log;
             this.cancellationToken = cancellationToken;
+            workingCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             this.createRetryPolicy = createRetryPolicy;
-            thread = new Thread(ExecutePollingLoop);
-            thread.Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
-            thread.IsBackground = true;
+            this.asyncHalibutFeature = asyncHalibutFeature;
+            
         }
 
         public void Start()
         {
             working = true;
-            thread.Start();
+
+            if (asyncHalibutFeature == AsyncHalibutFeature.Disabled)
+            {
+                pollingClientLoopThread = new Thread(ExecutePollingLoop!);
+                pollingClientLoopThread.Name = "Polling client for " + secureClient.ServiceEndpoint + " for subscription " + subscription;
+                pollingClientLoopThread.IsBackground = true;
+            }
+            else
+            {
+                pollingClientLoopTask = Task.Run(async () => await ExecutePollingLoopAsync());
+            }
         }
 
         public void Dispose()
         {
             working = false;
-        }
+            try
+            {
+                workingCancellationTokenSource.Cancel();
+            }
+            catch
+            {
+            }
 
-        // TODO: ASYNC ME UP!
+            try
+            {
+                workingCancellationTokenSource.Dispose();
+            }
+            catch
+            {
+            }
+        }
+        
         void ExecutePollingLoop(object ignored)
         {
             var retry = createRetryPolicy();
@@ -92,6 +113,46 @@ namespace Halibut.Transport
                 finally
                 {
                     Thread.Sleep(sleepFor);
+                }
+            }
+        }
+        
+        async Task ExecutePollingLoopAsync()
+        {
+            var retry = createRetryPolicy();
+            var sleepFor = TimeSpan.Zero;
+            while (!workingCancellationTokenSource.Token.IsCancellationRequested)
+            {
+                try
+                {
+                    try
+                    {
+                        retry.Try();
+                        await secureClient.ExecuteTransactionAsync(async (protocol, cancellationToken) =>
+                        {
+                            // We have successfully connected at this point so reset the retry policy
+                            // Subsequent connection issues will try and reconnect quickly and then back-off
+                            retry.Success();
+                            await protocol.ExchangeAsSubscriberAsync(subscription, handleIncomingRequest, int.MaxValue, cancellationToken);
+                        }, workingCancellationTokenSource.Token);
+                        retry.Success();
+                    }
+                    finally
+                    {
+                        sleepFor = retry.GetSleepPeriod();
+                    }
+                }
+                catch (HalibutClientException ex)
+                {
+                    log?.WriteException(EventType.Error, $"Halibut client exception: {ex.Message?.TrimEnd('.')}. Retrying in {sleepFor.TotalSeconds:n1} seconds", ex);
+                }
+                catch (Exception ex)
+                {
+                    log?.WriteException(EventType.Error, $"Exception in the polling loop. Retrying in {sleepFor.TotalSeconds:n1} seconds. This may be cause by a network error and usually rectifies itself. Disregard this message unless you are having communication problems.", ex);
+                }
+                finally
+                {
+                    await Task.Delay(sleepFor, workingCancellationTokenSource.Token);
                 }
             }
         }

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -59,8 +59,8 @@ namespace Halibut.Transport
         public void Dispose()
         {
             working = false;
-            Try.CatchingError(workingCancellationTokenSource.Cancel, exception => { });
-            Try.CatchingError(workingCancellationTokenSource.Dispose, exception => { });
+            Try.CatchingError(workingCancellationTokenSource.Cancel, _ => { });
+            Try.CatchingError(workingCancellationTokenSource.Dispose, _ => { });
         }
         
         void ExecutePollingLoop(object ignored)

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -59,16 +59,8 @@ namespace Halibut.Transport
         public void Dispose()
         {
             working = false;
-            workingCancellationTokenSource.Cancel();
-
-            try
-            {
-                // Lets not worry about double dispose.
-                workingCancellationTokenSource.Dispose();
-            }
-            catch
-            {
-            }
+            Try.CatchingError(workingCancellationTokenSource.Cancel, exception => { });
+            Try.CatchingError(workingCancellationTokenSource.Dispose, exception => { });
         }
         
         void ExecutePollingLoop(object ignored)

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -51,7 +51,7 @@ namespace Halibut.Transport
             }
             else
             {
-                pollingClientLoopTask = Task.Run(async () => await ExecutePollingLoopAsync());
+                pollingClientLoopTask = Task.Run(async () => await ExecutePollingLoopAsyncCatchingExceptions());
             }
         }
 
@@ -116,7 +116,18 @@ namespace Halibut.Transport
                 }
             }
         }
-        
+
+        async Task ExecutePollingLoopAsyncCatchingExceptions()
+        {
+            try
+            {
+                await ExecutePollingLoopAsync();
+            }
+            catch (Exception)
+            {
+                // We may get errors about the workingCancellationTokenSource being used when it is disposed, we don't care about that.
+            }
+        }
         async Task ExecutePollingLoopAsync()
         {
             var retry = createRetryPolicy();

--- a/source/Halibut/Util/AsyncHalibutFeature.cs
+++ b/source/Halibut/Util/AsyncHalibutFeature.cs
@@ -18,4 +18,12 @@
             return feature == AsyncHalibutFeature.Disabled;
         }
     }
+
+    public static class AsyncHalibutFeatureValues
+    {
+        public static AsyncHalibutFeature[] All()
+        {
+            return new[] {AsyncHalibutFeature.Disabled, AsyncHalibutFeature.Enabled};
+        }
+    }
 }

--- a/source/Halibut/Util/Try.cs
+++ b/source/Halibut/Util/Try.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Halibut.Util
+{
+    public static class Try
+    {
+        public static void CatchingError(Action tryThisAction, Action<Exception> onFailure)
+        {
+            try
+            {
+                tryThisAction();
+            }
+            catch (Exception e)
+            {
+                onFailure(e);
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
# Background

[SC-53211]

Polling Client now supports async, which means that the polling loop is completely async (no Threads are created). The choose between async and sync in the polling loop is based on `AsyncHalibutFeature`.

By default the tests will continue to test only against a "sync" service which in `PollingClient` terms means creates a new thread and call the old sync methods.

An option has been added to the standard attributes which allows for additionally testing async services and this has been enabled on some tests. For now we only need some tests to test this, as we wont be using the async service for some time. When we do enable async services on all tests the result will be almost doubling the number of tests run.

# Additional optional shorting of test names

With the addition of the `AsyncService/SyncService` parameter in tests, the test name was again frequently becoming longer than what rider would show. Since I needed to see what tests were running this PR also adds a new environment variable `UseShortTestNames` which when set to `true` will cause the test names to be shortened:

<img width="689" alt="image" src="https://github.com/OctopusDeploy/Halibut/assets/7076477/c78aa2b9-a597-40aa-93d0-301564476558">

Personally I prefer those shorter test names.

The test names in teamcity wont be shortened and are locally not shortened by default.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
