### PR TITLE
Make the compat binary runners more async and completely remove the use of shellfish.

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -46,7 +46,6 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
-    <PackageReference Include="Octopus.Shellfish" Version="0.2.1180" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CliWrap;
 using Halibut.Logging;
+using Nito.AsyncEx;
 using Octopus.Shellfish;
 using Serilog;
 
@@ -101,7 +102,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
         async Task<(Task, int?)> StartHalibutTestBinary(string version, Dictionary<string, string> settings, TmpDirectory tmp, CancellationToken cancellationToken)
         {
-            var hasTentacleStarted = new ManualResetEventSlim();
+            var hasTentacleStarted = new AsyncManualResetEvent();
             hasTentacleStarted.Reset();
 
             int? serviceListenPort = null;
@@ -136,7 +137,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 }
             }, cancellationToken);
 
-            await Task.WhenAny(runningTentacle, Task.Run(() => { hasTentacleStarted.WaitHandle.WaitOne(TimeSpan.FromMinutes(1)); }));
+            await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(cancellationToken), Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
 
             // Will throw.
             if (runningTentacle.IsCompleted) await runningTentacle;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using CliWrap;
 using Halibut.Logging;
 using Nito.AsyncEx;
-using Octopus.Shellfish;
 using Serilog;
 
 namespace Halibut.Tests.Support.BackwardsCompatibility

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using CliWrap;
 using Halibut.Logging;
 using Nito.AsyncEx;
-using Octopus.Shellfish;
 
 namespace Halibut.Tests.Support.BackwardsCompatibility
 {


### PR DESCRIPTION
# Background

Make the compat binary runners more async and completely remove the use of shellfish.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
