### PR TITLE
Increase hang dump time

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -114,7 +114,10 @@ class Build : NukeBuild
                     .EnableBlameCrash()
                     .SetBlameCrashDumpType("full")
                     .EnableBlameHang()
-                    .SetBlameHangTimeout(TimeSpan.FromMinutes(20).TotalMilliseconds.ToString())
+                    // This is set high since when a hang dump is collected it is saved into /tmp/
+                    // On windows the dump collecting utility appears to be missing and so nothing is collected.
+                    // Setting high means we will have time to get in and collect a dump manually
+                    .SetBlameHangTimeout(TimeSpan.FromMinutes(9999).TotalMilliseconds.ToString())
                     .SetBlameHangDumpType("full"));
 
             });


### PR DESCRIPTION
# Background

So that we have time to collect a dump, since currently the dump is either not collected or collected and placed into /tmp/ where we can't get it.


# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
