### PR TITLE
Make AuthenticateAsClientAsync respect timeouts

### DIFF
--- a/source/Halibut.Tests/Support/TestAttributes/StreamMethodAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/StreamMethodAttribute.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Halibut.Tests.Transport.Streams;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class StreamMethodAttribute : TestCaseSourceAttribute
+    {
+        public StreamMethodAttribute(bool testSync = true) : base(
+            typeof(TestCases),
+            nameof(TestCases.GetEnumerator),
+            new object?[]{testSync})
+        {
+        }
+
+        static class TestCases
+        {
+            public static IEnumerable GetEnumerator(bool testSync)
+            {
+                if (testSync)
+                {
+                    yield return StreamMethod.Sync;
+                }
+                
+                yield return StreamMethod.Async;
+                yield return StreamMethod.LegacyAsync;
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/TestAttributes/StreamMethodAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/StreamMethodAttribute.cs
@@ -27,7 +27,8 @@ namespace Halibut.Tests.Support.TestAttributes
                 }
                 
                 yield return StreamMethod.Async;
-                yield return StreamMethod.LegacyAsync;
+                yield return StreamMethod.LegacyAsyncCallEndWithinCallback;
+                yield return StreamMethod.LegacyAsyncCallEndOutsideCallback;
             }
         }
     }

--- a/source/Halibut.Tests/Support/TestAttributes/StreamMethodTestCaseAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/StreamMethodTestCaseAttribute.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Collections;
-using System.Threading.Tasks;
 using Halibut.Tests.Transport.Streams;
-using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
-    public class StreamMethodAttribute : TestCaseSourceAttribute
+    public class StreamMethodTestCaseAttribute : TestCaseSourceAttribute
     {
-        public StreamMethodAttribute(bool testSync = true) : base(
+        public StreamMethodTestCaseAttribute(bool testSync = true) : base(
             typeof(TestCases),
             nameof(TestCases.GetEnumerator),
             new object?[]{testSync})

--- a/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
+++ b/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
@@ -32,20 +32,8 @@ namespace Halibut.Tests.Timeouts
             int writeNumberToPauseOn // Ie pause on the first or second write
             ) 
         {
-            bool hasPausedAConnection = false;
-            int numberOfWritesSeen = 0;
-            
             var dataTransferObserverPauser = new DataTransferObserverBuilder()
-                .WithWritingDataObserver((tcpPump, _) =>
-                {
-                    Interlocked.Increment(ref numberOfWritesSeen);
-                    if (!hasPausedAConnection && numberOfWritesSeen == writeNumberToPauseOn)
-                    {
-                        hasPausedAConnection = true;
-                        Logger.Information("Pausing pump");
-                        tcpPump.Pause();
-                    }
-                })
+                .WithWritePausing(Logger, writeNumberToPauseOn)
                 .Build();
             var dataTransferObserverDoNothing = new DataTransferObserverBuilder().Build();
             

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -19,7 +19,7 @@ namespace Halibut.Tests.Transport.Streams
     public class NetworkTimeoutStreamFixture : BaseTest
     {
         [Test]
-        [StreamMethod]
+        [StreamMethodTestCase]
         public async Task ReadingFromStreamShouldPassThrough(StreamMethod streamMethod)
         {
             var (disposables, sut, performListenerWrite) = await BuildTcpClientAndTcpListener(CancellationToken);
@@ -37,7 +37,7 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        [StreamMethod(testSync:false)]
+        [StreamMethodTestCase(testSync:false)]
         public async Task ReadingFromStreamAsyncShouldTimeout_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamMethod streamMethod)
         {
             var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
@@ -91,7 +91,7 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
-        [StreamMethod]
+        [StreamMethodTestCase]
         public async Task WritingToStreamShouldPassThrough(StreamMethod streamMethod)
         {
             string? readData = null;
@@ -119,7 +119,7 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
-        [StreamMethod(testSync: false)]
+        [StreamMethodTestCase(testSync: false)]
         public async Task WritingToStreamAsyncShouldTimeout_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamMethod streamMethod)
         {
             var (disposables, sut, _) = await BuildTcpClientAndTcpListener(

--- a/source/Halibut.Tests/Transport/Streams/ReadIntoMemoryBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/ReadIntoMemoryBufferStreamFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Util;
 using Halibut.Transport.Observability;
 using Halibut.Transport.Streams;
@@ -13,7 +14,8 @@ namespace Halibut.Tests.Transport.Streams
     public class ReadIntoMemoryBufferStreamFixture : BaseTest
     {
         [Test]
-        public async Task ReadsFromSourceStream_IfBufferingWasNotApplied([Values]StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task ReadsFromSourceStream_IfBufferingWasNotApplied(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -31,7 +33,8 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
-        public async Task ReadsFromMemoryBuffer_IfBufferingWasApplied_WithLimitEqualToDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task ReadsFromMemoryBuffer_IfBufferingWasApplied_WithLimitEqualToDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -51,7 +54,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task ReadsFromMemoryBuffer_IfBufferingWasApplied_WithLimitGreaterThanDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task ReadsFromMemoryBuffer_IfBufferingWasApplied_WithLimitGreaterThanDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -71,7 +75,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task PartiallyReadsFromMemoryBuffer_IfBufferingWasApplied_WithLimitLessThanDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task PartiallyReadsFromMemoryBuffer_IfBufferingWasApplied_WithLimitLessThanDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -96,7 +101,8 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
-        public async Task PartiallyReadsFromMemoryBuffer_IfBufferingWasApplied_ReadingOneByteAtATime([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task PartiallyReadsFromMemoryBuffer_IfBufferingWasApplied_ReadingOneByteAtATime(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");

--- a/source/Halibut.Tests/Transport/Streams/StreamMethod.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamMethod.cs
@@ -6,6 +6,10 @@ namespace Halibut.Tests.Transport.Streams
     {
         Async,
         Sync,
-        LegacyAsync
+        // This refers to the Asynchronous Programming Model (APM) Begin/End way of calling streams
+        // Note that 'End' can be called either by itself after calling Begin (and block), or within the callback that is given to Begin.
+        // We should test both ways of doing it
+        LegacyAsyncCallEndWithinCallback,
+        LegacyAsyncCallEndOutsideCallback
     }
 }

--- a/source/Halibut.Tests/Transport/Streams/WriteIntoMemoryBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/WriteIntoMemoryBufferStreamFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Util;
 using Halibut.Transport.Observability;
 using Halibut.Transport.Streams;
@@ -13,7 +14,8 @@ namespace Halibut.Tests.Transport.Streams
     public class WriteIntoMemoryBufferStreamFixture : BaseTest
     {
         [Test]
-        public async Task DoesNotWriteToSink_IfBufferingWasNotApplied_WithLimitGreaterThanDataSize([Values]StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task DoesNotWriteToSink_IfBufferingWasNotApplied_WithLimitGreaterThanDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -29,7 +31,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteToSink_IfBufferingWasNotApplied_WithLimitGreaterThanDataSize_WhenDisposed([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_IfBufferingWasNotApplied_WithLimitGreaterThanDataSize_WhenDisposed(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -47,7 +50,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteToSink_OnlyOne_IfBufferingWasApplied_WithLimitGreaterThanDataSize_AndThenDisposed([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_OnlyOne_IfBufferingWasApplied_WithLimitGreaterThanDataSize_AndThenDisposed(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -66,7 +70,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteToSink_IfBufferingWasNotApplied_WithLimitLessThanDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_IfBufferingWasNotApplied_WithLimitLessThanDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -82,7 +87,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteToSink_IfBufferingWasApplied_WithLimitLessThanDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_IfBufferingWasApplied_WithLimitLessThanDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -99,7 +105,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteToSink_IfBufferingWasApplied_WithLimitEqualToDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_IfBufferingWasApplied_WithLimitEqualToDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -116,7 +123,8 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task WriteToSink_IfBufferingWasApplied_WithLimitGreaterThanDataSize([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_IfBufferingWasApplied_WithLimitGreaterThanDataSize(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some bytes for testing");
@@ -133,7 +141,8 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
-        public async Task WriteToSink_IfBufferingWasApplied_WithLimitLessThanDataSize_WritingOneByteAtATime([Values] StreamMethod streamMethod)
+        [StreamMethodTestCase]
+        public async Task WriteToSink_IfBufferingWasApplied_WithLimitLessThanDataSize_WritingOneByteAtATime(StreamMethod streamMethod)
         {
             // Arrange
             var bytesToWrite = Encoding.ASCII.GetBytes("Some");
@@ -153,7 +162,5 @@ namespace Halibut.Tests.Transport.Streams
             memoryStream.Length.Should().Be(bytesToWrite.Length);
             sut.BytesWrittenIntoMemory.Should().Be(writeIntoMemoryLimitBytes);
         }
-
-        
     }
 }

--- a/source/Halibut.Tests/Util/StreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/StreamExtensionMethods.cs
@@ -1,4 +1,8 @@
+using System;
 using System.IO;
+using System.Threading.Tasks;
+using System.Threading;
+using Halibut.Tests.Transport.Streams;
 
 namespace Halibut.Tests.Util
 {
@@ -8,6 +12,104 @@ namespace Halibut.Tests.Util
         {
             var bytes = s.GetBytesUtf8();
             stream.Write(bytes, 0, bytes.Length);
+        }
+
+        public static async Task<int> ReadFromStream(this Stream sut, StreamMethod streamMethod, byte[] readBuffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            switch (streamMethod)
+            {
+                case StreamMethod.Async:
+                    return await sut.ReadAsync(readBuffer, offset, count, cancellationToken);
+                case StreamMethod.Sync:
+                    return sut.Read(readBuffer, offset, count);
+                case StreamMethod.LegacyAsync:
+                    return await sut.ReadFromStreamLegacyAsync(readBuffer, offset, count, cancellationToken);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(streamMethod), streamMethod, null);
+            }
+        }
+
+        public static async Task<int> ReadFromStreamLegacyAsync(this Stream sut, byte[] readBuffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // This is the way async reading was done in earlier version of .NET
+            var bytesRead = -1;
+            sut.BeginRead(readBuffer, offset, count, AsyncCallback, sut);
+
+            Exception? exception = null;
+            void AsyncCallback(IAsyncResult result)
+            {
+                try
+                {
+                    bytesRead = sut.EndRead(result);
+                }
+                catch (Exception e)
+                {
+                    exception = e;
+                    throw;
+                }
+            }
+
+            while (bytesRead < 0 && !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(10, cancellationToken);
+
+                if (exception is not null)
+                {
+                    throw exception;
+                }
+            }
+
+            return bytesRead;
+        }
+
+        public static async Task WriteToStream(this Stream sut, StreamMethod streamMethod, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            switch (streamMethod)
+            {
+                case StreamMethod.Async:
+                    await sut.WriteAsync(buffer, offset, count, cancellationToken);
+                    return;
+                case StreamMethod.Sync:
+                    sut.Write(buffer, offset, count);
+                    return;
+                case StreamMethod.LegacyAsync:
+                    await WriteToStreamLegacyAsync(sut, buffer, offset, count, cancellationToken);
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(streamMethod), streamMethod, null);
+            }
+        }
+
+        static async Task WriteToStreamLegacyAsync(Stream sut, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            // This is the way async writing was done in earlier version of .NET
+            var written = false;
+            sut.BeginWrite(buffer, offset, count, AsyncCallback, sut);
+
+            Exception? exception = null;
+            void AsyncCallback(IAsyncResult result)
+            {
+                try
+                {
+                    sut.EndWrite(result);
+                    written = true;
+                }
+                catch (Exception e)
+                {
+                    exception = e;
+                    throw;
+                }
+            }
+
+            while (!written && !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(10, cancellationToken);
+
+                if (exception is not null)
+                {
+                    throw exception;
+                }
+            }
         }
     }
 }

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -62,15 +62,12 @@ namespace Halibut.Transport
                 {
                     using (var networkStream = client.GetStream())
                     {
-#if NETFRAMEWORK
-                        //AuthenticateAsClientAsync in .NET 4.8 does not listen to timeouts, and does not have an override that supports a cancellation token.
                         var networkTimeoutStream = new NetworkTimeoutStream(networkStream);
                         using (var ssl = new SslStream(networkTimeoutStream, false, ValidateCertificate))
                         {
+#if NETFRAMEWORK
                             await ssl.AuthenticateAsClientAsync(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
 #else
-                        using (var ssl = new SslStream(networkStream, false, ValidateCertificate))
-                        {
                             await ssl.AuthenticateAsClientEnforcingTimeout(serviceEndpoint, new X509Certificate2Collection(), cancellationToken);
 #endif
                             await ssl.WriteAsync(HelloLine, 0, HelloLine.Length, cancellationToken);

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -66,6 +66,8 @@ namespace Halibut.Transport
                         using (var ssl = new SslStream(networkTimeoutStream, false, ValidateCertificate))
                         {
 #if NETFRAMEWORK
+                            // TODO: ASYNC ME UP!
+                            // AuthenticateAsClientAsync in .NET 4.8 does not support cancellation tokens. So `cancellationToken` is not respected here.
                             await ssl.AuthenticateAsClientAsync(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
 #else
                             await ssl.AuthenticateAsClientEnforcingTimeout(serviceEndpoint, new X509Certificate2Collection(), cancellationToken);

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -144,7 +144,7 @@ namespace Halibut.Transport.Streams
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
         {
-            // BeginRead does not respect timeouts. So force it to use ReadAsync which does.
+            // BeginRead does not respect timeouts. So force it to use ReadAsync, which does.
             return ReadAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
         }
 

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -169,13 +169,9 @@ namespace Halibut.Transport.Streams
         public override void EndWrite(IAsyncResult asyncResult)
         {
             var task = (Task)asyncResult;
-
             try
             {
-                if (task.Exception is not null)
-                {
-                    throw task.Exception;
-                }
+                Task.WaitAll(task);
             }
             catch (AggregateException e) when (e.InnerExceptions.Count == 1 && e.InnerException is not null)
             {

--- a/source/Halibut/Transport/Streams/SslStreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/SslStreamExtensionMethods.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Transport.Streams
+{
+    static class SslStreamExtensionMethods
+    {
+#if !NETFRAMEWORK
+        internal static async Task AuthenticateAsClientEnforcingTimeout(
+            this SslStream ssl, 
+            ServiceEndPoint serviceEndpoint,
+            X509Certificate2Collection clientCertificates, 
+            CancellationToken cancellationToken)
+        {
+            using var timeoutCts = new CancellationTokenSource(ssl.ReadTimeout);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+
+            var options = new SslClientAuthenticationOptions
+            {
+                TargetHost = serviceEndpoint.BaseUri.Host,
+                ClientCertificates = clientCertificates,
+                EnabledSslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck
+            };
+
+            await ssl.AuthenticateAsClientAsync(options, linkedCts.Token);
+        }
+#endif
+    }
+}

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -62,6 +62,8 @@ namespace Halibut.Transport
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
 
 #if NETFRAMEWORK
+            // TODO: ASYNC ME UP!
+            // AuthenticateAsClientAsync in .NET 4.8 does not support cancellation tokens. So `cancellationToken` is not respected here.
             await ssl.AuthenticateAsClientAsync(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(clientCertificate), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
 #else
             await ssl.AuthenticateAsClientEnforcingTimeout(serviceEndpoint, new X509Certificate2Collection(clientCertificate), cancellationToken);

--- a/source/Halibut/Util/TaskExtensionMethods.cs
+++ b/source/Halibut/Util/TaskExtensionMethods.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Threading.Tasks;
 
 namespace Halibut.Util
@@ -23,6 +24,35 @@ namespace Halibut.Util
                     var observedException = t.Exception;
                 },
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+
+        public static IAsyncResult AsAsynchronousProgrammingModel<T>(
+            this Task<T> task,
+            AsyncCallback? callback,
+            object? state)
+        {
+            var tcs = new TaskCompletionSource<T>(state);
+
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    tcs.TrySetException(t.Exception!.InnerExceptions);
+                }
+                else if (t.IsCanceled)
+                {
+                    tcs.TrySetCanceled();
+                }
+                else
+                {
+                    tcs.TrySetResult(t.Result);
+                }
+
+                callback?.Invoke(tcs.Task);
+            }, TaskScheduler.Default);
+
+            return tcs.Task;
         }
     }
 }

--- a/source/Halibut/Util/TaskExtensionMethods.cs
+++ b/source/Halibut/Util/TaskExtensionMethods.cs
@@ -39,8 +39,7 @@ namespace Halibut.Util
             {
                 if (t.IsFaulted)
                 {
-                    //tcs.TrySetException(t.Exception!.InnerExceptions);
-                    tcs.TrySetException(t.Exception!.InnerExceptions[0]);
+                    tcs.TrySetException(t.Exception!.InnerExceptions);
                 }
                 else if (t.IsCanceled)
                 {
@@ -75,8 +74,13 @@ namespace Halibut.Util
                 {
                     tcs.TrySetCanceled();
                 }
-
+                else
+                {
+                    tcs.TrySetResult(new object());
+                }
+                
                 callback?.Invoke(tcs.Task);
+                
             }, TaskScheduler.Default);
 
             return tcs.Task;


### PR DESCRIPTION
[sc-55405]

# Background

The SSL certificate auth was made async. But it did not respect the timeouts set, causing the async versions of `TimeoutsApplyDuringHandShake` to fail.

# Results

Related to https://github.com/OctopusDeploy/Issues/issues/8266

## Before
`AuthenticateAsClientAsync` would not time out, despite what was set in the `TcpClient`

## After
We have now made `AuthenticateAsClientAsync` respect the timeouts from the `TcpClient`.

The `TimeoutsApplyDuringHandShake` could now be made async friendly.

We also noticed that `DiscoveryClient` also used `AuthenticateAsClientAsync`, so we also made that respect the timeouts as well.

### .NET 6.0 vs .NET 4.8
Sadly, only .NET 6.0 has the override of `AuthenticateAsClientAsync` that respects the cancellation token.

So for .NET 4.8, we had to use the `NetworkTimeoutStream`, and enhance it to make it work. This involved mapping between the Task Asynchronous Programming (TAP) and older Asynchronous Programming Model (APM) ([demonstrated by Microsoft](https://learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/interop-with-other-asynchronous-patterns-and-types))

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
