### PR TITLE
Make WebSocketStream async

### DIFF
--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -83,7 +83,7 @@ namespace Halibut.Tests.Transport.Streams
                     stopWatch.Stop();
 
                     actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
-                    actualException!.Message.Should().Be("The ReadAsync operation was cancelled.");
+                    actualException!.Message.Should().Be($"The {nameof(NetworkTimeoutStream)}.ReadAsync operation was cancelled.");
 
                     stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
                 }
@@ -183,7 +183,7 @@ namespace Halibut.Tests.Transport.Streams
                     stopWatch.Stop();
 
                     actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
-                    actualException!.Message.Should().Be("The WriteAsync operation was cancelled.");
+                    actualException!.Message.Should().Be($"The {nameof(NetworkTimeoutStream)}.WriteAsync operation was cancelled.");
 
                     stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
                 }

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -83,7 +83,7 @@ namespace Halibut.Tests.Transport.Streams
                     stopWatch.Stop();
 
                     actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
-                    actualException!.Message.Should().Be($"The {nameof(NetworkTimeoutStream)}.ReadAsync operation was cancelled.");
+                    actualException!.Message.Should().Be("The ReadAsync operation was cancelled.");
 
                     stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
                 }
@@ -183,7 +183,7 @@ namespace Halibut.Tests.Transport.Streams
                     stopWatch.Stop();
 
                     actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
-                    actualException!.Message.Should().Be($"The {nameof(NetworkTimeoutStream)}.WriteAsync operation was cancelled.");
+                    actualException!.Message.Should().Be("The WriteAsync operation was cancelled.");
 
                     stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
                 }

--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -89,7 +89,7 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        public async Task<string> ReadTextMessage(CancellationToken cancellationToken)
+        public async Task<string> ReadTextMessage(TimeSpan timeout, CancellationToken cancellationToken)
         {
             AssertCanReadOrWrite();
             var sb = new StringBuilder();
@@ -99,8 +99,6 @@ namespace Halibut.Transport.Protocol
             {
                 var readResult = await CancellationAndTimeoutTaskWrapper.WrapWithCancellationAndTimeout(async ct =>
                     {
-						// TODO - ASYNC ME UP!
-		                // What should the timeout be here? thew new code that allows passing in a timeout or the static value?
                         var result = await context.ReceiveAsync(buffer, ct).ConfigureAwait(false);
                         if (result.MessageType == WebSocketMessageType.Close)
                         {
@@ -122,7 +120,7 @@ namespace Halibut.Transport.Protocol
                         var socketException = new SocketException(10060);
                         return new IOException($"Unable to read data from the transport connection: {socketException.Message}.", socketException);
                     },
-                    HalibutLimits.TcpClientReceiveTimeout,
+                    timeout,
                     nameof(ReadTextMessage),
                     cancellationToken);
 

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -133,7 +133,7 @@ namespace Halibut.Transport
                 var webSocketContext = await listenerContext.AcceptWebSocketAsync("Octopus").ConfigureAwait(false);
                 webSocketStream = new WebSocketStream(webSocketContext.WebSocket);
 
-                var req = await webSocketStream.ReadTextMessage().ConfigureAwait(false); // Initial message
+                var req = await webSocketStream.ReadTextMessage(CancellationToken.None).ConfigureAwait(false); // Initial message
                 if (string.IsNullOrEmpty(req))
                 {
                     log.Write(EventType.Diagnostic, "Ignoring empty request");

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -136,7 +136,7 @@ namespace Halibut.Transport
                 string req;
                 if (asyncHalibutFeature.IsEnabled())
                 {
-                    req = await webSocketStream.ReadTextMessage(cts.Token).ConfigureAwait(false);
+                    req = await webSocketStream.ReadTextMessage(halibutTimeoutsAndLimits.TcpClientReceiveTimeout, cts.Token).ConfigureAwait(false);
                 }
                 else
                 {

--- a/source/Halibut/Transport/Streams/CancellationAndTimeoutTaskWrapper.cs
+++ b/source/Halibut/Transport/Streams/CancellationAndTimeoutTaskWrapper.cs
@@ -1,0 +1,63 @@
+﻿#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Util;
+
+namespace Halibut.Transport.Streams
+{
+    public class CancellationAndTimeoutTaskWrapper
+    {
+        public static async Task<T> WrapWithCancellationAndTimeout<T>(
+            Func<CancellationToken, Task<T>> action,
+            Action onCancellationAction,
+            Func<Exception> getExceptionOnTimeout,
+            TimeSpan timeout,
+            string callingTypeName,
+            string methodName,
+            CancellationToken cancellationToken)
+        {
+            
+            using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
+            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+
+            var actionTask = action(linkedCancellationTokenSource.Token);
+            var cancellationTask = linkedCancellationTokenSource.Token.AsTask<T>();
+
+            try
+            {
+                var completedTask = await Task.WhenAny(actionTask, cancellationTask);
+
+                if (completedTask == cancellationTask)
+                {
+                    actionTask.IgnoreUnobservedExceptions();
+
+                    onCancellationAction();
+
+                    ThrowMeaningfulException();
+                }
+
+                return await actionTask;
+            }
+            catch (Exception e)
+            {
+                ThrowMeaningfulException(e);
+
+                throw;
+            }
+
+            void ThrowMeaningfulException(Exception? innerException = null)
+            {
+                if (timeoutCancellationTokenSource.IsCancellationRequested)
+                {
+                    throw getExceptionOnTimeout();
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw new OperationCanceledException($"The {callingTypeName}.{methodName} operation was cancelled.", innerException);
+                }
+            }
+        }
+    }
+}

--- a/source/Halibut/Transport/Streams/CancellationAndTimeoutTaskWrapper.cs
+++ b/source/Halibut/Transport/Streams/CancellationAndTimeoutTaskWrapper.cs
@@ -13,7 +13,6 @@ namespace Halibut.Transport.Streams
             Action onCancellationAction,
             Func<Exception> getExceptionOnTimeout,
             TimeSpan timeout,
-            string callingTypeName,
             string methodName,
             CancellationToken cancellationToken)
         {
@@ -55,7 +54,7 @@ namespace Halibut.Transport.Streams
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    throw new OperationCanceledException($"The {callingTypeName}.{methodName} operation was cancelled.", innerException);
+                    throw new OperationCanceledException($"The {methodName} operation was cancelled.", innerException);
                 }
             }
         }

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -114,7 +114,6 @@ namespace Halibut.Transport.Streams
                 OnCancellationAction,
                 CreateExceptionOnTimeout,
                 TimeSpan.FromMilliseconds(timeout),
-                nameof(NetworkTimeoutStream),
                 methodName,
                 cancellationToken);
         }

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -89,56 +89,34 @@ namespace Halibut.Transport.Streams
 
         async Task<T> WrapWithCancellationAndTimeout<T>(
             Func<CancellationToken, Task<T>> action,
-            int timeout, 
+            int timeout,
             bool isRead,
-            string methodName, 
+            string methodName,
             CancellationToken cancellationToken)
         {
-            using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
-            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
-
-            var actionTask = action(linkedCancellationTokenSource.Token);
-            var cancellationTask = linkedCancellationTokenSource.Token.AsTask<T>();
-
-            try
+            void OnCancellationAction()
             {
-                var completedTask = await Task.WhenAny(actionTask, cancellationTask);
-
-                if (completedTask == cancellationTask)
+                try
                 {
-                    actionTask.IgnoreUnobservedExceptions();
-
-                    try
-                    {
-                        inner.Close();
-                    }
-                    catch { }
-
-                    ThrowMeaningfulException();
+                    inner.Close();
                 }
+                catch { }
+            };
 
-                return await actionTask;
-            }
-            catch (Exception e)
+            Exception CreateExceptionOnTimeout()
             {
-                ThrowMeaningfulException(e);
-
-                throw;
+                var socketException = new SocketException(10060);
+                return new IOException($"Unable to {(isRead ? "read data from" : "write data to")} the transport connection: {socketException.Message}.", socketException);
             }
 
-            void ThrowMeaningfulException(Exception? innerException = null)
-            {
-                if (timeoutCancellationTokenSource.IsCancellationRequested)
-                {
-                    var socketException = new SocketException(10060);
-                    throw new IOException($"Unable to {(isRead ? "read data from" : "write data to")} the transport connection: {socketException.Message}.", socketException);
-                }
-
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    throw new OperationCanceledException($"The {methodName} operation was cancelled.", innerException);
-                }
-            }
+            return await CancellationAndTimeoutTaskWrapper.WrapWithCancellationAndTimeout(
+                action,
+                OnCancellationAction,
+                CreateExceptionOnTimeout,
+                TimeSpan.FromMilliseconds(timeout),
+                nameof(NetworkTimeoutStream),
+                methodName,
+                cancellationToken);
         }
 
         public override void Close() => inner.Close();
@@ -227,6 +205,7 @@ namespace Halibut.Transport.Streams
         public override bool CanSeek => inner.CanSeek;
         public override bool CanWrite => inner.CanWrite;
         public override long Length => inner.Length;
+
         public override long Position
         {
             get => inner.Position;


### PR DESCRIPTION
This PR makes `WebSocketStream` async, as part of [sc-53211].

* Implement `CopyToAsync`, `WriteAsync`, `ReadAsync`
* Maintain existing sync behviour (i.e. blocking on async implementations)
* Remove timeout logic, reimplement using timeout and cancellation logic from `NetworkTimeoutStream` which has been extracted and generalised into a reusable helper
* New async implementation of `ReadTextMessage` adds a new timeout argument, so as to not use a static timeout value, as per [sc-45207](https://app.shortcut.com/octopusdeploy/story/45207/improve-halibut-to-support-testing-with-different-tcp-timeouts-allowing-tests-to-control-timeouts). See also [PR comment](https://github.com/OctopusDeploy/Halibut/pull/427#discussion_r1294058105)
