### PR TITLE
Async Request Cancellation

### DIFF
--- a/source/Halibut.TestUtils.Contracts/LockService.cs
+++ b/source/Halibut.TestUtils.Contracts/LockService.cs
@@ -1,6 +1,4 @@
-using System;
 using System.IO;
-using System.Net;
 using System.Threading;
 
 namespace Halibut.TestUtils.Contracts
@@ -9,7 +7,6 @@ namespace Halibut.TestUtils.Contracts
     {
         public void WaitForFileToBeDeleted(string file, string fileSignalWhenRequestIsStarted)
         {
-            
             File.Create(fileSignalWhenRequestIsStarted);
             while (File.Exists(file))
             {

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -83,7 +83,7 @@ namespace Halibut.Tests
                 });
 
                 // Act
-                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token)), CancellationToken);
+                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None)), CancellationToken);
 
                 // Interestingly the message exchange error is logged to a non polling looking URL, perhaps because it has not been identified?
                 Wait.UntilActionSucceeds(() => {
@@ -129,14 +129,14 @@ namespace Halibut.Tests
                     });
 
                 // Works normally
-                await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token));
-                await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token));
+                await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None));
+                await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None));
                 
                 // Act
                 clientAndBuilder.Client.TrustOnly(new List<string>());
                 
                 // Assert
-                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token)), CancellationToken);
+                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None)), CancellationToken);
 
                 await Task.Delay(3000, CancellationToken);
 
@@ -194,7 +194,7 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(2000);
                 });
                 
-                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token)), CancellationToken);
+                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None)), CancellationToken);
 
                 Func<LogEvent, bool> hasExpectedLog = logEvent =>
                     logEvent.FormattedMessage.Contains("The server at")
@@ -251,7 +251,7 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
                 });
                 
-                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token)), CancellationToken);
+                var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None)), CancellationToken);
 
                 // Interestingly the message exchange error is logged to a non polling looking URL, perhaps because it has not been identified?
                 Wait.UntilActionSucceeds(() => { AllLogs(serviceLoggers).Select(l => l.FormattedMessage).ToArray()

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
+using Halibut.Tests.Support.ExtensionMethods;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
@@ -20,37 +22,144 @@ namespace Halibut.Tests
         [Test]
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
-        public async Task CancellationCanBeDoneViaClientProxy(ClientAndServiceTestCase clientAndServiceTestCase)
+        public async Task HalibutProxyRequestOptions_ConnectingCancellationToken_CanCancel_ConnectingOrQueuedRequests(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var tokenSourceToCancel = new CancellationTokenSource();
+            var halibutRequestOption = new HalibutProxyRequestOptions(tokenSourceToCancel.Token, CancellationToken.None);
+
+            await CanCancel_ConnectingOrQueuedRequests(clientAndServiceTestCase, tokenSourceToCancel, halibutRequestOption);
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testSyncClients: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false, testSyncClients: false)]
+        public async Task HalibutProxyRequestOptions_InProgressCancellationToken_CanCancel_ConnectingOrQueuedRequests(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var tokenSourceToCancel = new CancellationTokenSource();
+            var halibutRequestOption = new HalibutProxyRequestOptions(CancellationToken.None, tokenSourceToCancel.Token);
+
+            await CanCancel_ConnectingOrQueuedRequests(clientAndServiceTestCase, tokenSourceToCancel, halibutRequestOption);
+        }
+
+        async Task CanCancel_ConnectingOrQueuedRequests(ClientAndServiceTestCase clientAndServiceTestCase, CancellationTokenSource tokenSourceToCancel, HalibutProxyRequestOptions halibutRequestOption)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port).Build())
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
-                
                 clientAndService.PortForwarder.EnterKillNewAndExistingConnectionsMode();
                 var data = new byte[1024 * 1024 + 15];
                 new Random().NextBytes(data);
 
-                var echo = clientAndService.CreateClientWithOptions<ICountingService, ISyncClientCountingServiceWithOptions, IAsyncClientCountingServiceWithOptions>(point =>
-                    {
-                        point.RetryCountLimit = 1000000;
-                        point.ConnectionErrorRetryTimeout = TimeSpan.MaxValue;
-                    });
-
-                var cts = new CancellationTokenSource();
-                cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+                var echo = clientAndService.CreateClientWithOptions<ICountingService, ISyncClientCountingServiceWithOptions, IAsyncClientCountingServiceWithOptions>(
+                    point => point.TryAndConnectForALongTime());
                 
-                (await AssertAsync.Throws<Exception>(() => echo.IncrementAsync(new HalibutProxyRequestOptions(cts.Token))))
-                    .And
-                    .Message.Contains("The operation was canceled");
+                tokenSourceToCancel.CancelAfter(TimeSpan.FromMilliseconds(100));
+                
+                (await AssertAsync.Throws<Exception>(() => echo.IncrementAsync(halibutRequestOption)))
+                    .And.Message.Contains("The operation was canceled");
 
                 clientAndService.PortForwarder.ReturnToNormalMode();
                 
-                await echo.IncrementAsync(new HalibutProxyRequestOptions(CancellationToken));
+                await echo.IncrementAsync(new HalibutProxyRequestOptions(CancellationToken, CancellationToken.None));
 
-                (await echo.GetCurrentValueAsync(new HalibutProxyRequestOptions(CancellationToken)))
+                (await echo.GetCurrentValueAsync(new HalibutProxyRequestOptions(CancellationToken, CancellationToken.None)))
                     .Should().Be(1, "Since we cancelled the first call");
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
+        public async Task HalibutProxyRequestOptions_ConnectingCancellationToken_CanNotCancel_InFlightRequests(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithHalibutLoggingLevel(LogLevel.Trace)
+                       .WithStandardServices()
+                       .Build(CancellationToken))
+            {
+                var lockService = clientAndService.CreateClientWithOptions<ILockService, ISyncClientLockServiceWithOptions, IAsyncClientLockServiceWithOptions>();
+
+                var tokenSourceToCancel = new CancellationTokenSource();
+                using var tmpDir = new TemporaryDirectory();
+                var fileThatOnceDeletedEndsTheCall = tmpDir.CreateRandomFile();
+                var callStartedFile = tmpDir.RandomFileName();
+
+                var inFlightRequest = Task.Run(async () => await lockService.WaitForFileToBeDeletedAsync(
+                    fileThatOnceDeletedEndsTheCall,
+                    callStartedFile,
+                    new HalibutProxyRequestOptions(tokenSourceToCancel.Token, CancellationToken.None)));
+
+                Logger.Information("Waiting for the RPC call to be inflight");
+                while (!File.Exists(callStartedFile))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken);
+                }
+
+                // The call is now in flight. Call cancel on the cancellation token for that in flight request.
+                tokenSourceToCancel.Cancel();
+
+                // Give time for the cancellation to do something
+                await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
+
+                if (inFlightRequest.Status == TaskStatus.Faulted) await inFlightRequest;
+
+                inFlightRequest.IsCompleted.Should().Be(false, $"The cancellation token can not cancel in flight requests. Current state: {inFlightRequest.Status}");
+
+                File.Delete(fileThatOnceDeletedEndsTheCall);
+
+                // Now the lock is released we should be able to complete the request.
+                await inFlightRequest;
+            }
+        }
+
+        [Test]
+// TODO: ASYNC ME UP!
+// net48 does not support cancellation of the request as the DeflateStream ends up using Begin and End methods which don't get passed the cancellation token
+#if NETFRAMEWORK
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening:false, testSyncClients: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false, testListening:false, testSyncClients: false)]
+#else
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testSyncClients: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false, testSyncClients: false)]
+#endif
+        public async Task HalibutProxyRequestOptions_InProgressCancellationToken_CanCancel_InFlightRequests(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .WithStandardServices()
+                       .Build(CancellationToken))
+            {
+                var lockService = clientAndService.CreateClientWithOptions<ILockService, ISyncClientLockServiceWithOptions, IAsyncClientLockServiceWithOptions>();
+
+                var tokenSourceToCancel = new CancellationTokenSource();
+                using var tmpDir = new TemporaryDirectory();
+                var fileThatOnceDeletedEndsTheCall = tmpDir.CreateRandomFile();
+                var callStartedFile = tmpDir.RandomFileName();
+
+                var inFlightRequest = Task.Run(async () =>
+                {
+                    await lockService.WaitForFileToBeDeletedAsync(
+                        fileThatOnceDeletedEndsTheCall,
+                        callStartedFile,
+                        new HalibutProxyRequestOptions(CancellationToken.None, tokenSourceToCancel.Token));
+                });
+
+                Logger.Information("Waiting for the RPC call to be inflight");
+                while (!File.Exists(callStartedFile))
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken);
+                }
+                
+                // The call is now in flight. Call cancel on the cancellation token for that in flight request.
+                tokenSourceToCancel.Cancel();
+                
+                // Give time for the cancellation to do something
+                await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
+
+                (await AssertionExtensions.Should(async () => await inFlightRequest)
+                    .ThrowAsync<Exception>()).And
+                    .Should().Match<Exception>(x => x is OperationCanceledException || (x.GetType() == typeof(HalibutClientException) && x.Message.Contains("The ReadAsync operation was cancelled")));
             }
         }
 
@@ -89,52 +198,25 @@ namespace Halibut.Tests
             {
                 var echo = clientAndService.CreateClientWithOptions<IEchoService, ISyncClientEchoServiceWithOptions, IAsyncClientEchoServiceWithOptions>();
 
-                (await echo.SayHelloAsync("Hello!!", new HalibutProxyRequestOptions(new CancellationToken())))
+                (await echo.SayHelloAsync("Hello!!", new HalibutProxyRequestOptions(CancellationToken, null)))
                     .Should()
                     .Be("Hello!!...");
             }
         }
-        
-        
+
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
-        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
-        public async Task HalibutProxyRequestOptions_CanNotCancel_InFlightRequests(ClientAndServiceTestCase clientAndServiceTestCase)
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncClients: false)]
+        [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false, testAsyncClients: false)]
+        public async Task HalibutProxyRequestOptions_CanNotCancel_InFlightRequests_ForSyncServiceCalls(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
-                var lockService = clientAndService.CreateClientWithOptions<ILockService, ISyncClientLockServiceWithOptions, IAsyncClientLockServiceWithOptions>();
+                var echo = clientAndService.CreateClient<IEchoService, ISyncClientEchoServiceWithOptions>();
 
-                var cts = new CancellationTokenSource();
-                using var tmpDir = new TemporaryDirectory();
-                var fileThatOnceDeletedEndsTheCall = tmpDir.CreateRandomFile();
-                var callStartedFile = tmpDir.RandomFileName();
-
-                var inFlightRequest = Task.Run(async () => await lockService.WaitForFileToBeDeletedAsync(fileThatOnceDeletedEndsTheCall, callStartedFile, new HalibutProxyRequestOptions(CancellationToken.None)));
-
-                Logger.Information("Waiting for the RPC call to be inflight");
-                while (!File.Exists(callStartedFile))
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(100), CancellationToken);
-                }
-                
-                // The call is now in flight.
-                // Call cancel on the cancellation token for that in flight request.
-                cts.Cancel();
-                
-                // Give time for the cancellation to do something
-                await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
-                
-                if (inFlightRequest.Status == TaskStatus.Faulted) await inFlightRequest;
-                
-                inFlightRequest.IsCompleted.Should().Be(false, $"The cancellation token can not cancel in flight requests. Current state: {inFlightRequest.Status}");
-                
-                File.Delete(fileThatOnceDeletedEndsTheCall);
-
-                // Now the lock is released we should be able to complete the request.
-                await inFlightRequest;
+                AssertionExtensions.Should(() => echo.SayHello("Hello!!", new HalibutProxyRequestOptions(CancellationToken, CancellationToken))).Throw<ArgumentException>()
+                    .And.Message.Should().Be("HalibutProxyRequestOptions.InProgressRequestCancellationToken is not supported by HalibutProxy");
             }
         }
     }

--- a/source/Halibut.Tests/DataStreamFixture.cs
+++ b/source/Halibut.Tests/DataStreamFixture.cs
@@ -40,7 +40,7 @@ namespace Halibut.Tests
         }
         
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncAndSyncClients: false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncClients: false)]
         public async Task AsyncDataStreamsAreUsedWhenInAsync(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -45,8 +45,8 @@ namespace Halibut.Tests
             {
                 var client = clientAndService.CreateClientWithOptions<ICachingService, IClientCachingService, IAsyncClientCachingServiceWithOptions>();
 
-                var result1 = await client.NonCachableCallAsync(new HalibutProxyRequestOptions(CancellationToken.None));
-                var result2 = await client.NonCachableCallAsync(new HalibutProxyRequestOptions(CancellationToken.None));
+                var result1 = await client.NonCachableCallAsync(new HalibutProxyRequestOptions(CancellationToken, CancellationToken.None));
+                var result2 = await client.NonCachableCallAsync(new HalibutProxyRequestOptions(CancellationToken, CancellationToken.None));
 
                 result1.Should().NotBe(result2);
             }
@@ -81,8 +81,8 @@ namespace Halibut.Tests
             {
                 var client = clientAndService.CreateClientWithOptions<ICachingService, IClientCachingService, IAsyncClientCachingServiceWithOptions>();
 
-                var result1 = await client.CachableCallAsync(new HalibutProxyRequestOptions(CancellationToken.None));
-                var result2 = await client.CachableCallAsync(new HalibutProxyRequestOptions(CancellationToken.None));
+                var result1 = await client.CachableCallAsync(new HalibutProxyRequestOptions(CancellationToken, CancellationToken.None));
+                var result2 = await client.CachableCallAsync(new HalibutProxyRequestOptions(CancellationToken, CancellationToken.None));
 
                 result1.Should().Be(result2);
             }

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -26,7 +26,7 @@ namespace Halibut.Tests.ServiceModel
             var request = new RequestMessageBuilder(endpoint).Build();
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
             
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, CancellationToken);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, CancellationToken);
             await sut.DequeueAsync(CancellationToken);
             
 
@@ -53,7 +53,7 @@ namespace Halibut.Tests.ServiceModel
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
             var unexpectedResponse = new ResponseMessageBuilder(Guid.NewGuid().ToString()).Build();
 
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, CancellationToken);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, CancellationToken);
             await sut.DequeueAsync(CancellationToken);
 
 
@@ -90,7 +90,7 @@ namespace Halibut.Tests.ServiceModel
             
             // Act
             var stopwatch = Stopwatch.StartNew();
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, CancellationToken);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, CancellationToken);
             var response = await queueAndWaitTask;
 
             // Assert
@@ -122,7 +122,7 @@ namespace Halibut.Tests.ServiceModel
 
             // Act
             var stopwatch = Stopwatch.StartNew();
-            var (queueAndWaitTask, _) = await QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(sut, request, CancellationToken);
+            var (queueAndWaitTask, _) = await QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(sut, request, syncOrAsync, CancellationToken);
             var response = await queueAndWaitTask;
 
             // Assert
@@ -153,7 +153,7 @@ namespace Halibut.Tests.ServiceModel
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
             // Act
-            var (queueAndWaitTask, dequeued) = await QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(sut, request, CancellationToken);
+            var (queueAndWaitTask, dequeued) = await QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(sut, request, syncOrAsync, CancellationToken);
 
             await Task.Delay(2000, CancellationToken);
 
@@ -186,7 +186,7 @@ namespace Halibut.Tests.ServiceModel
             var queueAndWaitTasksInOrder = new List<Task<ResponseMessage>>();
             foreach (var request in requestsInOrder)
             {
-                var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, CancellationToken);
+                var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, CancellationToken);
                 queueAndWaitTasksInOrder.Add(queueAndWaitTask);
             }
 
@@ -215,7 +215,7 @@ namespace Halibut.Tests.ServiceModel
 
             // Act
             var queueAndWaitTasksInOrder = requestsInOrder
-                .Select(request => StartQueueAndWait(sut, request, CancellationToken))
+                .Select(request => StartQueueAndWait(sut, request, syncOrAsync, CancellationToken))
                 .ToList();
 
             await WaitForQueueCountToBecome(sut, requestsInOrder.Count);
@@ -249,7 +249,7 @@ namespace Halibut.Tests.ServiceModel
 
             // Act
             var queueAndWaitTasksInOrder = requestsInOrder
-                .Select(request => StartQueueAndWait(sut, request, CancellationToken))
+                .Select(request => StartQueueAndWait(sut, request, SyncOrAsync.Async, CancellationToken))
                 .ToList();
 
             await WaitForQueueCountToBecome(sut, requestsInOrder.Count);
@@ -277,7 +277,7 @@ namespace Halibut.Tests.ServiceModel
             var cancellationTokenSource = new CancellationTokenSource();
 
             // Act
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, cancellationTokenSource.Token);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, cancellationTokenSource.Token);
 
             cancellationTokenSource.Cancel();
 
@@ -306,7 +306,7 @@ namespace Halibut.Tests.ServiceModel
             var cancellationTokenSource = new CancellationTokenSource();
 
             // Act
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, cancellationTokenSource.Token);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, cancellationTokenSource.Token);
 
             var dequeued = await sut.DequeueAsync(CancellationToken);
 
@@ -342,7 +342,7 @@ namespace Halibut.Tests.ServiceModel
 
             // Act
             var stopwatch = Stopwatch.StartNew();
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, cancellationTokenSource.Token);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, cancellationTokenSource.Token);
             
             await sut.DequeueAsync(CancellationToken);
             cancellationTokenSource.Cancel();
@@ -393,7 +393,7 @@ namespace Halibut.Tests.ServiceModel
             var previousRequest = new RequestMessageBuilder(endpoint).Build();
             var expectedPreviousResponse = ResponseMessageBuilder.FromRequest(previousRequest).Build();
 
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, previousRequest, CancellationToken);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, previousRequest, SyncOrAsync.Async ,CancellationToken);
             await sut.DequeueAsync(CancellationToken);
             await sut.ApplyResponse(expectedPreviousResponse, previousRequest.Destination);
             await queueAndWaitTask;
@@ -425,7 +425,7 @@ namespace Halibut.Tests.ServiceModel
 
             await Task.Delay(1000, CancellationToken);
 
-            var queueAndWaitTask = StartQueueAndWait(sut, request, CancellationToken);
+            var queueAndWaitTask = StartQueueAndWait(sut, request, syncOrAsync, CancellationToken);
             
             var dequeuedRequest = await dequeueTask;
             
@@ -459,7 +459,7 @@ namespace Halibut.Tests.ServiceModel
             await Task.Delay(1000, CancellationToken);
 
             // Act
-            var queueAndWaitTask = StartQueueAndWait(sut, request, CancellationToken);
+            var queueAndWaitTask = StartQueueAndWait(sut, request, syncOrAsync, CancellationToken);
 
             // Assert
             await Task.WhenAll(dequeueTasks);
@@ -488,7 +488,7 @@ namespace Halibut.Tests.ServiceModel
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
             var cancellationTokenSource = new CancellationTokenSource();
-            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, cancellationTokenSource.Token);
+            var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, cancellationTokenSource.Token);
 
             cancellationTokenSource.Cancel();
 
@@ -511,11 +511,12 @@ namespace Halibut.Tests.ServiceModel
         async Task<Task<ResponseMessage>> StartQueueAndWaitAndWaitForRequestToBeQueued(
             IPendingRequestQueue pendingRequestQueue,
             RequestMessage request,
+            SyncOrAsync syncOrAsync,
             CancellationToken queueAndWaitCancellationToken)
         {
             var count = pendingRequestQueue.Count;
 
-            var task = StartQueueAndWait(pendingRequestQueue, request, queueAndWaitCancellationToken);
+            var task = StartQueueAndWait(pendingRequestQueue, request, syncOrAsync, queueAndWaitCancellationToken);
 
             await WaitForQueueCountToBecome(pendingRequestQueue, count + 1);
 
@@ -530,21 +531,33 @@ namespace Halibut.Tests.ServiceModel
             }
         }
 
-        Task<ResponseMessage> StartQueueAndWait(IPendingRequestQueue pendingRequestQueue, RequestMessage request, CancellationToken queueAndWaitCancellationToken)
+        Task<ResponseMessage> StartQueueAndWait(IPendingRequestQueue pendingRequestQueue, RequestMessage request, SyncOrAsync syncOrAsync, CancellationToken queueAndWaitCancellationToken)
         {
             var task = Task.Run(
-                async () => await pendingRequestQueue.QueueAndWaitAsync(request, queueAndWaitCancellationToken),
+                async () =>
+                {
+                    if (syncOrAsync == SyncOrAsync.Sync)
+                    {
+                        return await pendingRequestQueue.QueueAndWaitAsync(request, queueAndWaitCancellationToken);
+                    }
+
+                    return await pendingRequestQueue.QueueAndWaitAsync(request, new RequestCancellationTokens(queueAndWaitCancellationToken, CancellationToken.None));
+                },
                 CancellationToken);
             return task;
         }
 
-        async Task<(Task<ResponseMessage> queueAndWaitTask, RequestMessage dequeued)> QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(IPendingRequestQueue sut, RequestMessage request, CancellationToken cancellationToken)
+        async Task<(Task<ResponseMessage> queueAndWaitTask, RequestMessage dequeued)> QueueAndDequeueRequest_ForTimeoutTestingOnly_ToCopeWithRaceCondition(
+            IPendingRequestQueue sut, 
+            RequestMessage request, 
+            SyncOrAsync syncOrAsync,
+            CancellationToken cancellationToken)
         {
             //For most tests, this is not a good method to use. It is a fix for some specific tests to cope with a race condition when Team City runs out of resources (and causes tests to become flaky)
 
             while (true)
             {
-                var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, cancellationToken);
+                var queueAndWaitTask = await StartQueueAndWaitAndWaitForRequestToBeQueued(sut, request, syncOrAsync, CancellationToken);
                 sut.Count.Should().Be(1, "Item should be queued");
 
                 var dequeued = await sut.DequeueAsync(cancellationToken);

--- a/source/Halibut.Tests/Support/ExtensionMethods/ServiceEndPointExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/ExtensionMethods/ServiceEndPointExtensionMethods.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Halibut.Tests.Support.ExtensionMethods
+{
+    public static class ServiceEndPointExtensionMethods
+    {
+        public static void TryAndConnectForALongTime(this ServiceEndPoint point)
+        {
+            point.RetryCountLimit = 1000000;
+            point.ConnectionErrorRetryTimeout = TimeSpan.FromDays(1);
+            point.PollingRequestQueueTimeout = TimeSpan.FromDays(1);
+            point.TcpClientConnectTimeout = TimeSpan.FromDays(1);
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -362,7 +362,6 @@ namespace Halibut.Tests.Support
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
-                ;
                 var webSocketListeningInfo = await TryListenWebSocket.WebSocketListeningPort(logger, client, cancellationToken);
                 var webSocketListeningPort = webSocketListeningInfo.WebSocketListeningPort;
 

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Util;
@@ -19,20 +20,21 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testNetworkConditions = true,
             bool testListening = true,
             bool testPolling = true,
-            bool testAsyncAndSyncClients = true,
+            bool testSyncClients = true,
+            bool testAsyncClients = true,
             bool testAsyncServicesAsWell = false, // False means only the sync service will be tested.
             params object[] additionalParameters
             ) :
             base(
                 typeof(LatestClientAndLatestServiceTestCases),
                 nameof(LatestClientAndLatestServiceTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, additionalParameters, testAsyncServicesAsWell})
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testSyncClients, testAsyncClients, testAsyncServicesAsWell, additionalParameters })
         {
         }
 
         static class LatestClientAndLatestServiceTestCases
         {
-            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, object[] additionalParameters, bool testAsyncServicesAsWell)
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testSyncClients, bool testAsyncClients, bool testAsyncServicesAsWell, object[] additionalParameters)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -51,10 +53,16 @@ namespace Halibut.Tests.Support.TestAttributes
                     serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
                 
-                ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];
-                if (testAsyncAndSyncClients)
+                List<ForceClientProxyType> clientProxyTypesToTest = new();
+                
+                if (testAsyncClients)
                 {
-                    clientProxyTypesToTest = ForceClientProxyTypeValues.All;
+                    clientProxyTypesToTest.Add(ForceClientProxyType.AsyncClient);
+
+                    if (testSyncClients)
+                    {
+                        clientProxyTypesToTest.Add(ForceClientProxyType.SyncClient);
+                    }
                 }
                 
                 var serviceAsyncHalibutFeatureTestCases = AsyncHalibutFeatureValues.All().ToList();

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
@@ -15,19 +15,20 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testNetworkConditions = true,
             bool testListening = true,
             bool testPolling = true,
-            bool testAsyncAndSyncClients = true,
+            bool testAsyncClients = true,
+            bool testSyncClients = true,
             bool testAsyncServicesAsWell = false // False means only the sync service will be tested.
             ) :
             base(
                 typeof(LatestClientAndPreviousServiceVersionsTestCases),
                 nameof(LatestClientAndPreviousServiceVersionsTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncAndSyncClients, testAsyncServicesAsWell})
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncClients, testSyncClients, testAsyncServicesAsWell })
         {
         }
         
         static class LatestClientAndPreviousServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling,  bool testAsyncAndSyncClients, bool testAsyncServicesAsWell)
+            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncClients, bool testSyncClients, bool testAsyncServicesAsWell)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -46,10 +47,16 @@ namespace Halibut.Tests.Support.TestAttributes
                     serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
                 
-                ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];
-                if (testAsyncAndSyncClients)
+                List<ForceClientProxyType> clientProxyTypesToTest = new();
+
+                if (testAsyncClients)
                 {
-                    clientProxyTypesToTest = ForceClientProxyTypeValues.All;
+                    clientProxyTypesToTest.Add(ForceClientProxyType.AsyncClient);
+
+                    if (testSyncClients)
+                    {
+                        clientProxyTypesToTest.Add(ForceClientProxyType.SyncClient);
+                    }
                 }
 
                 var serviceAsyncHalibutFeatureTestCases = AsyncHalibutFeatureValues.All().ToList();

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientDoSomeActionServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientDoSomeActionServiceWithOptions.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientDoSomeActionServiceWithOptions
+    {
+        Task ActionAsync(HalibutProxyRequestOptions options);
+    }
+}

--- a/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientDoSomeActionServiceWithOptions.cs
+++ b/source/Halibut.Tests/TestServices/SyncClientWithOptions/ISyncClientDoSomeActionServiceWithOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using Halibut.ServiceModel;
+
+namespace Halibut.Tests.TestServices.SyncClientWithOptions
+{
+    public interface ISyncClientDoSomeActionServiceWithOptions
+    {
+        void Action(HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
@@ -65,7 +65,7 @@ namespace Halibut.Tests.Transport
         }
 
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false, testAsyncAndSyncClients: true)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
         public async Task DiscoverShouldRespectTcpClientReceiveTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var dataTransferObserverPauser = new DataTransferObserverBuilder()

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -70,10 +70,12 @@ namespace Halibut.Tests.Transport
             var secureClient = new SecureListeningClient((s, l)  => GetProtocol(s, l, syncOrAsync), endpoint, Certificates.Octopus, log, connectionManager);
             ResponseMessage response = null!;
 
+            using var requestCancellationTokens = new RequestCancellationTokens(CancellationToken.None, CancellationToken.None);
+
 #pragma warning disable CS0612
             await syncOrAsync
                 .WhenSync(() => secureClient.ExecuteTransaction((mep) => response = mep.ExchangeAsClient(request), CancellationToken.None))
-                .WhenAsync(async () => await secureClient.ExecuteTransactionAsync(async (mep, ct) => response = await mep.ExchangeAsClientAsync(request, ct), CancellationToken.None));
+                .WhenAsync(async () => await secureClient.ExecuteTransactionAsync(async (mep, ct) => response = await mep.ExchangeAsClientAsync(request, ct), requestCancellationTokens));
 #pragma warning restore CS0612
 
             // The pool should be cleared after the second failure

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -9,7 +9,6 @@ using Halibut.Diagnostics;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Transport;
-using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Transport
@@ -61,9 +60,11 @@ namespace Halibut.Tests.Transport
                     Certificates.TentacleListening,
                     null,
                     null,
-                    thumbprint => true,
+                    _ => true,
                     new LogFactory(),
                     () => "",
+                    () => new Dictionary<string, string>(),
+                    (_, _) => UnauthorizedClientConnectResponse.BlockConnection,
                     syncOrAsync.ToAsyncHalibutFeature()
                 );
 

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices;
+using Halibut.Tests.TestServices.Async;
+using Halibut.Tests.TestServices.SyncClientWithOptions;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
@@ -18,34 +22,63 @@ namespace Halibut.Tests
         public class AndTheRequestIsStillQueued : BaseTest
         {
             [Test]
-            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncAndSyncClients: false)]
-            public async Task TheRequestShouldBeCancelled(ClientAndServiceTestCase clientAndServiceTestCase)
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncClients: false)]
+            public async Task TheRequestShouldBeCancelled_WhenUsingCreateClientWithASingleCancellationToken(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 var cancellationTokenSource = new CancellationTokenSource();
                 
                 using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                           .As<LatestClientAndLatestServiceBuilder>()
-                           // No Tentacle
+                           .AsLatestClientAndLatestServiceBuilder()
                            .NoService()
-                           // CancelWhenRequestQueuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
                            .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, cancellationTokenSource)))
                            .Build(CancellationToken))
                 {
                     var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService>(cancellationTokenSource.Token);
 
-                    Exception actualException = null;
+                    Assert.Throws<OperationCanceledException>(() => doSomeActionService.Action());
+                }
+            }
 
-                    try
-                    {
-                        doSomeActionService.Action();
-                    }
-                    catch (Exception ex)
-                    {
-                        actualException = ex;
-                    }
+            [Test]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncClients: false)]
+            public async Task TheRequestShouldBeCancelled_WhenTheConnectingOrInProgressCancellationTokenIsCancelled_OnSyncClients(
+                ClientAndServiceTestCase clientAndServiceTestCase)
+            {
+                var tokenSourceToCancel = new CancellationTokenSource();
+                var halibutProxyRequestOptions = new HalibutProxyRequestOptions(tokenSourceToCancel.Token, null);
 
-                    actualException.Should().NotBeNull();
-                    actualException.Should().BeOfType<OperationCanceledException>();
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
+                           .NoService()
+                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, tokenSourceToCancel)))
+                           .Build(CancellationToken))
+                {
+                    var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService, ISyncClientDoSomeActionServiceWithOptions>();
+
+                    Assert.Throws<OperationCanceledException>(() => doSomeActionService.Action(halibutProxyRequestOptions));
+                }
+            }
+
+            [Test]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testSyncClients: false, additionalParameters: new object[]{ true, false })]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testSyncClients: false, additionalParameters: new object[]{ false, true })]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testSyncClients: false, additionalParameters: new object[]{ true, true })]
+            public async Task TheRequestShouldBeCancelled_WhenTheConnectingOrInProgressCancellationTokenIsCancelled_OnAsyncClients(
+                ClientAndServiceTestCase clientAndServiceTestCase, 
+                bool connectingCancellationTokenCancelled,
+                bool inProgressCancellationTokenCancelled)
+            {
+                var (tokenSourcesToCancel, halibutProxyRequestOptions) = CreateTokenSourceAndHalibutProxyRequestOptions(connectingCancellationTokenCancelled, inProgressCancellationTokenCancelled);
+
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
+                           .NoService()
+                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, tokenSourcesToCancel)))
+                           .Build(CancellationToken))
+                {
+                    var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+                    await AssertAsync.Throws<OperationCanceledException>(() => doSomeActionService.ActionAsync(halibutProxyRequestOptions));
                 }
             }
         }
@@ -53,61 +86,196 @@ namespace Halibut.Tests
         public class AndTheRequestHasBeenDequeuedButNoResponseReceived : BaseTest
         {
             [Test]
-            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncAndSyncClients: false)]
-            public async Task TheRequestShouldNotBeCancelled(ClientAndServiceTestCase clientAndServiceTestCase)
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncClients: false)]
+            public async Task TheRequestShouldNotBeCancelled_WhenUsingCreateClientWithASingleCancellationToken(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 var calls = new List<DateTime>();
-                var cancellationTokenSource = new CancellationTokenSource();
+                var tokenSourceToCancel = new CancellationTokenSource();
 
                 using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                           .As<LatestClientAndLatestServiceBuilder>()
+                           .AsLatestClientAndLatestServiceBuilder()
                            .WithDoSomeActionService(() =>
                            {
                                calls.Add(DateTime.UtcNow);
 
-                               while (!cancellationTokenSource.IsCancellationRequested)
+                               while (!tokenSourceToCancel.IsCancellationRequested)
                                {
                                    Thread.Sleep(TimeSpan.FromMilliseconds(10));
                                }
 
                                Thread.Sleep(TimeSpan.FromSeconds(1));
                            })
-                           // CancelWhenRequestDequeuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
-                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, cancellationTokenSource)))
+                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, tokenSourceToCancel)))
                            .Build(CancellationToken))
                 {
-                    clientAndService.CreateClient<IDoSomeActionService>(cancellationTokenSource.Token).Action();
+                    var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService>(tokenSourceToCancel.Token);
+                    doSomeActionService.Action();
+
+                }
+
+                calls.Should().HaveCount(1);
+            }
+
+            [Test]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testAsyncClients: false)]
+            public async Task TheRequestShouldNotBeCancelled_WhenTheConnectingCancellationTokenIsCancelled_OnSyncClients(ClientAndServiceTestCase clientAndServiceTestCase)
+            {
+                var calls = new List<DateTime>();
+                var tokenSourceToCancel = new CancellationTokenSource();
+                var halibutProxyRequestOptions = new HalibutProxyRequestOptions(tokenSourceToCancel.Token, null);
+
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
+                           .WithDoSomeActionService(() =>
+                           {
+                               calls.Add(DateTime.UtcNow);
+
+                               while (!tokenSourceToCancel.IsCancellationRequested)
+                               {
+                                   Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                               }
+
+                               Thread.Sleep(TimeSpan.FromSeconds(1));
+                           })
+                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, tokenSourceToCancel)))
+                           .Build(CancellationToken))
+                {
+                    var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService, ISyncClientDoSomeActionServiceWithOptions>();
+
+                    doSomeActionService.Action(halibutProxyRequestOptions);
+                }
+
+                calls.Should().HaveCount(1);
+            }
+
+            [Test]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testSyncClients: false)]
+            public async Task TheRequestShouldNotBeCancelled_WhenTheConnectingCancellationTokenIsCancelled_OnAsyncClients(ClientAndServiceTestCase clientAndServiceTestCase)
+            {
+                var calls = new List<DateTime>();
+                var (tokenSourcesToCancel, halibutProxyRequestOptions) = CreateTokenSourceAndHalibutProxyRequestOptions(
+                    connectingCancellationTokenCancelled: true, 
+                    inProgressCancellationTokenCancelled: false);
+
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
+                           .WithDoSomeActionService(() =>
+                           {
+                               calls.Add(DateTime.UtcNow);
+
+                               while (!tokenSourcesToCancel.All(x => x.IsCancellationRequested))
+                               {
+                                   Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                               }
+
+                               Thread.Sleep(TimeSpan.FromSeconds(1));
+                           })
+                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, tokenSourcesToCancel)))
+                           .Build(CancellationToken))
+                {
+                    var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+                    await doSomeActionService.ActionAsync(halibutProxyRequestOptions);
+                }
+
+                calls.Should().HaveCount(1);
+            }
+
+            [Test]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testSyncClients: false, additionalParameters: new object[]{ false, true })]
+            [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false, testSyncClients: false, additionalParameters: new object[]{ true, true })]
+            public async Task TheRequestShouldBeCancelled_WhenTheInProgressCancellationTokenIsCancelled_OnAsyncClients(
+                ClientAndServiceTestCase clientAndServiceTestCase, 
+                bool connectingCancellationTokenCancelled,
+                bool inProgressCancellationTokenCancelled)
+            {
+                var calls = new List<DateTime>();
+                var (tokenSourcesToCancel, halibutProxyRequestOptions) = CreateTokenSourceAndHalibutProxyRequestOptions(connectingCancellationTokenCancelled, inProgressCancellationTokenCancelled);
+
+                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                           .AsLatestClientAndLatestServiceBuilder()
+                           .WithHalibutLoggingLevel(LogLevel.Trace)
+                           .WithDoSomeActionService(() =>
+                           {
+                               calls.Add(DateTime.UtcNow);
+
+                               while (!tokenSourcesToCancel.All(x => x.IsCancellationRequested))
+                               {
+                                   Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                               }
+
+                               Thread.Sleep(TimeSpan.FromSeconds(1));
+                           })
+                           .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, tokenSourcesToCancel)))
+                           .Build(CancellationToken))
+                {
+                    var doSomeActionService = clientAndService.CreateClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+                    await AssertAsync.Throws<OperationCanceledException>(() => doSomeActionService.ActionAsync(halibutProxyRequestOptions));
                 }
 
                 calls.Should().HaveCount(1);
             }
         }
 
-        internal class CancelWhenRequestQueuedPendingRequestQueueFactory : IPendingRequestQueueFactory
+        static (CancellationTokenSource[] ToeknSourcesToCancel, HalibutProxyRequestOptions HalibutProxyRequestOptions) CreateTokenSourceAndHalibutProxyRequestOptions(
+            bool connectingCancellationTokenCancelled, 
+            bool inProgressCancellationTokenCancelled)
         {
-            readonly CancellationTokenSource cancellationTokenSource;
+            var connectingCancellationTokenSource = new CancellationTokenSource();
+            var inProgressCancellationTokenSource = new CancellationTokenSource();
+
+            CancellationTokenSource[] tokenSourcesToCancel;
+
+            if (connectingCancellationTokenCancelled && inProgressCancellationTokenCancelled)
+            {
+                tokenSourcesToCancel = new [] { connectingCancellationTokenSource, inProgressCancellationTokenSource };
+            }
+            else if (connectingCancellationTokenCancelled)
+            {
+                tokenSourcesToCancel = new [] { connectingCancellationTokenSource };
+            }
+            else
+            {
+                tokenSourcesToCancel = new [] { inProgressCancellationTokenSource };
+            }
+
+            var halibutProxyRequestOptions = new HalibutProxyRequestOptions(connectingCancellationTokenSource.Token, inProgressCancellationTokenSource.Token);
+                
+            return (tokenSourcesToCancel, halibutProxyRequestOptions);
+        }
+
+        /// <summary>
+        /// CancelWhenRequestQueuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
+        /// </summary>
+        class CancelWhenRequestQueuedPendingRequestQueueFactory : IPendingRequestQueueFactory
+        {
+            readonly CancellationTokenSource[] cancellationTokenSources;
             readonly IPendingRequestQueueFactory inner;
 
-            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource)
+            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource[] cancellationTokenSources)
             {
-                this.cancellationTokenSource = cancellationTokenSource;
+                this.cancellationTokenSources = cancellationTokenSources;
                 this.inner = inner;
+            }
+
+            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource) : this(inner, new[]{ cancellationTokenSource }) {
             }
 
             public IPendingRequestQueue CreateQueue(Uri endpoint)
             {
-                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSource);
+                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSources);
             }
 
             class Decorator : IPendingRequestQueue
             {
-                readonly CancellationTokenSource cancellationTokenSource;
+                readonly CancellationTokenSource[] cancellationTokenSources;
                 readonly IPendingRequestQueue inner;
 
-                public Decorator(IPendingRequestQueue inner, CancellationTokenSource cancellationTokenSource)
+                public Decorator(IPendingRequestQueue inner, CancellationTokenSource[] cancellationTokenSources)
                 {
                     this.inner = inner;
-                    this.cancellationTokenSource = cancellationTokenSource;
+                    this.cancellationTokenSources = cancellationTokenSources;
                 }
 
                 public bool IsEmpty => inner.IsEmpty;
@@ -115,7 +283,7 @@ namespace Halibut.Tests
                 public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
                 public async Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken) => await inner.DequeueAsync(cancellationToken);
 
-                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
+                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken queuedRequestCancellationToken)
                 {
                     var task = Task.Run(async () =>
                         {
@@ -124,42 +292,67 @@ namespace Halibut.Tests
                                 await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
                             }
 
-                            cancellationTokenSource.Cancel();
+                            Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2)));
                         },
                         CancellationToken.None);
 
-                    var result = await inner.QueueAndWaitAsync(request, cancellationToken);
+                    var result = await inner.QueueAndWaitAsync(request, queuedRequestCancellationToken);
+                    await task;
+                    return result;
+                }
+
+                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
+                {
+                    var task = Task.Run(async () =>
+                        {
+                            while (inner.IsEmpty)
+                            {
+                                await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                            }
+
+                            Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.Cancel());
+                        },
+                        CancellationToken.None);
+
+                    var result = await inner.QueueAndWaitAsync(request, requestCancellationTokens);
                     await task;
                     return result;
                 }
             }
         }
 
-        internal class CancelWhenRequestDequeuedPendingRequestQueueFactory : IPendingRequestQueueFactory
+        /// <summary>
+        /// CancelWhenRequestDequeuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
+        /// </summary>
+        class CancelWhenRequestDequeuedPendingRequestQueueFactory : IPendingRequestQueueFactory
         {
-            readonly CancellationTokenSource cancellationTokenSource;
+            readonly CancellationTokenSource[] cancellationTokenSources;
             readonly IPendingRequestQueueFactory inner;
 
-            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource)
+            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource[] cancellationTokenSources)
             {
-                this.cancellationTokenSource = cancellationTokenSource;
+                this.cancellationTokenSources = cancellationTokenSources;
                 this.inner = inner;
+            }
+
+            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource): this(inner, new []{ cancellationTokenSource })
+            {
             }
 
             public IPendingRequestQueue CreateQueue(Uri endpoint)
             {
-                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSource);
+                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSources);
             }
 
             class Decorator : IPendingRequestQueue
             {
-                readonly CancellationTokenSource cancellationTokenSource;
+                readonly CancellationTokenSource[] cancellationTokenSources;
                 readonly IPendingRequestQueue inner;
 
-                public Decorator(IPendingRequestQueue inner, CancellationTokenSource cancellationTokenSource)
+                public Decorator(IPendingRequestQueue inner, CancellationTokenSource[] cancellationTokenSources)
                 {
                     this.inner = inner;
-                    this.cancellationTokenSource = cancellationTokenSource;
+                    this.cancellationTokenSources = cancellationTokenSources;
                 }
 
                 public bool IsEmpty => inner.IsEmpty;
@@ -169,12 +362,17 @@ namespace Halibut.Tests
                 public async Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken)
                 {
                     var response = await inner.DequeueAsync(cancellationToken);
-                    cancellationTokenSource.Cancel();
+                    
+                    Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2)));
+
                     return response;
                 }
 
-                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
-                    => await inner.QueueAndWaitAsync(request, cancellationToken);
+                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken queuedRequestCancellationToken)
+                    => await inner.QueueAndWaitAsync(request, queuedRequestCancellationToken);
+
+                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
+                    => await inner.QueueAndWaitAsync(request, requestCancellationTokens);
             }
         }
     }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -318,7 +318,7 @@ namespace Halibut
             return response;
         }
 
-        async Task<ResponseMessage> SendOutgoingRequestAsync(RequestMessage request, MethodInfo methodInfo, CancellationToken cancellationToken)
+        async Task<ResponseMessage> SendOutgoingRequestAsync(RequestMessage request, MethodInfo methodInfo, RequestCancellationTokens requestCancellationTokens)
         {
             var endPoint = request.Destination;
 
@@ -334,10 +334,10 @@ namespace Halibut
             switch (endPoint.BaseUri.Scheme.ToLowerInvariant())
             {
                 case "https":
-                    response = await SendOutgoingHttpsRequestAsync(request, cancellationToken).ConfigureAwait(false);
+                    response = await SendOutgoingHttpsRequestAsync(request, requestCancellationTokens).ConfigureAwait(false);
                     break;
                 case "poll":
-                    response = await SendOutgoingPollingRequest(request, cancellationToken).ConfigureAwait(false);
+                    response = await SendOutgoingPollingRequestAsync(request, requestCancellationTokens).ConfigureAwait(false);
                     break;
                 default: throw new ArgumentException("Unknown endpoint type: " + endPoint.BaseUri.Scheme);
             }
@@ -360,7 +360,7 @@ namespace Halibut
             return response;
         }
 
-        async Task<ResponseMessage> SendOutgoingHttpsRequestAsync(RequestMessage request, CancellationToken cancellationToken)
+        async Task<ResponseMessage> SendOutgoingHttpsRequestAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
         {
             var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
 
@@ -371,7 +371,7 @@ namespace Halibut
                 {
                     response = await protocol.ExchangeAsClientAsync(request, cts).ConfigureAwait(false);
                 }, 
-                cancellationToken).ConfigureAwait(false);
+                requestCancellationTokens).ConfigureAwait(false);
 
             return response;
         }
@@ -380,6 +380,12 @@ namespace Halibut
         {
             var queue = GetQueue(request.Destination.BaseUri);
             return await queue.QueueAndWaitAsync(request, cancellationToken);
+        }
+
+        async Task<ResponseMessage> SendOutgoingPollingRequestAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
+        {
+            var queue = GetQueue(request.Destination.BaseUri);
+            return await queue.QueueAndWaitAsync(request, requestCancellationTokens);
         }
 
         ResponseMessage HandleIncomingRequest(RequestMessage request)

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -157,14 +157,20 @@ namespace Halibut.ServiceModel
         {
             return messageRouter(requestMessage, targetMethod, connectCancellationToken);
         }
+
         CancellationToken ConnectingCancellationToken(HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
-            if (halibutProxyRequestOptions == null || halibutProxyRequestOptions.ConnectCancellationToken == null)
+            if (halibutProxyRequestOptions?.InProgressRequestCancellationToken != null && halibutProxyRequestOptions?.InProgressRequestCancellationToken != CancellationToken.None)
+            {
+                throw new ArgumentException($"{nameof(HalibutProxyRequestOptions)}.{nameof(HalibutProxyRequestOptions.InProgressRequestCancellationToken)} is not supported by HalibutProxy");
+            }
+
+            if (halibutProxyRequestOptions == null || halibutProxyRequestOptions.ConnectingCancellationToken == null)
             {
                 return globalCancellationToken;
             }
 
-            return (CancellationToken) halibutProxyRequestOptions.ConnectCancellationToken;
+            return (CancellationToken) halibutProxyRequestOptions.ConnectingCancellationToken;
         }
 
         void EnsureNotError(ResponseMessage responseMessage)

--- a/source/Halibut/ServiceModel/HalibutProxyRequestOptions.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyRequestOptions.cs
@@ -7,14 +7,28 @@ namespace Halibut.ServiceModel
     public class HalibutProxyRequestOptions
     {
         /// <summary>
-        /// When cancelled, this will only stop a RPC call if it is known to not be
-        /// received by the service.
+        /// When cancelled, will only stop an RPC call if it is known to not be received by the service.
+        /// For a Listening Service, cancellation can occur when the Client is still connecting to the Service.
+        /// For a Polling Service, cancellation can occur when the Client has queued a Request but the Service has not yet Dequeued it.
         /// </summary>
-        public CancellationToken? ConnectCancellationToken { get; }
+        public CancellationToken? ConnectingCancellationToken { get; }
 
-        public HalibutProxyRequestOptions(CancellationToken? connectCancellationToken)
+        /// <summary>
+        /// When cancelled, will try to cancel an in-progress / in-flight RPC call.
+        /// This is a best effort cancellation and is not guaranteed.
+        /// For Sync Halibut, providing this cancellation token is not supported.
+        /// For Async Halibut this will attempt to cancel the RPC call.
+        /// If the call is to a Listening Service, then cancellation is performed all the way down to the Socket operations.
+        /// if the call is to a Polling Service, then cancellation is performed all the way down to the Polling Queue,
+        /// this means the client can cancel the call but the service will still process the request and return a response.
+        /// </summary>
+        public CancellationToken? InProgressRequestCancellationToken { get; }
+
+        public HalibutProxyRequestOptions(CancellationToken? connectingCancellationToken, 
+            CancellationToken? inProgressRequestCancellationToken)
         {
-            this.ConnectCancellationToken = connectCancellationToken;
+            ConnectingCancellationToken = connectingCancellationToken;
+            InProgressRequestCancellationToken = inProgressRequestCancellationToken;
         }
     }
 }

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Transport.Protocol;
@@ -11,6 +10,7 @@ namespace Halibut.ServiceModel
         int Count { get; }
         Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination);
         Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken);
-        Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken);
+        Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken queuedRequestCancellationToken);
+        Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens);
     }
 }

--- a/source/Halibut/ServiceModel/PendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueue.cs
@@ -59,12 +59,20 @@ namespace Halibut.ServiceModel
             return pending.Response;
         }
 
-        public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
+        public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken queuedRequestCancellationToken)
         {
 #pragma warning disable 612
-            var responseMessage = QueueAndWait(request, cancellationToken);
+            var responseMessage = QueueAndWait(request, queuedRequestCancellationToken);
 #pragma warning restore 612
             return await Task.FromResult(responseMessage);
+        }
+
+        [Obsolete]
+        public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
+        {
+            await Task.CompletedTask;
+
+            throw new NotSupportedException($"Use {nameof(QueueAndWaitAsync)} with {nameof(CancellationToken)}");
         }
 
         public bool IsEmpty

--- a/source/Halibut/ServiceModel/RequestCancellationTokens.cs
+++ b/source/Halibut/ServiceModel/RequestCancellationTokens.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading;
+
+namespace Halibut.ServiceModel
+{
+    public class RequestCancellationTokens : IDisposable
+    {
+        CancellationTokenSource linkedCancellationTokenSource;
+
+        public RequestCancellationTokens(CancellationToken connectingCancellationToken, CancellationToken inProgressRequestCancellationToken)
+        {
+            ConnectingCancellationToken = connectingCancellationToken;
+            InProgressRequestCancellationToken = inProgressRequestCancellationToken;
+        }
+
+        public CancellationToken ConnectingCancellationToken { get; set; }
+        public CancellationToken InProgressRequestCancellationToken { get; set; }
+
+        public CancellationToken LinkedCancellationToken => LazyLinkedCancellationToken.Value;
+
+        Lazy<CancellationToken> LazyLinkedCancellationToken => new (() =>
+        {
+            if (ConnectingCancellationToken == CancellationToken.None && InProgressRequestCancellationToken == CancellationToken.None)
+            {
+                return CancellationToken.None;
+            }
+
+            linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ConnectingCancellationToken, InProgressRequestCancellationToken);
+
+            return linkedCancellationTokenSource.Token;
+        });
+
+        public void Dispose()
+        {
+            linkedCancellationTokenSource?.Dispose();
+        }
+
+        public bool CanCancelInProgressRequest()
+        {
+            return InProgressRequestCancellationToken != CancellationToken.None;
+        }
+    }
+}

--- a/source/Halibut/Transport/ISecureClient.cs
+++ b/source/Halibut/Transport/ISecureClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.Transport
@@ -11,6 +12,6 @@ namespace Halibut.Transport
 
         [Obsolete]
         void ExecuteTransaction(ExchangeAction protocolHandler, CancellationToken cancellationToken);
-        Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, CancellationToken cancellationToken);
+        Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, RequestCancellationTokens requestCancellationTokens);
     }
 }

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
+using Halibut.ServiceModel;
 using Halibut.Transport.Protocol;
 using Halibut.Util;
 
@@ -131,7 +132,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        public async Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, CancellationToken cancellationToken)
+        public async Task ExecuteTransactionAsync(ExchangeActionAsync protocolHandler, RequestCancellationTokens requestCancellationTokens)
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 
@@ -144,7 +145,7 @@ namespace Halibut.Transport
             {
                 if (i > 0)
                 {
-                    await Task.Delay(retryInterval, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(retryInterval, requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
                     log.Write(EventType.OpeningNewConnection, $"Retrying connection to {ServiceEndpoint.Format()} - attempt #{i}.");
                 }
 
@@ -160,15 +161,18 @@ namespace Halibut.Transport
                             new TcpConnectionFactory(clientCertificate), 
                             ServiceEndpoint, 
                             log, 
-                            cancellationToken).ConfigureAwait(false);
+                            requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;
 
-                        await protocolHandler(connection.Protocol, cancellationToken).ConfigureAwait(false);
+                        // TODO: Enhancement: Pass the RequestCancellationTokens to the protocol handler so that it can cancel
+                        // PrepareExchangeAsClientAsync as part of the ConnectingCancellationToken being cancelled
+                        await protocolHandler(connection.Protocol, requestCancellationTokens.InProgressRequestCancellationToken).ConfigureAwait(false);
                     }
                     catch
                     {
+                        // TODO - ASYNC ME UP!
                         connection?.Dispose();
                         if (connectionManager.IsDisposed)
                             return;

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -40,25 +40,23 @@ namespace Halibut.Transport
         readonly ILogFactory logFactory;
         readonly Func<string> getFriendlyHtmlPageContent;
         readonly Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders;
-        readonly CancellationTokenSource cts = new CancellationTokenSource();
-        readonly TcpClientManager tcpClientManager = new TcpClientManager();
+        readonly CancellationTokenSource cts = new();
+        readonly TcpClientManager tcpClientManager = new();
         readonly ExchangeActionAsync exchangeAction;
         readonly AsyncHalibutFeature asyncHalibutFeature;
         ILog log;
         TcpListener listener;
         Thread backgroundThread;
 
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, AsyncHalibutFeature asyncHalibutFeature)
-            : this(endPoint, serverCertificate, exchangeProtocolBuilder, exchangeAction, verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, () => new Dictionary<string, string>(), asyncHalibutFeature)
-        {
-        }
-
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, AsyncHalibutFeature asyncHalibutFeature) :
-            this(endPoint, serverCertificate, exchangeProtocolBuilder, exchangeAction, verifyClientThumbprint, logFactory, getFriendlyHtmlPageContent, getFriendlyHtmlPageHeaders, (clientName, thumbprint) => UnauthorizedClientConnectResponse.BlockConnection, asyncHalibutFeature)
-        {
-        }
-
-        public SecureListener(IPEndPoint endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders,
+        public SecureListener(
+            IPEndPoint endPoint, 
+            X509Certificate2 serverCertificate, 
+            ExchangeProtocolBuilder exchangeProtocolBuilder, 
+            ExchangeActionAsync exchangeAction, 
+            Predicate<string> verifyClientThumbprint, 
+            ILogFactory logFactory, 
+            Func<string> getFriendlyHtmlPageContent, 
+            Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders,
             Func<string, string, UnauthorizedClientConnectResponse> unauthorizedClientConnect, AsyncHalibutFeature asyncHalibutFeature)
         {
             this.endPoint = endPoint;


### PR DESCRIPTION
# Background

This PR adds connecting and in-progress cancelation to async halibut client calls

# Results

When using async Halibut the client can send a request and cancel that request in 2 different phases.

- When the request is queued for a polling service or the client is establishing the connection for a listening service
- When the request is in-progress. That is, it has been dequeued for a polling service, or is being sent by the client for a listening service.

When using sync Halibut the request can only  be cancelled in the connecting / queued phase, which is current behaviour.

## Limitations

> net48 does not support cancelling a Listing In-Prgress request currently due to the DeflateStream using Begin and End Read/Write methods for async operations which result in Cancellation Tokens not being passed to inner streams, including the NetworkTimeoutStream

> Cancelling an in-progress Polling Request will cancel the operation as far as the `IPendingRequestQueue`. The Polling Tentacle will still continue to transfer the request and any data streams and provide the response. This can be enhanced in the future to support cancellation all the way down to the socket for Polling Tentacles.

## Core changes

`HalibutRequestProxyOptions` now takes 2 cancellation tokens.

```
public HalibutProxyRequestOptions(CancellationToken? connectingCancellationToken, 
            CancellationToken? inProgressRequestCancellationToken)
{
    ConnectingCancellationToken = connectingCancellationToken;
    InProgressRequestCancellationToken = inProgressRequestCancellationToken;
}
```

These are passed through the Halibut stack as `RequestCancellationTokens` to allow the executing code to decide if it will cancel for connecting `ConnectingCancellationToken`, in-progress `InProgressRequestCancellationToken` or both `LinkedCancellationToken`

```
public class RequestCancellationTokens : IDisposable
    {
        CancellationTokenSource linkedCancellationTokenSource;

        public RequestCancellationTokens(CancellationToken connectingCancellationToken, CancellationToken inProgressRequestCancellationToken)
        {
            ConnectingCancellationToken = connectingCancellationToken;
            InProgressRequestCancellationToken = inProgressRequestCancellationToken;
        }

        public CancellationToken ConnectingCancellationToken { get; set; }
        public CancellationToken InProgressRequestCancellationToken { get; set; }

        public CancellationToken LinkedCancellationToken => LazyLinkedCancellationToken.Value;

        Lazy<CancellationToken> LazyLinkedCancellationToken => new (() =>
        {
            if (ConnectingCancellationToken == CancellationToken.None && InProgressRequestCancellationToken == CancellationToken.None)
            {
                return CancellationToken.None;
            }
            linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ConnectingCancellationToken, InProgressRequestCancellationToken);
            return linkedCancellationTokenSource.Token;
        });

        public void Dispose()
        {
            linkedCancellationTokenSource?.Dispose();
        }

        public bool CanCancelInProgressRequest()
        {
            return InProgressRequestCancellationToken != CancellationToken.None;
        }
    }
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
