### PR TITLE
Logs are now easier to read

### DIFF
--- a/source/Halibut.Tests/Support/StringExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/StringExtensionMethods.cs
@@ -1,0 +1,12 @@
+﻿using System.Text;
+
+namespace Halibut.Tests.Support
+{
+    public static class StringExtensionMethods
+    {
+        public static byte[] GetUTF8Bytes(this string s)
+        {
+            return Encoding.UTF8.GetBytes(s);
+        }
+    }
+}


### PR DESCRIPTION
# Background

* Reduces log length in TeamCity by using a hash of the test name on each log line instead of the full test name.
* The fixed and short length hash makes reading logs easier since less needs to be manually skipped.
* The total log file size in teamcity should now be smaller since the ~155 chars of a test name are replaced with 10. Hopefully this reduces load in TeamCity.
    * **For a recent 0.5GB log file, with `1,779,888` lines assume 155 chars extra per line = 263MB saved.**
* Since each line now has a hash, a new log line is added for each test which logs the name of the test making it easy to find the hash for your test. Once the hash is found, it can be used between runs on teamcity since the hash is stable.
* The order of context for log lines is now changes to be `<Testhash If in team city> <time> <context>`. Having the context after the time means that the timestamp will always be in the same place.

# Results

## Before

```
[ResponseMessageCacheFixture] 08:12:28.228 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)] Test started
[TestContextConnectionLog] 08:12:28.278 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)]          Service: Info: listen://[::]:49709/  17 Listener started
[TestContextConnectionLog] 08:12:28.366 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)]          Service: Info: listen://[::]:49709/  4 Accepted TCP client: [::1]:49710
[TestContextConnectionLog] 08:12:28.495 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)]           Client: Info: https://localhost:49709/  5 Secure connection established. Server at [::1]:49709 identified by thumbprint: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D, using protocol Tls12
[TestContextConnectionLog] 08:12:28.497 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)]          Service: Info: listen://[::]:49709/  36 Client at [::1]:49710 authenticated as 76225C0717A16C1D0BA4A7FFA76519D286D8A248
[LatestClientAndLatestServiceBuilder+ClientAndService] 08:12:28.715 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)] ****** ****** ****** ****** ****** ****** ******
[LatestClientAndLatestServiceBuilder+ClientAndService] 08:12:28.715 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)] ****** CLIENT AND SERVICE DISPOSE CALLED  ******
[LatestClientAndLatestServiceBuilder+ClientAndService] 08:12:28.715 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)] *     Subsequent errors should be ignored      *
[LatestClientAndLatestServiceBuilder+ClientAndService] 08:12:28.715 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)] ****** ****** ****** ****** ****** ****** ******
[TestContextConnectionLog] 08:12:28.737 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)]          Service: Info: listen://[::]:49709/  5 Listener stopped
[ResponseMessageCacheFixture] 08:12:28.738 +10:00 [ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient)] Tearing down

```

## After

```
2H40HhBGHP 08:11:24.193 +10:00  Test: ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, v:Latest, Network: 'Perfect', RecommendedIters: 1000, AsyncClient) has hash 2H40HhBGHP
2H40HhBGHP 08:11:24.202 +10:00 ResponseMessageCacheFixture Test started
2H40HhBGHP 08:11:24.246 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:49688/  18 Listener started
2H40HhBGHP 08:11:24.334 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:49688/  6 Accepted TCP client: [::1]:49689
2H40HhBGHP 08:11:24.471 +10:00 TestContextConnectionLog           Client: Info: https://localhost:49688/  11 Secure connection established. Server at [::1]:49688 identified by thumbprint: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D, using protocol Tls12
2H40HhBGHP 08:11:24.472 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:49688/  38 Client at [::1]:49689 authenticated as 76225C0717A16C1D0BA4A7FFA76519D286D8A248
2H40HhBGHP 08:11:24.687 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService ****** ****** ****** ****** ****** ****** ******
2H40HhBGHP 08:11:24.687 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService ****** CLIENT AND SERVICE DISPOSE CALLED  ******
2H40HhBGHP 08:11:24.687 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService *     Subsequent errors should be ignored      *
2H40HhBGHP 08:11:24.687 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService ****** ****** ****** ****** ****** ****** ******
2H40HhBGHP 08:11:24.707 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:49688/  6 Listener stopped
2H40HhBGHP 08:11:24.709 +10:00 ResponseMessageCacheFixture Tearing down
```

Note that only for a different test will the hash be different:
```
eLECfp8JgV 08:18:30.488 +10:00  Test: ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(Listening, vClient:Latest;vService:4.4.8, Network: 'Perfect', RecommendedIters: 1000, AsyncClient) has hash eLECfp8JgV
eLECfp8JgV 08:18:30.496 +10:00 ResponseMessageCacheFixture Test started
eLECfp8JgV 08:18:30.601 +10:00 HalibutRuntimeBuilder Mode is: serviceonly
eLECfp8JgV 08:18:30.627 +10:00 HalibutRuntimeBuilder Not using an Http Proxy
eLECfp8JgV 08:18:30.662 +10:00 HalibutRuntimeBuilder  ExternalService: ListenerStarted: listen://[::]:50339/  1 Listener started
eLECfp8JgV 08:18:30.662 +10:00 HalibutRuntimeBuilder Listening on port: 50339
eLECfp8JgV 08:18:30.675 +10:00 HalibutRuntimeBuilder RunningAndReady
```

Locally the changes are just the time is now always to the very left.

```
08:28:06.592 +10:00 ResponseMessageCacheFixture Test started
08:28:06.642 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:50525/  27 Listener started
08:28:06.734 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:50525/  11 Accepted TCP client: [::1]:50526
08:28:06.870 +10:00 TestContextConnectionLog           Client: Info: https://localhost:50525/  6 Secure connection established. Server at [::1]:50525 identified by thumbprint: 36F35047CE8B000CF4C671819A2DD1AFCDE3403D, using protocol Tls12
08:28:06.872 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:50525/  12 Client at [::1]:50526 authenticated as 76225C0717A16C1D0BA4A7FFA76519D286D8A248
08:28:07.090 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService ****** ****** ****** ****** ****** ****** ******
08:28:07.090 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService ****** CLIENT AND SERVICE DISPOSE CALLED  ******
08:28:07.090 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService *     Subsequent errors should be ignored      *
08:28:07.090 +10:00 LatestClientAndLatestServiceBuilder+ClientAndService ****** ****** ****** ****** ****** ****** ******
08:28:07.110 +10:00 TestContextConnectionLog          Service: Info: listen://[::]:50525/  4 Listener stopped
08:28:07.111 +10:00 ResponseMessageCacheFixture Tearing down
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
