### PR TITLE
ParallelRequestsFixture is already tested in sync and async

### DIFF
--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -122,9 +122,7 @@ namespace Halibut.Tests
         public class SyncParallelRequestsFixture : BaseTest
         {
             [Test]
-            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false,
-                testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
-            )]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false, testAsyncAndSyncClients: false)]
             public async Task MultipleRequestsCanBeInFlightInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
@@ -183,9 +181,7 @@ namespace Halibut.Tests
             }
 
             [Test]
-            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false,
-                testAsyncAndSyncClients: false // TODO - ASYNC ME UP!
-            )]
+            [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false, testAsyncAndSyncClients: false)]
             public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
             {
                 using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()


### PR DESCRIPTION
# Background

[SC-54458] The tests is already tested in sync and async. With two separate methods to avoid thread pool exhaustion.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
