### PR TITLE
PoC - Trust all certs issued by trusted root authority - Do Not Merge

### DIFF
--- a/source/Halibut.Tests/TlsInsepctionTests.cs
+++ b/source/Halibut.Tests/TlsInsepctionTests.cs
@@ -1,0 +1,49 @@
+using System;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using Halibut.Tests.Support;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class TlsInspectionTests : BaseTest
+    {
+        
+        [Test]
+        public void TrustAnyCertificateIssuedByTrustedCertificateRootAuthority()
+        {
+            var services = GetDelegateServiceFactory();
+            var clientTrustProvider = new DefaultTrustProvider();
+            using (var octopusServer = new HalibutRuntimeBuilder()
+                       .WithServerCertificate(CertAndThumbprint.Octopus.Certificate2)
+                       .Build())
+            using (var tentaclePolling = new HalibutRuntimeBuilder()
+                       .WithServiceFactory(services)
+                       .WithServerCertificate(CertAndThumbprint.TentaclePolling.Certificate2)
+                       .WithTrustProvider(clientTrustProvider)
+                       .Build())
+            {
+                octopusServer.Trust(CertAndThumbprint.TentaclePolling.Thumbprint);
+                
+                var port = octopusServer.Listen();
+                
+                tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + port), CertAndThumbprint.TentaclePolling.Thumbprint));
+
+                var echo = octopusServer.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", CertAndThumbprint.TentaclePolling.Thumbprint);
+
+                var result = echo.SayHello("World");
+                result.Should().Be("World...");
+            }
+        }
+        
+        
+        static DelegateServiceFactory GetDelegateServiceFactory()
+        {
+            var services = new DelegateServiceFactory();
+            services.Register<IEchoService>(() => new EchoService());
+            return services;
+        }
+        
+    }
+}

--- a/source/Halibut.Tests/TlsInsepctionTests.cs
+++ b/source/Halibut.Tests/TlsInsepctionTests.cs
@@ -28,7 +28,7 @@ namespace Halibut.Tests
                 
                 var port = octopusServer.Listen();
                 
-                tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + port), CertAndThumbprint.TentaclePolling.Thumbprint));
+                tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + port), CertAndThumbprint.Octopus.Thumbprint));
 
                 var echo = octopusServer.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", CertAndThumbprint.TentaclePolling.Thumbprint);
 

--- a/source/Halibut.Tests/TlsInsepctionTests.cs
+++ b/source/Halibut.Tests/TlsInsepctionTests.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.TestUtils.Contracts;
+using Halibut.Transport;
 using NUnit.Framework;
 
 namespace Halibut.Tests
@@ -11,17 +14,15 @@ namespace Halibut.Tests
     {
         
         [Test]
-        public void TrustAnyCertificateIssuedByTrustedCertificateRootAuthority()
+        public void TrustExplicitlySpecifiedCerts()
         {
             var services = GetDelegateServiceFactory();
-            var clientTrustProvider = new DefaultTrustProvider();
             using (var octopusServer = new HalibutRuntimeBuilder()
                        .WithServerCertificate(CertAndThumbprint.Octopus.Certificate2)
                        .Build())
             using (var tentaclePolling = new HalibutRuntimeBuilder()
                        .WithServiceFactory(services)
                        .WithServerCertificate(CertAndThumbprint.TentaclePolling.Certificate2)
-                       .WithTrustProvider(clientTrustProvider)
                        .Build())
             {
                 octopusServer.Trust(CertAndThumbprint.TentaclePolling.Thumbprint);
@@ -37,7 +38,51 @@ namespace Halibut.Tests
             }
         }
         
-        
+        [Test]
+        public void TrustAnyCertificateIssuedByTrustedCertificateRootAuthority()
+        {
+            var store = new X509Store(StoreName.My);
+            store.Open(OpenFlags.ReadOnly);
+
+            var trustedCert = FindTrustedCert(store.Certificates);
+            var serverCert = trustedCert;
+            
+            var services = GetDelegateServiceFactory();
+            using (var octopusServer = new HalibutRuntimeBuilder()
+                       .WithServerCertificate(serverCert)
+                       .Build())
+            using (var tentaclePolling = new HalibutRuntimeBuilder()
+                       .WithServiceFactory(services)
+                       .WithClientCertificateValidatorFactory(new TrustRootCertificateAuthorityValidatorFactory())
+                       .WithServerCertificate(CertAndThumbprint.TentaclePolling.Certificate2)
+                       .Build())
+            {
+                octopusServer.Trust(CertAndThumbprint.TentaclePolling.Thumbprint);
+                
+                var port = octopusServer.Listen();
+                
+                tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri("https://localhost:" + port), null));
+
+                var echo = octopusServer.CreateClient<IEchoService>("poll://SQ-TENTAPOLL", CertAndThumbprint.TentaclePolling.Thumbprint);
+
+                var result = echo.SayHello("World");
+                result.Should().Be("World...");
+            }
+        }
+
+        X509Certificate2 FindTrustedCert(X509Certificate2Collection storeCertificates)
+        {
+            foreach (var storeCertificate in storeCertificates)
+            {
+                if (storeCertificate.Verify() && storeCertificate.HasPrivateKey)
+                {
+                    return storeCertificate;
+                }
+            }
+
+            return null;
+        }
+
         static DelegateServiceFactory GetDelegateServiceFactory()
         {
             var services = new DelegateServiceFactory();

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -20,6 +20,7 @@ namespace Halibut.Tests.Transport
         ServiceEndPoint endpoint;
         HalibutRuntime tentacle;
         ILog log;
+        ClientCertificateValidatorFactory clientCertificateValidatorFactory;
 
         [SetUp]
         public void SetUp()
@@ -27,6 +28,7 @@ namespace Halibut.Tests.Transport
             var services = new DelegateServiceFactory();
             services.Register<IEchoService>(() => new EchoService());
             tentacle = new HalibutRuntime(services, Certificates.TentacleListening);
+            clientCertificateValidatorFactory = new ClientCertificateValidatorFactory();
             var tentaclePort = tentacle.Listen();
             tentacle.Trust(Certificates.OctopusPublicThumbprint);
             endpoint = new ServiceEndPoint("https://localhost:" + tentaclePort, Certificates.TentacleListeningPublicThumbprint)
@@ -67,7 +69,7 @@ namespace Halibut.Tests.Transport
                 Params = new object[] { "Fred" }
             };
 
-            var secureClient = new SecureListeningClient((s, l)  => GetProtocol(s, l, syncOrAsync), endpoint, Certificates.Octopus, log, connectionManager);
+            var secureClient = new SecureListeningClient((s, l)  => GetProtocol(s, l, syncOrAsync), endpoint, Certificates.Octopus, log, connectionManager, clientCertificateValidatorFactory);
             ResponseMessage response = null!;
 
             using var requestCancellationTokens = new RequestCancellationTokens(CancellationToken.None, CancellationToken.None);

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
+using Halibut.Transport;
 using Halibut.Transport.Protocol;
 using Halibut.Util;
 
@@ -20,6 +21,7 @@ namespace Halibut
         Func<RetryPolicy> pollingReconnectRetryPolicy = RetryPolicy.Create;
         AsyncHalibutFeature asyncHalibutFeature = AsyncHalibutFeature.Disabled;
         Func<string, string, UnauthorizedClientConnectResponse> onUnauthorizedClientConnect;
+        IClientCertificateValidatorFactory clientCertificateValidatorFactory;
 
         public HalibutRuntimeBuilder WithServiceFactory(IServiceFactory serviceFactory)
         {
@@ -27,6 +29,12 @@ namespace Halibut
             return this;
         }
 
+        public HalibutRuntimeBuilder WithClientCertificateValidatorFactory(IClientCertificateValidatorFactory clientCertificateValidator)
+        {
+            this.clientCertificateValidatorFactory = clientCertificateValidator;
+            return this;
+        }
+        
         public HalibutRuntimeBuilder WithServerCertificate(X509Certificate2 serverCertificate)
         {
             this.serverCertificate = serverCertificate;
@@ -97,6 +105,7 @@ namespace Halibut
 #pragma warning restore CS0612
             var trustProvider = this.trustProvider ?? new DefaultTrustProvider();
             var typeRegistry = this.typeRegistry ?? new TypeRegistry();
+            var clientCertificateValidatorFactory = this.clientCertificateValidatorFactory ?? new ClientCertificateValidatorFactory();
 
             var messageContracts = serviceFactory.RegisteredServiceTypes.ToArray();
             typeRegistry.AddToMessageContract(messageContracts);
@@ -114,7 +123,8 @@ namespace Halibut
                 typeRegistry,
                 messageSerializer, 
                 pollingReconnectRetryPolicy,
-                asyncHalibutFeature);
+                asyncHalibutFeature,
+                clientCertificateValidatorFactory);
 
             if (onUnauthorizedClientConnect is not null)
             {

--- a/source/Halibut/Transport/ClientCertificateValidator.cs
+++ b/source/Halibut/Transport/ClientCertificateValidator.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Halibut.Transport
 {
-    class ClientCertificateValidator
+    class ClientCertificateValidator : IClientCertificateValidator
     {
         readonly ServiceEndPoint endPoint;
 
@@ -24,6 +24,41 @@ namespace Halibut.Transport
             }
 
             throw new UnexpectedCertificateException(providedCert, endPoint);
+        }
+    }
+
+    class TrustRootCertificateAuthorityValidator : IClientCertificateValidator
+    {
+        public bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
+        {
+           var result = new X509Certificate2(certificate).Verify();
+           return result;
+        }
+    }
+
+    public interface IClientCertificateValidator
+    {
+        bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors);
+    }
+    
+    public interface IClientCertificateValidatorFactory
+    {
+        IClientCertificateValidator Create(ServiceEndPoint serviceEndpoint);
+    }
+    
+    public class ClientCertificateValidatorFactory : IClientCertificateValidatorFactory
+    {
+        public IClientCertificateValidator Create(ServiceEndPoint serviceEndpoint)
+        {
+            return new ClientCertificateValidator(serviceEndpoint);
+        }
+    }
+    
+    public class TrustRootCertificateAuthorityValidatorFactory : IClientCertificateValidatorFactory
+    {
+        public IClientCertificateValidator Create(ServiceEndPoint serviceEndpoint)
+        {
+            return new TrustRootCertificateAuthorityValidator();
         }
     }
 }


### PR DESCRIPTION
# Background

Some environments require all traffic to be decrypted and inspected by a centralized proxy.  This is usually done by implementing [MITM](https://en.wikipedia.org/wiki/Man-in-the-middle_attack), where the proxy becomes a trusted Root Authority and the clients trust all certificates issued by it.  Halibut security is based on [certificate pinning](https://security.stackexchange.com/questions/29988/what-is-certificate-pinning), which breaks MITM.

This PoC proposes to support the first leg of MITM (halibut -> proxy) by adding an option to Halibut to allow it to trust any cert issued by a trusted root authority. 
