### PR TITLE
Connection pool async

### DIFF
--- a/source/Halibut.Tests.DotMemory/MemoryFixture.cs
+++ b/source/Halibut.Tests.DotMemory/MemoryFixture.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
 using Halibut.ServiceModel;
@@ -39,7 +38,7 @@ namespace Halibut.Tests.DotMemory
 
         [Test]
         [DotMemoryUnit(SavingStrategy = SavingStrategy.OnCheckFail, Directory = @"c:\temp\dotmemoryunit", WorkspaceNumberLimit = 5, DiskSpaceLimit = 104857600)]
-        public async Task TcpClientsAreDisposedCorrectly()
+        public void TcpClientsAreDisposedCorrectly()
         {
             if (!dotMemoryApi.IsEnabled)
                 Assert.Inconclusive("This test is meant to be run under dotMemory Unit. In your IDE, right click on the test icon and choose 'Run under dotMemory Unit'.");
@@ -57,12 +56,12 @@ namespace Halibut.Tests.DotMemory
                 for (var i = 0; i < NumberOfClients; i++)
                 {
                     expectedTcpClientCount++; // each time the server polls, it keeps a tcpclient (as we dont have support to say StopPolling)
-                    await RunPollingClient(server, Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint);
+                    RunPollingClient(server, Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint);
                 }
 
 #if SUPPORTS_WEB_SOCKET_CLIENT
                 for (var i = 0; i < NumberOfClients; i++)
-                    await RunWebSocketPollingClient(server, Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint, Certificates.OctopusPublicThumbprint);
+                    RunWebSocketPollingClient(server, Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint, Certificates.OctopusPublicThumbprint);
 #endif
 
                 //https://dotnettools-support.jetbrains.com/hc/en-us/community/posts/360000088690-How-reproduce-DotMemory-s-Force-GC-button-s-behaviour-on-code-with-c-?page=1#community_comment_360000072750
@@ -137,7 +136,7 @@ namespace Halibut.Tests.DotMemory
             }
         }
 
-        static async Task RunPollingClient(HalibutRuntime server, X509Certificate2 clientCertificate, string remoteThumbprint, bool expectSuccess = true)
+        static void RunPollingClient(HalibutRuntime server, X509Certificate2 clientCertificate, string remoteThumbprint, bool expectSuccess = true)
         {
             using (var runtime = new HalibutRuntimeBuilder()
                        .WithServerCertificate(clientCertificate)
@@ -164,7 +163,7 @@ namespace Halibut.Tests.DotMemory
             }
         }
 
-        static async Task RunWebSocketPollingClient(
+        static void RunWebSocketPollingClient(
             HalibutRuntime server,
             X509Certificate2 clientCertificate, 
             string remoteThumbprint,

--- a/source/Halibut.Tests.DotMemory/MemoryFixture.cs
+++ b/source/Halibut.Tests.DotMemory/MemoryFixture.cs
@@ -160,7 +160,7 @@ namespace Halibut.Tests.DotMemory
 
                 MakeRequest(calculator, "polling", expectSuccess);
 
-                await runtime.DisconnectAsync(clientEndpoint, CancellationToken.None);
+                runtime.Disconnect(clientEndpoint);
             }
         }
 
@@ -190,7 +190,7 @@ namespace Halibut.Tests.DotMemory
 
                 MakeRequest(calculator, "websocket polling", expectSuccess);
 
-                await runtime.DisconnectAsync(clientEndpoint, CancellationToken.None);
+                runtime.Disconnect(clientEndpoint);
             }
         }
 

--- a/source/Halibut.Tests/Support/TestConnection.cs
+++ b/source/Halibut.Tests/Support/TestConnection.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Halibut.Transport;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Tests.Support
+{
+    public class TestConnection : IConnection
+    {
+        bool hasExpired;
+
+        public void NotifyUsed()
+        {
+            UsageCount++;
+        }
+
+        public bool HasExpired()
+        {
+            return hasExpired;
+        }
+
+        public int UsageCount { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+
+        public MessageExchangeProtocol Protocol => null;
+
+        public void Expire()
+        {
+            hasExpired = true;
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/TestConnection.cs
+++ b/source/Halibut.Tests/Support/TestConnection.cs
@@ -8,6 +8,17 @@ namespace Halibut.Tests.Support
     {
         bool hasExpired;
 
+        public int UsageCount { get; private set; }
+
+        public bool Disposed { get; private set; }
+
+        public MessageExchangeProtocol Protocol => null;
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+
         public void NotifyUsed()
         {
             UsageCount++;
@@ -17,18 +28,7 @@ namespace Halibut.Tests.Support
         {
             return hasExpired;
         }
-
-        public int UsageCount { get; private set; }
-
-        public bool Disposed { get; private set; }
-
-        public void Dispose()
-        {
-            Disposed = true;
-        }
-
-        public MessageExchangeProtocol Protocol => null;
-
+        
         public void Expire()
         {
             hasExpired = true;

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -22,6 +22,7 @@ namespace Halibut.Tests.Transport
                     throw new ArgumentOutOfRangeException(nameof(syncOrAsync), syncOrAsync, null);
             }
         }
+
         public static async Task<IConnection> AcquireConnection_SyncOrAsync(this IConnectionManager connectionManager, SyncOrAsync syncOrAsync, ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
         {
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -37,6 +38,24 @@ namespace Halibut.Tests.Transport
             await syncOrAsync
                 .WhenSync(() => connectionManager.ReleaseConnection(serviceEndpoint, connection))
                 .WhenAsync(async () => await connectionManager.ReleaseConnectionAsync(serviceEndpoint, connection, cancellationToken));
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+
+        public static async Task Disconnect_SyncOrAsync(this IConnectionManager connectionManager, SyncOrAsync syncOrAsync, ServiceEndPoint serviceEndPoint, ILog? log, CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            await syncOrAsync
+                .WhenSync(() => connectionManager.Disconnect(serviceEndPoint, log))
+                .WhenAsync(async () => await connectionManager.DisconnectAsync(serviceEndPoint, log, cancellationToken));
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+
+        public static async Task ClearPooledConnections_SyncOrAsync(this IConnectionManager connectionManager, SyncOrAsync syncOrAsync, ServiceEndPoint serviceEndPoint, ILog? log, CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            await syncOrAsync
+                .WhenSync(() => connectionManager.ClearPooledConnections(serviceEndPoint, log))
+                .WhenAsync(async () => await connectionManager.ClearPooledConnectionsAsync(serviceEndPoint, log, cancellationToken));
 #pragma warning restore CS0612 // Type or member is obsolete
         }
     }

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -10,7 +10,19 @@ namespace Halibut.Tests.Transport
 {
     public static class ConnectionManagerExtensionMethods
     {
-        public static async Task<IConnection> AcquireConnection_SyncOrAsync(this ConnectionManager connectionManager, SyncOrAsync syncOrAsync, ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
+        public static IConnectionManager CreateConnectionManager(this SyncOrAsync syncOrAsync)
+        {
+            switch (syncOrAsync)
+            {
+                case SyncOrAsync.Sync:
+                    return new ConnectionManager();
+                case SyncOrAsync.Async:
+                    return new ConnectionManagerAsync();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(syncOrAsync), syncOrAsync, null);
+            }
+        }
+        public static async Task<IConnection> AcquireConnection_SyncOrAsync(this IConnectionManager connectionManager, SyncOrAsync syncOrAsync, ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
         {
 #pragma warning disable CS0612 // Type or member is obsolete
             return await syncOrAsync
@@ -19,7 +31,7 @@ namespace Halibut.Tests.Transport
 #pragma warning restore CS0612 // Type or member is obsolete
         }
 
-        public static async Task ReleaseConnection_SyncOrAsync(this ConnectionManager connectionManager, SyncOrAsync syncOrAsync, ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken)
+        public static async Task ReleaseConnection_SyncOrAsync(this IConnectionManager connectionManager, SyncOrAsync syncOrAsync, ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken)
         {
 #pragma warning disable CS0612 // Type or member is obsolete
             await syncOrAsync

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -18,5 +18,14 @@ namespace Halibut.Tests.Transport
                 .WhenAsync(async () => await connectionManager.AcquireConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken));
 #pragma warning restore CS0612 // Type or member is obsolete
         }
+
+        public static async Task ReleaseConnection_SyncOrAsync(this ConnectionManager connectionManager, SyncOrAsync syncOrAsync, ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken)
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            await syncOrAsync
+                .WhenSync(() => connectionManager.ReleaseConnection(serviceEndpoint, connection))
+                .WhenAsync(async () => await connectionManager.ReleaseConnectionAsync(serviceEndpoint, connection, cancellationToken));
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
     }
 }

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.Transport
                 case SyncOrAsync.Sync:
                     return new ConnectionManager();
                 case SyncOrAsync.Async:
-                    return new ConnectionManagerAsync(new HalibutTimeoutsAndLimits());
+                    return new ConnectionManagerAsync();
                 default:
                     throw new ArgumentOutOfRangeException(nameof(syncOrAsync), syncOrAsync, null);
             }

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.Transport
                 case SyncOrAsync.Sync:
                     return new ConnectionManager();
                 case SyncOrAsync.Async:
-                    return new ConnectionManagerAsync();
+                    return new ConnectionManagerAsync(new HalibutTimeoutsAndLimits());
                 default:
                     throw new ArgumentOutOfRangeException(nameof(syncOrAsync), syncOrAsync, null);
             }
@@ -28,7 +28,7 @@ namespace Halibut.Tests.Transport
 #pragma warning disable CS0612 // Type or member is obsolete
             return await syncOrAsync
                 .WhenSync(() => connectionManager.AcquireConnection(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken))
-                .WhenAsync(async () => await connectionManager.AcquireConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, new HalibutTimeoutsAndLimits(), log, cancellationToken));
+                .WhenAsync(async () => await connectionManager.AcquireConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken));
 #pragma warning restore CS0612 // Type or member is obsolete
         }
 

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace Halibut.Tests.Transport
 {
     [TestFixture]
-    public class ConnectionManagerFixture
+    public class ConnectionManagerFixture : BaseTest
     {
         public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder) SetUp(SyncOrAsync syncOrAsync)
         {
@@ -37,8 +37,8 @@ namespace Halibut.Tests.Transport
             var connectionManager = new ConnectionManager();
 
             //do it twice because this bug only triggers on multiple enumeration, having 1 in the collection doesn't trigger the bug
-            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
-            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
             connectionManager.Disconnect(serviceEndpoint, null);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
@@ -53,10 +53,10 @@ namespace Halibut.Tests.Transport
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
-            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+            await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, activeConnection, CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
         }
 
@@ -69,7 +69,7 @@ namespace Halibut.Tests.Transport
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             activeConnection.Dispose();
@@ -85,7 +85,7 @@ namespace Halibut.Tests.Transport
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
             var connectionManager = new ConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -31,7 +31,7 @@ namespace Halibut.Tests.Transport
             await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
-            connectionManager.Disconnect(serviceEndpoint, null);
+            await connectionManager.Disconnect_SyncOrAsync(syncOrAsync, serviceEndpoint, null, CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
         }
 
@@ -80,7 +80,7 @@ namespace Halibut.Tests.Transport
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
-            connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            await connectionManager.Disconnect_SyncOrAsync(syncOrAsync, serviceEndpoint, null, CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
 
             var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
@@ -99,9 +99,9 @@ namespace Halibut.Tests.Transport
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
-            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+            await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, activeConnection, CancellationToken);
 
-            connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            await connectionManager.Disconnect_SyncOrAsync(syncOrAsync, serviceEndpoint, null, CancellationToken);
 
             var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
             createdTestConnection.Disposed.Should().BeTrue();
@@ -136,7 +136,7 @@ namespace Halibut.Tests.Transport
             using (var connectionManager = syncOrAsync.CreateConnectionManager())
             {
                 var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
-                connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+                await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, activeConnection, CancellationToken);
             }
 
             var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
@@ -154,7 +154,7 @@ namespace Halibut.Tests.Transport
             using var connectionManager = syncOrAsync.CreateConnectionManager();
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
-            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+            await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, activeConnection, CancellationToken);
 
             var testConnection = createdTestConnections.Should().ContainSingle().Subject;
             testConnection.Expire();
@@ -186,7 +186,7 @@ namespace Halibut.Tests.Transport
 
             foreach (var connection in connections)
             {
-                connectionManager.ReleaseConnection(serviceEndpoint, connection);
+                await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, connection, CancellationToken);
             }
 
             createdTestConnections.Where(c => c.Disposed).Should().HaveCount(5);
@@ -206,9 +206,9 @@ namespace Halibut.Tests.Transport
             var inMemoryConnectionLog = new InMemoryConnectionLog(serviceEndpoint.ToString());
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
 
-            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
-            
-            connectionManager.ClearPooledConnections(serviceEndpoint, inMemoryConnectionLog);
+            await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, activeConnection, CancellationToken);
+
+            await connectionManager.ClearPooledConnections_SyncOrAsync(syncOrAsync, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
 
             var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
             createdTestConnection.Disposed.Should().BeTrue();
@@ -227,9 +227,9 @@ namespace Halibut.Tests.Transport
             var inMemoryConnectionLog = new InMemoryConnectionLog(serviceEndpoint.ToString());
             await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
             var returnedConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
-            connectionManager.ReleaseConnection(serviceEndpoint, returnedConnection);
+            await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, returnedConnection, CancellationToken);
             
-            connectionManager.Disconnect(serviceEndpoint, inMemoryConnectionLog);
+            await connectionManager.Disconnect_SyncOrAsync(syncOrAsync, serviceEndpoint, null, CancellationToken);
 
             createdTestConnections.Should().HaveCount(2);
             createdTestConnections.Should().AllSatisfy(c => c.Disposed.Should().BeTrue());

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -16,15 +18,54 @@ namespace Halibut.Tests.Transport
     [TestFixture]
     public class ConnectionManagerFixture : BaseTest
     {
-        public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder) SetUp(SyncOrAsync syncOrAsync)
+        public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder) SetUp(SyncOrAsync syncOrAsync
+            //TODO: Value in real connection?
+            , bool testConnection = false)
         {
+            //TODO: Verify this is actually used/needed
             MessageExchangeProtocol ExchangeProtocolBuilder(Stream s, ILog l) => GetProtocol(s, l, syncOrAsync);
 
-            var connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, ExchangeProtocolBuilder, Substitute.For<ILog>());
-            var connectionFactory = Substitute.For<IConnectionFactory>();
-            connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(connection);
+            // TODO: Use EstablishNewConnectionAsync. But did the tests just work without it??
+            if (testConnection)
+            {
+                var connectionFactory = Substitute.For<IConnectionFactory>();
+                connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
+                    .Returns(_ => new TestConnection());
 
-            return (connectionFactory, ExchangeProtocolBuilder);
+                return (connectionFactory, ExchangeProtocolBuilder);
+            }
+            else
+            {
+                var connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, ExchangeProtocolBuilder, Substitute.For<ILog>());
+                var connectionFactory = Substitute.For<IConnectionFactory>();
+                connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(connection);
+
+                return (connectionFactory, ExchangeProtocolBuilder);
+            }
+            
+        }
+
+        public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder, List<TestConnection> connectionsCreated) SetUpWithTestConnection(SyncOrAsync syncOrAsync)
+        {
+            //TODO: Verify this is actually used/needed
+            MessageExchangeProtocol ExchangeProtocolBuilder(Stream s, ILog l) => GetProtocol(s, l, syncOrAsync);
+
+            var connectionFactory = Substitute.For<IConnectionFactory>();
+            var connectionsCreated = new List<TestConnection>();
+            connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    connectionsCreated.Add(new TestConnection());
+                    return connectionsCreated.Last();
+                });
+            connectionFactory.EstablishNewConnectionAsync(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    connectionsCreated.Add(new TestConnection());
+                    return connectionsCreated.Last();
+                });
+
+            return (connectionFactory, ExchangeProtocolBuilder, connectionsCreated);
         }
 
         [Test]
@@ -34,7 +75,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            using var connectionManager = new ConnectionManager();
 
             //do it twice because this bug only triggers on multiple enumeration, having 1 in the collection doesn't trigger the bug
             await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
@@ -51,7 +92,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            using var connectionManager = new ConnectionManager();
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
@@ -67,7 +108,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            using var connectionManager = new ConnectionManager();
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
@@ -83,13 +124,155 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            using var connectionManager = new ConnectionManager();
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
+        }
+
+
+        [Test]
+        [SyncAndAsync]
+        public async Task DisconnectDisposesReleasedConnections(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using var connectionManager = new ConnectionManager();
+
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+
+            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+
+            connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
+            //TODO VERIFY
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task DisposingConnectionManagerDisposesActiveConnections(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using (var connectionManager = new ConnectionManager())
+            {
+
+                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+                connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
+            }
+
+            //TODO Verify
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task DisposingConnectionManagerDisposesConnectionsInConnectionPool(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using (var connectionManager = new ConnectionManager())
+            {
+
+                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+                connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+            }
+
+            //TODO Verify
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task AcquireConnectionCreatesNewConnectionIfConnectionInPoolHasExpired(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
+
+            
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using var connectionManager = new ConnectionManager();
+
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+
+            var testConnection = connectionsCreated.Should().ContainSingle().Subject;
+            testConnection.Expire();
+
+            var newActiveConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+
+            connectionsCreated.Should().HaveCount(2);
+            newActiveConnection.Should().NotBe(activeConnection);
+
+            testConnection.Disposed.Should().BeTrue();
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task ReleaseConnectionCreatesNewConnectionIfConnectionInPoolHasExpired(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
+            
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using var connectionManager = new ConnectionManager();
+
+            var connections = new List<IConnection>();
+            for (int i = 0; i < 10; i++)
+            {
+                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+                connections.Add(activeConnection);
+
+                connectionsCreated[i].Expire();
+            }
+
+            foreach (var connection in connections)
+            {
+                connectionManager.ReleaseConnection(serviceEndpoint, connection);
+            }
+            
+            //TODO: Verify
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task ClearPooledConnectionsDisposesAllConnectionsInPool(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
+
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using var connectionManager = new ConnectionManager();
+
+            var inMemoryConnectionLog = new InMemoryConnectionLog(serviceEndpoint.ToString());
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
+
+            connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
+
+
+            connectionManager.ClearPooledConnections(serviceEndpoint, inMemoryConnectionLog);
+
+            //TODO: Verify
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task DisconnectClearsPoolAndActiveConnection(SyncOrAsync syncOrAsync)
+        {
+            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
+
+            var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
+            using var connectionManager = new ConnectionManager();
+
+            var inMemoryConnectionLog = new InMemoryConnectionLog(serviceEndpoint.ToString());
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
+            var returnedConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
+            connectionManager.ReleaseConnection(serviceEndpoint, returnedConnection);
+
+
+            connectionManager.Disconnect(serviceEndpoint, inMemoryConnectionLog);
+
+            //TODO: Verify
         }
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog log, SyncOrAsync syncOrAsync)

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -265,7 +265,6 @@ namespace Halibut.Tests.Transport
 
         static MessageExchangeProtocol GetProtocol(Stream stream, ILog log)
         {
-            //return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), log), log);
             throw new NotImplementedException("Not important for this test");
         }
     }

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -18,68 +18,18 @@ namespace Halibut.Tests.Transport
     [TestFixture]
     public class ConnectionManagerFixture : BaseTest
     {
-        public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder) SetUp(SyncOrAsync syncOrAsync
-            //TODO: Value in real connection?
-            , bool testConnection = false)
-        {
-            //TODO: Verify this is actually used/needed
-            MessageExchangeProtocol ExchangeProtocolBuilder(Stream s, ILog l) => GetProtocol(s, l, syncOrAsync);
-
-            // TODO: Use EstablishNewConnectionAsync. But did the tests just work without it??
-            if (testConnection)
-            {
-                var connectionFactory = Substitute.For<IConnectionFactory>();
-                connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
-                    .Returns(_ => new TestConnection());
-
-                return (connectionFactory, ExchangeProtocolBuilder);
-            }
-            else
-            {
-                var connection = new SecureConnection(Substitute.For<IDisposable>(), Stream.Null, ExchangeProtocolBuilder, Substitute.For<ILog>());
-                var connectionFactory = Substitute.For<IConnectionFactory>();
-                connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>()).Returns(connection);
-
-                return (connectionFactory, ExchangeProtocolBuilder);
-            }
-            
-        }
-
-        public (IConnectionFactory ConnectionFactory, ExchangeProtocolBuilder ExchngeProtocolBuilder, List<TestConnection> connectionsCreated) SetUpWithTestConnection(SyncOrAsync syncOrAsync)
-        {
-            //TODO: Verify this is actually used/needed
-            MessageExchangeProtocol ExchangeProtocolBuilder(Stream s, ILog l) => GetProtocol(s, l, syncOrAsync);
-
-            var connectionFactory = Substitute.For<IConnectionFactory>();
-            var connectionsCreated = new List<TestConnection>();
-            connectionFactory.EstablishNewConnection(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
-                .Returns(_ =>
-                {
-                    connectionsCreated.Add(new TestConnection());
-                    return connectionsCreated.Last();
-                });
-            connectionFactory.EstablishNewConnectionAsync(ExchangeProtocolBuilder, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
-                .Returns(_ =>
-                {
-                    connectionsCreated.Add(new TestConnection());
-                    return connectionsCreated.Last();
-                });
-
-            return (connectionFactory, ExchangeProtocolBuilder, connectionsCreated);
-        }
-
         [Test]
         [SyncAndAsync]
         public async Task DisposedConnectionsAreRemovedFromActive_WhenMultipleConnectionsAreActive(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
             //do it twice because this bug only triggers on multiple enumeration, having 1 in the collection doesn't trigger the bug
-            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
-            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
             connectionManager.Disconnect(serviceEndpoint, null);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
@@ -89,12 +39,12 @@ namespace Halibut.Tests.Transport
         [SyncAndAsync]
         public async Task ReleasedConnectionsAreNotActive(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             await connectionManager.ReleaseConnection_SyncOrAsync(syncOrAsync, serviceEndpoint, activeConnection, CancellationToken);
@@ -105,12 +55,12 @@ namespace Halibut.Tests.Transport
         [SyncAndAsync]
         public async Task DisposedConnectionsAreRemovedFromActive(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             activeConnection.Dispose();
@@ -121,89 +71,97 @@ namespace Halibut.Tests.Transport
         [SyncAndAsync]
         public async Task DisconnectDisposesActiveConnections(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
             connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
+
+            var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
+            createdTestConnection.Disposed.Should().BeTrue();
         }
-
-
+        
         [Test]
         [SyncAndAsync]
         public async Task DisconnectDisposesReleasedConnections(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
             connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
 
             connectionManager.Disconnect(serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()));
-            //TODO VERIFY
+
+            var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
+            createdTestConnection.Disposed.Should().BeTrue();
         }
 
         [Test]
         [SyncAndAsync]
         public async Task DisposingConnectionManagerDisposesActiveConnections(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using (var connectionManager = new ConnectionManager())
+            using (var connectionManager = syncOrAsync.CreateConnectionManager())
             {
-
-                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
                 connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
             }
 
-            //TODO Verify
+            var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
+            createdTestConnection.Disposed.Should().BeTrue();
         }
 
         [Test]
         [SyncAndAsync]
         public async Task DisposingConnectionManagerDisposesConnectionsInConnectionPool(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using (var connectionManager = new ConnectionManager())
+            using (var connectionManager = syncOrAsync.CreateConnectionManager())
             {
-
-                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
                 connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
             }
 
-            //TODO Verify
+            var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
+            createdTestConnection.Disposed.Should().BeTrue();
         }
 
         [Test]
         [SyncAndAsync]
-        public async Task AcquireConnectionCreatesNewConnectionIfConnectionInPoolHasExpired(SyncOrAsync syncOrAsync)
+        public async Task AcquireConnection_WhenConnectionInPoolHasExpired_CreatesNewConnectionAndDisposesExpiredConnection(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
-
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
             
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
 
-            var testConnection = connectionsCreated.Should().ContainSingle().Subject;
+            var testConnection = createdTestConnections.Should().ContainSingle().Subject;
             testConnection.Expire();
 
-            var newActiveConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+            var newActiveConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
-            connectionsCreated.Should().HaveCount(2);
+            createdTestConnections.Should().HaveCount(2);
             newActiveConnection.Should().NotBe(activeConnection);
 
             testConnection.Disposed.Should().BeTrue();
@@ -211,73 +169,104 @@ namespace Halibut.Tests.Transport
 
         [Test]
         [SyncAndAsync]
-        public async Task ReleaseConnectionCreatesNewConnectionIfConnectionInPoolHasExpired(SyncOrAsync syncOrAsync)
+        public async Task ReleaseConnection_WillKeep5ConnectionsInPool_AndDisposeOldConnections(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
-            
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
+
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
             var connections = new List<IConnection>();
             for (int i = 0; i < 10; i++)
             {
-                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
+                var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
                 connections.Add(activeConnection);
-
-                connectionsCreated[i].Expire();
             }
 
             foreach (var connection in connections)
             {
                 connectionManager.ReleaseConnection(serviceEndpoint, connection);
             }
-            
-            //TODO: Verify
+
+            createdTestConnections.Where(c => c.Disposed).Should().HaveCount(5);
+            createdTestConnections.Where(c => !c.Disposed).Should().HaveCount(5);
         }
 
         [Test]
         [SyncAndAsync]
         public async Task ClearPooledConnectionsDisposesAllConnectionsInPool(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
             var inMemoryConnectionLog = new InMemoryConnectionLog(serviceEndpoint.ToString());
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
+            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
 
             connectionManager.ReleaseConnection(serviceEndpoint, activeConnection);
-
-
+            
             connectionManager.ClearPooledConnections(serviceEndpoint, inMemoryConnectionLog);
 
-            //TODO: Verify
+            var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
+            createdTestConnection.Disposed.Should().BeTrue();
         }
 
         [Test]
         [SyncAndAsync]
         public async Task DisconnectClearsPoolAndActiveConnection(SyncOrAsync syncOrAsync)
         {
-            var (connectionFactory, exchangeProtocolBuilder, connectionsCreated) = SetUpWithTestConnection(syncOrAsync);
+            var createdTestConnections = new List<TestConnection>();
+            var connectionFactory = CreateFactoryThatCreatesTestConnections(syncOrAsync, createdTestConnections.Add);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
 
             var inMemoryConnectionLog = new InMemoryConnectionLog(serviceEndpoint.ToString());
-            var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
-            var returnedConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
+            await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
+            var returnedConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
             connectionManager.ReleaseConnection(serviceEndpoint, returnedConnection);
-
-
+            
             connectionManager.Disconnect(serviceEndpoint, inMemoryConnectionLog);
 
-            //TODO: Verify
+            createdTestConnections.Should().HaveCount(2);
+            createdTestConnections.Should().AllSatisfy(c => c.Disposed.Should().BeTrue());
         }
 
-        public MessageExchangeProtocol GetProtocol(Stream stream, ILog log, SyncOrAsync syncOrAsync)
+        static IConnectionFactory CreateFactoryThatCreatesTestConnections(SyncOrAsync syncOrAsync, Action<TestConnection>? connectionCreated = null)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), syncOrAsync.ToAsyncHalibutFeature(), log), log);
+            var connectionFactory = Substitute.For<IConnectionFactory>();
+            syncOrAsync
+                .WhenSync(() =>
+                    {
+                        connectionFactory.EstablishNewConnection(GetProtocol, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
+                            .Returns(_ =>
+                            {
+                                var testConnection = new TestConnection();
+                                connectionCreated?.Invoke(testConnection);
+                                return testConnection;
+                            });
+                    }
+                ).WhenAsync(() =>
+                {
+                    connectionFactory.EstablishNewConnectionAsync(GetProtocol, Arg.Any<ServiceEndPoint>(), Arg.Any<ILog>(), Arg.Any<CancellationToken>())
+                        .Returns(_ =>
+                        {
+                            var testConnection = new TestConnection();
+                            connectionCreated?.Invoke(testConnection);
+                            return testConnection;
+                        });
+                });
+
+            return connectionFactory;
+        }
+
+        static MessageExchangeProtocol GetProtocol(Stream stream, ILog log)
+        {
+            //return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), log), log);
+            throw new NotImplementedException("Not important for this test");
         }
     }
 }

--- a/source/Halibut.Tests/Transport/ConnectionPoolExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionPoolExtensionMethods.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Transport;
+
+namespace Halibut.Tests.Transport
+{
+    public static class ConnectionPoolExtensionMethods
+    {
+        public static IConnectionPool<TKey, TPooledResource> CreateConnectionPool<TKey, TPooledResource>(this SyncOrAsync syncOrAsync)
+            where TPooledResource : class, IPooledResource
+        {
+            switch (syncOrAsync)
+            {
+                case SyncOrAsync.Sync:
+                    return new ConnectionPool<TKey, TPooledResource>();
+                case SyncOrAsync.Async:
+                    return new ConnectionPoolAsync<TKey, TPooledResource>();
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(syncOrAsync), syncOrAsync, null);
+            }
+        }
+        public static async Task Return_SyncOrAsync<TKey, TPooledResource>(
+            this IConnectionPool<TKey, TPooledResource> connectionPool, 
+            SyncOrAsync syncOrAsync,
+            TKey endPoint, 
+            TPooledResource resource, 
+            CancellationToken cancellationToken)
+            where TPooledResource : class, IPooledResource
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            await syncOrAsync
+                .WhenSync(() => connectionPool.Return(endPoint, resource))
+                .WhenAsync(async () => await connectionPool.ReturnAsync(endPoint, resource, cancellationToken));
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+
+        public static async Task<TPooledResource> Take_SyncOrAsync<TKey, TPooledResource>(
+            this IConnectionPool<TKey, TPooledResource> connectionPool,
+            SyncOrAsync syncOrAsync,
+            TKey endPoint,
+            CancellationToken cancellationToken)
+            where TPooledResource : class, IPooledResource
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            return await syncOrAsync
+                .WhenSync(() => connectionPool.Take(endPoint))
+                .WhenAsync(async () => await connectionPool.TakeAsync(endPoint, cancellationToken));
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/ConnectionPoolFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionPoolFixture.cs
@@ -67,13 +67,18 @@ namespace Halibut.Tests.Transport
             var pool = syncOrAsync.CreateConnectionPool<string, TestConnection>();
             var connection = new TestConnection();
 
-            pool.GetTotalConnectionCount().Should().Be(0);
+            var takeResult = await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken);
+            takeResult.Should().BeNull();
 
             await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
-            pool.GetTotalConnectionCount().Should().Be(1);
-
             await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
-            pool.GetTotalConnectionCount().Should().Be(1);
+
+            // Assert by taking twice. The second one should be null again
+            takeResult = await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken);
+            takeResult.Should().Be(connection);
+
+            takeResult = await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken);
+            takeResult.Should().BeNull();
         }
     }
 }

--- a/source/Halibut.Tests/Transport/ConnectionPoolFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionPoolFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Transport;
-using Halibut.Transport.Protocol;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Transport
@@ -9,164 +9,71 @@ namespace Halibut.Tests.Transport
     public class ConnectionPoolFixture : BaseTest
     {
         [Test]
-        public void ShouldGetConnectionFromPool()
+        [SyncAndAsync]
+        public async Task ShouldGetConnectionFromPool(SyncOrAsync syncOrAsync)
         {
-            var pool = new ConnectionPool<string, TestConnection>();
-            pool.Return("http://foo", new TestConnection());
-            pool.Return("http://foo", new TestConnection());
-            pool.Return("http://foo", new TestConnection());
-            pool.Take("http://foo").Should().NotBeNull();
-            pool.Take("http://foo").Should().NotBeNull();
-            pool.Take("http://foo").Should().NotBeNull();
-            pool.Take("http://foo").Should().BeNull();
-            pool.Take("http://foo").Should().BeNull();
-            pool.Take("http://foo").Should().BeNull();
-            pool.Return("http://foo", new TestConnection());
-            pool.Take("http://foo").Should().NotBeNull();
-            pool.Take("http://foo").Should().BeNull();
+            var pool = syncOrAsync.CreateConnectionPool<string, TestConnection>();
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", new TestConnection(), CancellationToken);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", new TestConnection(), CancellationToken);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", new TestConnection(), CancellationToken);
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().NotBeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().NotBeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().NotBeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().BeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().BeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().BeNull();
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", new TestConnection(), CancellationToken);
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().NotBeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().BeNull();
         }
 
         [Test]
-        public async Task ShouldGetConnectionFromPoolAsync()
+        [SyncAndAsync]
+        public async Task ShouldGetConnectionFromPoolByKey(SyncOrAsync syncOrAsync)
         {
-            var pool = new ConnectionPool<string, TestConnection>();
-            await pool.ReturnAsync("http://foo", new TestConnection(), CancellationToken);
-            await pool.ReturnAsync("http://foo", new TestConnection(), CancellationToken);
-            await pool.ReturnAsync("http://foo", new TestConnection(), CancellationToken);
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().NotBeNull();
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().NotBeNull();
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().NotBeNull();
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().BeNull();
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().BeNull();
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().BeNull();
-            await pool.ReturnAsync("http://foo", new TestConnection(), CancellationToken);
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().NotBeNull();
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().BeNull();
+            var pool = syncOrAsync.CreateConnectionPool<string, TestConnection>();
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo1", new TestConnection(), CancellationToken);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo2", new TestConnection(), CancellationToken);
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo1", CancellationToken)).Should().NotBeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo1", CancellationToken)).Should().BeNull();
         }
-
+        
         [Test]
-        public void ShouldGetConnectionFromPoolByKey()
+        [SyncAndAsync]
+        public async Task ShouldLetConnectionsExpireAsync(SyncOrAsync syncOrAsync)
         {
-            var pool = new ConnectionPool<string, TestConnection>();
-            pool.Return("http://foo1", new TestConnection());
-            pool.Return("http://foo2", new TestConnection());
-            pool.Take("http://foo1").Should().NotBeNull();
-            pool.Take("http://foo1").Should().BeNull();
-        }
-
-        [Test]
-        public async Task ShouldGetConnectionFromPoolByKeyAsync()
-        {
-            var pool = new ConnectionPool<string, TestConnection>();
-            await pool.ReturnAsync("http://foo1", new TestConnection(), CancellationToken);
-            await pool.ReturnAsync("http://foo2", new TestConnection(), CancellationToken);
-            (await pool.TakeAsync("http://foo1", CancellationToken)).Should().NotBeNull();
-            (await pool.TakeAsync("http://foo1", CancellationToken)).Should().BeNull();
-        }
-
-        [Test]
-        public void ShouldLetConnectionsExpire()
-        {
-            var pool = new ConnectionPool<string, TestConnection>();
+            var pool = syncOrAsync.CreateConnectionPool<string, TestConnection>();
             var connection = new TestConnection();
 
-            pool.Return("http://foo", connection);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
             connection.UsageCount.Should().Be(1);
 
-            pool.Take("http://foo").Should().Be(connection);
-            pool.Return("http://foo", connection);
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().Be(connection);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
             connection.UsageCount.Should().Be(2);
 
-            pool.Take("http://foo").Should().Be(connection);
-            pool.Return("http://foo", connection);
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().Be(connection);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
             connection.UsageCount.Should().Be(3);
+            connection.Expire();
 
-            pool.Take("http://foo").Should().BeNull();
+            (await pool.Take_SyncOrAsync(syncOrAsync, "http://foo", CancellationToken)).Should().BeNull();
         }
-
+        
         [Test]
-        public async Task ShouldLetConnectionsExpireAsync()
+        [SyncAndAsync]
+        public async Task ShouldNotAllowMultipleReturnsOfSameConnectionAsync(SyncOrAsync syncOrAsync)
         {
-            var pool = new ConnectionPool<string, TestConnection>();
-            var connection = new TestConnection();
-
-            await pool.ReturnAsync("http://foo", connection, CancellationToken);
-            connection.UsageCount.Should().Be(1);
-
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().Be(connection);
-            await pool.ReturnAsync("http://foo", connection, CancellationToken);
-            connection.UsageCount.Should().Be(2);
-
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().Be(connection);
-            await pool.ReturnAsync("http://foo", connection, CancellationToken);
-            connection.UsageCount.Should().Be(3);
-
-            (await pool.TakeAsync("http://foo", CancellationToken)).Should().BeNull();
-        }
-
-        [Test]
-        public void ShouldNotAllowMultipleReturnsOfSameConnection()
-        {
-            var pool = new ConnectionPool<string, TestConnection>();
+            var pool = syncOrAsync.CreateConnectionPool<string, TestConnection>();
             var connection = new TestConnection();
 
             pool.GetTotalConnectionCount().Should().Be(0);
 
-            pool.Return("http://foo", connection);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
             pool.GetTotalConnectionCount().Should().Be(1);
 
-            pool.Return("http://foo", connection);
+            await pool.Return_SyncOrAsync(syncOrAsync, "http://foo", connection, CancellationToken);
             pool.GetTotalConnectionCount().Should().Be(1);
-        }
-
-        [Test]
-        public async Task ShouldNotAllowMultipleReturnsOfSameConnectionAsync()
-        {
-            var pool = new ConnectionPool<string, TestConnection>();
-            var connection = new TestConnection();
-
-            pool.GetTotalConnectionCount().Should().Be(0);
-
-            await pool.ReturnAsync("http://foo", connection, CancellationToken);
-            pool.GetTotalConnectionCount().Should().Be(1);
-
-            await pool.ReturnAsync("http://foo", connection, CancellationToken);
-            pool.GetTotalConnectionCount().Should().Be(1);
-        }
-    }
-
-    //TODO: Move to new home
-    public class TestConnection : IConnection
-    {
-        bool hasExpired;
-        public void NotifyUsed()
-        {
-            UsageCount++;
-            if (UsageCount >= 3)
-            {
-                hasExpired = true;
-            }
-        }
-
-        public bool HasExpired()
-        {
-            return hasExpired;
-        }
-
-        public int UsageCount { get; private set; }
-
-        public bool Disposed { get; private set; }
-
-        public void Dispose()
-        {
-            Disposed = true;
-        }
-
-        public MessageExchangeProtocol Protocol { get; }
-
-        public void Expire()
-        {
-            hasExpired = true;
         }
     }
 }

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -45,7 +45,7 @@ namespace Halibut.Tests.Transport
         [SyncAndAsync]
         public async Task SecureClientClearsPoolWhenAllConnectionsCorrupt(SyncOrAsync syncOrAsync)
         {
-            var connectionManager = new ConnectionManager();
+            using var connectionManager = new ConnectionManager();
             var stream = Substitute.For<IMessageExchangeStream>();
 
             syncOrAsync

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -45,7 +45,7 @@ namespace Halibut.Tests.Transport
         [SyncAndAsync]
         public async Task SecureClientClearsPoolWhenAllConnectionsCorrupt(SyncOrAsync syncOrAsync)
         {
-            using var connectionManager = new ConnectionManager();
+            using var connectionManager = syncOrAsync.CreateConnectionManager();
             var stream = Substitute.For<IMessageExchangeStream>();
 
             syncOrAsync

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -446,10 +446,17 @@ namespace Halibut
             friendlyHtmlPageHeaders = headers?.ToDictionary(x => x.Key, x => x.Value) ?? new Dictionary<string, string>();
         }
 
+        [Obsolete]
         public void Disconnect(ServiceEndPoint endpoint)
         {
             var log = logs.ForEndpoint(endpoint.BaseUri);
             connectionManager.Disconnect(endpoint, log);
+        }
+
+        public async Task DisconnectAsync(ServiceEndPoint endpoint, CancellationToken cancellationToken)
+        {
+            var log = logs.ForEndpoint(endpoint.BaseUri);
+            await connectionManager.DisconnectAsync(endpoint, log, cancellationToken);
         }
 
         public void Dispose()

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -101,7 +101,7 @@ namespace Halibut
 
             if (asyncHalibutFeature == AsyncHalibutFeature.Enabled)
             {
-                connectionManager = new ConnectionManagerAsync(halibutTimeoutsAndLimits);
+                connectionManager = new ConnectionManagerAsync();
             }
             else
             {

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -28,7 +28,7 @@ namespace Halibut
         readonly ConcurrentDictionary<Uri, ServiceEndPoint> routeTable = new();
         readonly IServiceInvoker invoker;
         readonly ILogFactory logs;
-        readonly ConnectionManager connectionManager = new();
+        readonly IConnectionManager connectionManager;
         readonly PollingClientCollection pollingClients = new();
         string friendlyHtmlPageContent = DefaultFriendlyHtmlPageContent;
         Dictionary<string, string> friendlyHtmlPageHeaders = new();
@@ -69,6 +69,8 @@ namespace Halibut
                 .WithTypeRegistry(typeRegistry)
                 .Build();
             invoker = new ServiceInvoker(serviceFactory);
+
+            connectionManager = new ConnectionManager();
         }
 
         internal HalibutRuntime(
@@ -91,6 +93,17 @@ namespace Halibut
             this.messageSerializer = messageSerializer;
             this.pollingReconnectRetryPolicy = pollingReconnectRetryPolicy;
             invoker = new ServiceInvoker(serviceFactory);
+
+            if (asyncHalibutFeature == AsyncHalibutFeature.Enabled)
+            {
+                connectionManager = new ConnectionManagerAsync();
+            }
+            else
+            {
+#pragma warning disable CS0612
+                connectionManager = new ConnectionManager();
+#pragma warning restore CS0612
+            }
         }
 
         public ILogFactory Logs => logs;

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -72,13 +72,8 @@ namespace Halibut
                 .WithTypeRegistry(typeRegistry)
                 .Build();
             invoker = new ServiceInvoker(serviceFactory);
-<<<<<<< HEAD
 
             connectionManager = new ConnectionManager();
-=======
-            this.connectionManager = new ConnectionManager(null);
-            
->>>>>>> origin/main
         }
 
         internal HalibutRuntime(
@@ -102,27 +97,22 @@ namespace Halibut
             this.messageSerializer = messageSerializer;
             this.pollingReconnectRetryPolicy = pollingReconnectRetryPolicy;
             invoker = new ServiceInvoker(serviceFactory);
-<<<<<<< HEAD
+            TimeoutsAndLimits = halibutTimeoutsAndLimits;
 
             if (asyncHalibutFeature == AsyncHalibutFeature.Enabled)
             {
-                connectionManager = new ConnectionManagerAsync();
+                connectionManager = new ConnectionManagerAsync(halibutTimeoutsAndLimits);
             }
             else
             {
+                if (halibutTimeoutsAndLimits != null)
+                {
+                    throw new Exception($"{nameof(halibutTimeoutsAndLimits)} must be null when in sync mode");
+                }
 #pragma warning disable CS0612
                 connectionManager = new ConnectionManager();
 #pragma warning restore CS0612
             }
-=======
-            if (asyncHalibutFeature == AsyncHalibutFeature.Disabled && halibutTimeoutsAndLimits != null)
-            {
-                throw new Exception($"{nameof(halibutTimeoutsAndLimits)} must be null when in sync mode");
-            }
-            
-            this.TimeoutsAndLimits = halibutTimeoutsAndLimits;
-            this.connectionManager = new ConnectionManager(halibutTimeoutsAndLimits);
->>>>>>> origin/main
         }
 
         public ILogFactory Logs => logs;

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Transport.Caching;
 using Halibut.Util;
@@ -71,6 +72,7 @@ namespace Halibut
         void Route(ServiceEndPoint to, ServiceEndPoint via);
         void SetFriendlyHtmlPageContent(string html);
         void Disconnect(ServiceEndPoint endpoint);
+        Task DisconnectAsync(ServiceEndPoint endpoint, CancellationToken cancellationToken);
         Func<string, string, UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
 
         OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -70,6 +70,7 @@ namespace Halibut.Transport
             }
         }
 
+        [Obsolete]
         public void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection)
         {
             lock (activeConnections)
@@ -87,6 +88,7 @@ namespace Halibut.Transport
             throw new NotImplementedException("Should not be called when async Halibut is not being used.");
         }
 
+        [Obsolete]
         public void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log)
         {
             lock (activeConnections)
@@ -114,6 +116,7 @@ namespace Halibut.Transport
             return NoConnections;
         }
 
+        [Obsolete]
         public void Disconnect(ServiceEndPoint serviceEndPoint, ILog log)
         {
             ClearPooledConnections(serviceEndPoint, log);

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -5,88 +5,44 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
-using Nito.AsyncEx;
 
 namespace Halibut.Transport
 {
-    public class ConnectionManager : IDisposable
+    [Obsolete]
+    public class ConnectionManager : IConnectionManager
     {
         readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new();
         readonly Dictionary<ServiceEndPoint, HashSet<IConnection>> activeConnections = new();
 
-        // We have separate locks for connections in general (including the pool) vs specifically activeConnections.
-        // This is because disposing calls OnConnectionDisposed, which causes deadlocks if we are not careful.
-        readonly SemaphoreSlim connectionsLock = new(1, 1);
-        readonly SemaphoreSlim activeConnectionsLock = new(1, 1);
-        
-
         public bool IsDisposed { get; private set; }
-
-        public void Dispose()
-        {
-            pool.Dispose();
-            IConnection[] connectionsToDispose;
-            using (activeConnectionsLock.Lock())
-            {
-                connectionsToDispose = activeConnections.SelectMany(kv => kv.Value).ToArray();
-            }
-
-            foreach (var connection in connectionsToDispose)
-            {
-                SafelyDisposeConnection(connection, null);
-            }
-
-            IsDisposed = true;
-        }
 
         [Obsolete]
         public IConnection AcquireConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
-            Tuple<IConnection, Action> openableConnection;
-            using (connectionsLock.Lock())
-            {
-                var existingConnectionFromPool = pool.Take(serviceEndpoint);
-                openableConnection = existingConnectionFromPool != null
-                    ? Tuple.Create<IConnection, Action>(existingConnectionFromPool, () => { }) // existing connections from the pool are already open
-                    : CreateNewConnection(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
-
-                using (activeConnectionsLock.Lock())
-                {
-                    AddConnectionToActiveConnections(serviceEndpoint, openableConnection.Item1);
-                }
-            }
-
+            var openableConnection = GetConnection(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
             openableConnection.Item2(); // Since this involves IO, this should never be done inside a lock
             return openableConnection.Item1;
         }
 
-        public async Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        public Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
-            //TODO: Can we keep this lock around the whole thing?
-            using (await connectionsLock.LockAsync(cancellationToken))
+            throw new NotImplementedException("Should not be called when async Halibut is not being used.");
+        }
+
+        // Connection is Lazy instantiated, so it is safe to use. If you need to wait for it to open (eg for error handling, an openConnection method is provided)
+        // For existing open connections, the openConnection method does nothing
+        [Obsolete]
+        Tuple<IConnection, Action> GetConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            lock (activeConnections)
             {
-                var existingConnectionFromPool = await pool.TakeAsync(serviceEndpoint, cancellationToken);
-                if (existingConnectionFromPool != null)
-                {
-                    using (await activeConnectionsLock.LockAsync(cancellationToken))
-                    {
-                        AddConnectionToActiveConnections(serviceEndpoint, existingConnectionFromPool);
-                    }
-
-                    return existingConnectionFromPool;
-                }
+                var existingConnectionFromPool = pool.Take(serviceEndpoint);
+                var openableConnection = existingConnectionFromPool != null
+                    ? Tuple.Create<IConnection, Action>(existingConnectionFromPool, () => { }) // existing connections from the pool are already open
+                    : CreateNewConnection(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
+                AddConnectionToActiveConnections(serviceEndpoint, openableConnection.Item1);
+                return openableConnection;
             }
-
-            var connection = await CreateNewConnectionWithIOAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
-            using (await connectionsLock.LockAsync(cancellationToken))
-            {
-                using (await activeConnectionsLock.LockAsync(cancellationToken))
-                {
-                    AddConnectionToActiveConnections(serviceEndpoint, connection);
-                }
-            }
-
-            return connection;
         }
         
         [Obsolete]
@@ -101,12 +57,6 @@ namespace Halibut.Transport
             });
         }
         
-        async Task<IConnection> CreateNewConnectionWithIOAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
-        {
-            var connection = await connectionFactory.EstablishNewConnectionAsync(exchangeProtocolBuilder, serviceEndpoint, log, cancellationToken);
-            return new DisposableNotifierConnection(new Lazy<IConnection>(() => connection), OnConnectionDisposed);
-        }
-
         void AddConnectionToActiveConnections(ServiceEndPoint serviceEndpoint, IConnection connection)
         {
             if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
@@ -115,69 +65,49 @@ namespace Halibut.Transport
             }
             else
             {
-                connections = new HashSet<IConnection> {connection};
+                connections = new HashSet<IConnection> { connection };
                 activeConnections.Add(serviceEndpoint, connections);
             }
         }
 
-        [Obsolete]
         public void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection)
         {
-            using (connectionsLock.Lock())
+            lock (activeConnections)
             {
                 pool.Return(serviceEndpoint, connection);
-                using (activeConnectionsLock.Lock())
+                if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
                 {
-                    if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
-                    {
-                        connections.Remove(connection);
-                    }
+                    connections.Remove(connection);
                 }
             }
         }
 
-        public async Task ReleaseConnectionAsync(ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken)
+        public Task ReleaseConnectionAsync(ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken)
         {
-            using (await connectionsLock.LockAsync(cancellationToken))
-            {
-                await pool.ReturnAsync(serviceEndpoint, connection, cancellationToken);
-                using (await activeConnectionsLock.LockAsync(cancellationToken))
-                {
-                    if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
-                    {
-                        connections.Remove(connection);
-                    }
-                }
-            }
+            throw new NotImplementedException("Should not be called when async Halibut is not being used.");
         }
 
         public void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log)
         {
-            using (connectionsLock.Lock())
+            lock (activeConnections)
             {
                 pool.Clear(serviceEndPoint, log);
             }
         }
 
-        public async Task ClearPooledConnectionsAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
+        public Task ClearPooledConnectionsAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
         {
-            using (await connectionsLock.LockAsync(cancellationToken))
-            {
-                await pool.ClearAsync(serviceEndPoint, log, cancellationToken);
-            }
+            throw new NotImplementedException("Should not be called when async Halibut is not being used.");
         }
 
         static IConnection[] NoConnections = new IConnection[0];
         public IReadOnlyCollection<IConnection> GetActiveConnections(ServiceEndPoint serviceEndPoint)
         {
-            using (connectionsLock.Lock())
+            lock (activeConnections)
             {
-                using (activeConnectionsLock.Lock())
+                if (activeConnections.TryGetValue(serviceEndPoint, out var value))
                 {
-                    if (activeConnections.TryGetValue(serviceEndPoint, out var value))
-                    {
-                        return value.ToArray();
-                    }
+                    return value.ToArray();
                 }
             }
 
@@ -186,49 +116,48 @@ namespace Halibut.Transport
 
         public void Disconnect(ServiceEndPoint serviceEndPoint, ILog log)
         {
-            using (connectionsLock.Lock())
-            {
-                pool.Clear(serviceEndPoint, log);
-                var toDelete = new List<IConnection>();
-                using (activeConnectionsLock.Lock())
-                {
-                    if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
-                    {
-                        toDelete = activeConnectionsForEndpoint.ToList();
-                    }
-                }
-
-                foreach (var connection in toDelete)
-                {
-                    SafelyDisposeConnection(connection, log);
-                }
-            }
+            ClearPooledConnections(serviceEndPoint, log);
+            ClearActiveConnections(serviceEndPoint, log);
         }
 
-        public async Task DisconnectAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
+        public Task DisconnectAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
         {
-            using (await connectionsLock.LockAsync(cancellationToken))
-            {
-                await pool.ClearAsync(serviceEndPoint, log, cancellationToken);
-                var toDelete = new List<IConnection>();
-                using (await activeConnectionsLock.LockAsync(cancellationToken))
-                {
-                    if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
-                    {
-                        toDelete = activeConnectionsForEndpoint.ToList();
-                    }
-                }
+            throw new NotImplementedException("Should not be called when async Halibut is not being used.");
+        }
 
-                foreach (var connection in toDelete)
+        public void Dispose()
+        {
+            pool.Dispose();
+            lock (activeConnections)
+            {
+                var connectionsToDispose = activeConnections.SelectMany(kv => kv.Value).ToArray();
+                foreach (var connection in connectionsToDispose)
                 {
-                    SafelyDisposeConnection(connection, log);
+                    SafelyDisposeConnection(connection, null);
+                }
+            }
+
+            IsDisposed = true;
+        }
+
+
+        void ClearActiveConnections(ServiceEndPoint serviceEndPoint, ILog log)
+        {
+            lock (activeConnections)
+            {
+                if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
+                {
+                    foreach (var connection in activeConnectionsForEndpoint.ToArray())
+                    {
+                        SafelyDisposeConnection(connection, log);
+                    }
                 }
             }
         }
-        
+
         void OnConnectionDisposed(IConnection connection)
         {
-            using (activeConnectionsLock.Lock())
+            lock (activeConnections)
             {
                 var setsContainingConnection = activeConnections.Where(c => c.Value.Contains(connection)).ToList();
                 var setsToRemoveCompletely = setsContainingConnection.Where(c => c.Value.Count == 1).ToList();

--- a/source/Halibut/Transport/ConnectionManager.cs
+++ b/source/Halibut/Transport/ConnectionManager.cs
@@ -13,7 +13,6 @@ namespace Halibut.Transport
     {
         readonly ConnectionPool<ServiceEndPoint, IConnection> pool = new();
         readonly Dictionary<ServiceEndPoint, HashSet<IConnection>> activeConnections = new();
-        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
 
         public bool IsDisposed { get; private set; }
 
@@ -25,7 +24,7 @@ namespace Halibut.Transport
             return openableConnection.Item1;
         }
 
-        public Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log, CancellationToken cancellationToken)
+        public Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
         {
             throw new NotImplementedException("Should not be called when async Halibut is not being used.");
         }
@@ -102,12 +101,6 @@ namespace Halibut.Transport
         }
 
         static IConnection[] NoConnections = new IConnection[0];
-
-        public ConnectionManager(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
-        {
-            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
-        }
-
         public IReadOnlyCollection<IConnection> GetActiveConnections(ServiceEndPoint serviceEndPoint)
         {
             lock (activeConnections)

--- a/source/Halibut/Transport/ConnectionManagerAsync.cs
+++ b/source/Halibut/Transport/ConnectionManagerAsync.cs
@@ -13,6 +13,7 @@ namespace Halibut.Transport
     {
         readonly ConnectionPoolAsync<ServiceEndPoint, IConnection> pool = new();
         readonly Dictionary<ServiceEndPoint, HashSet<IConnection>> activeConnections = new();
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
 
         // We have separate locks for connections in general (including the pool) vs specifically activeConnections.
         // This is because disposing calls OnConnectionDisposed, which causes deadlocks if we are not careful.
@@ -21,6 +22,11 @@ namespace Halibut.Transport
         
 
         public bool IsDisposed { get; private set; }
+
+        public ConnectionManagerAsync(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        {
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+        }
 
         public void Dispose()
         {

--- a/source/Halibut/Transport/ConnectionManagerAsync.cs
+++ b/source/Halibut/Transport/ConnectionManagerAsync.cs
@@ -25,15 +25,18 @@ namespace Halibut.Transport
         public void Dispose()
         {
             pool.Dispose();
-            IConnection[] connectionsToDispose;
-            using (activeConnectionsLock.Lock())
+            using (connectionsLock.Lock())
             {
-                connectionsToDispose = activeConnections.SelectMany(kv => kv.Value).ToArray();
-            }
+                IConnection[] connectionsToDispose;
+                using (activeConnectionsLock.Lock())
+                {
+                    connectionsToDispose = activeConnections.SelectMany(kv => kv.Value).ToArray();
+                }
 
-            foreach (var connection in connectionsToDispose)
-            {
-                SafelyDisposeConnection(connection, null);
+                foreach (var connection in connectionsToDispose)
+                {
+                    SafelyDisposeConnection(connection, null);
+                }
             }
 
             IsDisposed = true;

--- a/source/Halibut/Transport/ConnectionManagerAsync.cs
+++ b/source/Halibut/Transport/ConnectionManagerAsync.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
+using Nito.AsyncEx;
+
+namespace Halibut.Transport
+{
+    public class ConnectionManagerAsync : IConnectionManager
+    {
+        readonly ConnectionPoolAsync<ServiceEndPoint, IConnection> pool = new();
+        readonly Dictionary<ServiceEndPoint, HashSet<IConnection>> activeConnections = new();
+
+        // We have separate locks for connections in general (including the pool) vs specifically activeConnections.
+        // This is because disposing calls OnConnectionDisposed, which causes deadlocks if we are not careful.
+        readonly SemaphoreSlim connectionsLock = new(1, 1);
+        readonly SemaphoreSlim activeConnectionsLock = new(1, 1);
+        
+
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            pool.Dispose();
+            IConnection[] connectionsToDispose;
+            using (activeConnectionsLock.Lock())
+            {
+                connectionsToDispose = activeConnections.SelectMany(kv => kv.Value).ToArray();
+            }
+
+            foreach (var connection in connectionsToDispose)
+            {
+                SafelyDisposeConnection(connection, null);
+            }
+
+            IsDisposed = true;
+        }
+
+        [Obsolete]
+        public IConnection AcquireConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            Tuple<IConnection, Action> openableConnection;
+            using (connectionsLock.Lock())
+            {
+                var existingConnectionFromPool = pool.Take(serviceEndpoint);
+                openableConnection = existingConnectionFromPool != null
+                    ? Tuple.Create<IConnection, Action>(existingConnectionFromPool, () => { }) // existing connections from the pool are already open
+                    : CreateNewConnection(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
+
+                using (activeConnectionsLock.Lock())
+                {
+                    AddConnectionToActiveConnections(serviceEndpoint, openableConnection.Item1);
+                }
+            }
+
+            openableConnection.Item2(); // Since this involves IO, this should never be done inside a lock
+            return openableConnection.Item1;
+        }
+
+        public async Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            using (await connectionsLock.LockAsync(cancellationToken))
+            {
+                var existingConnectionFromPool = await pool.TakeAsync(serviceEndpoint, cancellationToken);
+                if (existingConnectionFromPool != null)
+                {
+                    using (await activeConnectionsLock.LockAsync(cancellationToken))
+                    {
+                        AddConnectionToActiveConnections(serviceEndpoint, existingConnectionFromPool);
+                    }
+
+                    return existingConnectionFromPool;
+                }
+            }
+
+            var connection = await CreateNewConnectionWithIoAsync(exchangeProtocolBuilder, connectionFactory, serviceEndpoint, log, cancellationToken);
+
+            //Do as a separate lock so that we do not lock on IO from creating a new connection.
+            using (await connectionsLock.LockAsync(cancellationToken))
+            {
+                using (await activeConnectionsLock.LockAsync(cancellationToken))
+                {
+                    AddConnectionToActiveConnections(serviceEndpoint, connection);
+                }
+            }
+
+            return connection;
+        }
+        
+        [Obsolete]
+        Tuple<IConnection, Action> CreateNewConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            var lazyConnection = new Lazy<IConnection>(() => connectionFactory.EstablishNewConnection(exchangeProtocolBuilder, serviceEndpoint, log, cancellationToken));
+            var connection = new DisposableNotifierConnection(lazyConnection, OnConnectionDisposed);
+            return Tuple.Create<IConnection, Action>(connection, () =>
+            {
+                // ReSharper disable once UnusedVariable
+                var c = lazyConnection.Value;
+            });
+        }
+        
+        async Task<IConnection> CreateNewConnectionWithIoAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
+        {
+            var connection = await connectionFactory.EstablishNewConnectionAsync(exchangeProtocolBuilder, serviceEndpoint, log, cancellationToken);
+            return new DisposableNotifierConnection(new Lazy<IConnection>(() => connection), OnConnectionDisposed);
+        }
+
+        void AddConnectionToActiveConnections(ServiceEndPoint serviceEndpoint, IConnection connection)
+        {
+            if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
+            {
+                connections.Add(connection);
+            }
+            else
+            {
+                connections = new HashSet<IConnection> {connection};
+                activeConnections.Add(serviceEndpoint, connections);
+            }
+        }
+
+        [Obsolete]
+        public void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection)
+        {
+            using (connectionsLock.Lock())
+            {
+                pool.Return(serviceEndpoint, connection);
+                using (activeConnectionsLock.Lock())
+                {
+                    if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
+                    {
+                        connections.Remove(connection);
+                    }
+                }
+            }
+        }
+
+        public async Task ReleaseConnectionAsync(ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken)
+        {
+            using (await connectionsLock.LockAsync(cancellationToken))
+            {
+                await pool.ReturnAsync(serviceEndpoint, connection, cancellationToken);
+                using (await activeConnectionsLock.LockAsync(cancellationToken))
+                {
+                    if (activeConnections.TryGetValue(serviceEndpoint, out var connections))
+                    {
+                        connections.Remove(connection);
+                    }
+                }
+            }
+        }
+
+        public void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log)
+        {
+            using (connectionsLock.Lock())
+            {
+                pool.Clear(serviceEndPoint, log);
+            }
+        }
+
+        public async Task ClearPooledConnectionsAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
+        {
+            using (await connectionsLock.LockAsync(cancellationToken))
+            {
+                await pool.ClearAsync(serviceEndPoint, log, cancellationToken);
+            }
+        }
+        
+        public IReadOnlyCollection<IConnection> GetActiveConnections(ServiceEndPoint serviceEndPoint)
+        {
+            using (connectionsLock.Lock())
+            {
+                using (activeConnectionsLock.Lock())
+                {
+                    if (activeConnections.TryGetValue(serviceEndPoint, out var value))
+                    {
+                        return value.ToArray();
+                    }
+                }
+            }
+
+            return Array.Empty<IConnection>();
+        }
+
+        public void Disconnect(ServiceEndPoint serviceEndPoint, ILog log)
+        {
+            using (connectionsLock.Lock())
+            {
+                pool.Clear(serviceEndPoint, log);
+                var toDelete = new List<IConnection>();
+                using (activeConnectionsLock.Lock())
+                {
+                    if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
+                    {
+                        toDelete = activeConnectionsForEndpoint.ToList();
+                    }
+                }
+
+                foreach (var connection in toDelete)
+                {
+                    SafelyDisposeConnection(connection, log);
+                }
+            }
+        }
+
+        public async Task DisconnectAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken)
+        {
+            using (await connectionsLock.LockAsync(cancellationToken))
+            {
+                await pool.ClearAsync(serviceEndPoint, log, cancellationToken);
+                var toDelete = new List<IConnection>();
+                using (await activeConnectionsLock.LockAsync(cancellationToken))
+                {
+                    if (activeConnections.TryGetValue(serviceEndPoint, out var activeConnectionsForEndpoint))
+                    {
+                        toDelete = activeConnectionsForEndpoint.ToList();
+                    }
+                }
+
+                foreach (var connection in toDelete)
+                {
+                    SafelyDisposeConnection(connection, log);
+                }
+            }
+        }
+        
+        void OnConnectionDisposed(IConnection connection)
+        {
+            // If we are not careful, we can introduce a deadlock. Time this out just in case we ever accidentally introduce one.
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+            using (activeConnectionsLock.Lock(cts.Token))
+            {
+                var setsContainingConnection = activeConnections.Where(c => c.Value.Contains(connection)).ToList();
+                var setsToRemoveCompletely = setsContainingConnection.Where(c => c.Value.Count == 1).ToList();
+                foreach (var setContainingConnection in setsContainingConnection.Except(setsToRemoveCompletely))
+                {
+                    setContainingConnection.Value.Remove(connection);
+                }
+
+                foreach (var setToRemoveCompletely in setsToRemoveCompletely)
+                {
+                    activeConnections.Remove(setToRemoveCompletely.Key);
+                }
+            }
+        }
+
+        static void SafelyDisposeConnection(IConnection connection, ILog log)
+        {
+            try
+            {
+                connection?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                log?.WriteException(EventType.Error, "Exception disposing connection", ex);
+            }
+        }
+
+        class DisposableNotifierConnection : IConnection
+        {
+            readonly Lazy<IConnection> connection;
+            readonly Action<IConnection> onDisposed;
+
+            public DisposableNotifierConnection(Lazy<IConnection> connection, Action<IConnection> onDisposed)
+            {
+                this.connection = connection;
+                this.onDisposed = onDisposed;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    connection.Value.Dispose();
+                }
+                finally
+                {
+                    onDisposed(this);
+                }
+            }
+
+            public void NotifyUsed()
+            {
+                connection.Value.NotifyUsed();
+            }
+
+            public bool HasExpired()
+            {
+                return connection.Value.HasExpired();
+            }
+
+            public MessageExchangeProtocol Protocol => connection.Value.Protocol;
+        }
+    }
+}

--- a/source/Halibut/Transport/ConnectionPool.cs
+++ b/source/Halibut/Transport/ConnectionPool.cs
@@ -12,14 +12,7 @@ namespace Halibut.Transport
     {
         readonly Dictionary<TKey, HashSet<TPooledResource>> pool = new Dictionary<TKey, HashSet<TPooledResource>>();
 
-        public int GetTotalConnectionCount()
-        {
-            lock (pool)
-            {
-                return pool.Values.Sum(v => v.Count);
-            }
-        }
-
+        [Obsolete]
         public TPooledResource Take(TKey endPoint)
         {
             lock (pool)
@@ -43,6 +36,7 @@ namespace Halibut.Transport
             throw new NotImplementedException("Should not be called when async Halibut is not being used.");
         }
 
+        [Obsolete]
         public void Return(TKey endPoint, TPooledResource resource)
         {
             lock (pool)
@@ -64,6 +58,7 @@ namespace Halibut.Transport
             throw new NotImplementedException("Should not be called when async Halibut is not being used.");
         }
 
+        [Obsolete]
         public void Clear(TKey key, ILog log = null)
         {
             lock (pool)

--- a/source/Halibut/Transport/ConnectionPoolAsync.cs
+++ b/source/Halibut/Transport/ConnectionPoolAsync.cs
@@ -14,14 +14,7 @@ namespace Halibut.Transport
         readonly Dictionary<TKey, HashSet<TPooledResource>> pool = new();
         readonly SemaphoreSlim poolLock = new(1, 1);
 
-        public int GetTotalConnectionCount()
-        {
-            using (poolLock.Lock())
-            {
-                return pool.Values.Sum(v => v.Count);
-            }
-        }
-
+        [Obsolete]
         public TPooledResource Take(TKey endPoint)
         {
             using (poolLock.Lock())
@@ -58,6 +51,7 @@ namespace Halibut.Transport
             }
         }
 
+        [Obsolete]
         public void Return(TKey endPoint, TPooledResource resource)
         {
             using (poolLock.Lock())
@@ -90,6 +84,7 @@ namespace Halibut.Transport
             }
         }
 
+        [Obsolete]
         public void Clear(TKey key, ILog log = null)
         {
             using (poolLock.Lock())

--- a/source/Halibut/Transport/ConnectionPoolAsync.cs
+++ b/source/Halibut/Transport/ConnectionPoolAsync.cs
@@ -1,0 +1,188 @@
+using Halibut.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Nito.AsyncEx;
+
+namespace Halibut.Transport
+{
+    public class ConnectionPoolAsync<TKey, TPooledResource> : IConnectionPool<TKey, TPooledResource> 
+        where TPooledResource : class, IPooledResource
+    {
+        readonly Dictionary<TKey, HashSet<TPooledResource>> pool = new();
+        readonly SemaphoreSlim poolLock = new(1, 1);
+
+        public int GetTotalConnectionCount()
+        {
+            using (poolLock.Lock())
+            {
+                return pool.Values.Sum(v => v.Count);
+            }
+        }
+
+        public TPooledResource Take(TKey endPoint)
+        {
+            using (poolLock.Lock())
+            {
+                var connections = GetOrAdd(endPoint);
+
+                while (true)
+                {
+                    var connection = Take(connections);
+
+                    if (connection == null || !connection.HasExpired())
+                        return connection;
+
+                    DestroyConnection(connection, null);
+                }
+            }
+        }
+
+        public async Task<TPooledResource> TakeAsync(TKey endPoint, CancellationToken cancellationToken)
+        {
+            using (await poolLock.LockAsync(cancellationToken))
+            {
+                var connections = GetOrAdd(endPoint);
+
+                while (true)
+                {
+                    var connection = Take(connections);
+
+                    if (connection == null || !connection.HasExpired())
+                        return connection;
+
+                    await DestroyConnectionAsync(connection, null, cancellationToken);
+                }
+            }
+        }
+
+        public void Return(TKey endPoint, TPooledResource resource)
+        {
+            using (poolLock.Lock())
+            {
+                var connections = GetOrAdd(endPoint);
+                connections.Add(resource);
+                resource.NotifyUsed();
+
+                while (connections.Count > 5)
+                {
+                    var connection = Take(connections);
+                    DestroyConnection(connection, null);
+                }
+            }
+        }
+
+        public async Task ReturnAsync(TKey endPoint, TPooledResource resource, CancellationToken cancellationToken)
+        {
+            using (await poolLock.LockAsync(cancellationToken))
+            {
+                var connections = GetOrAdd(endPoint);
+                connections.Add(resource);
+                resource.NotifyUsed();
+
+                while (connections.Count > 5)
+                {
+                    var connection = Take(connections);
+                    await DestroyConnectionAsync(connection, null, cancellationToken);
+                }
+            }
+        }
+
+        public void Clear(TKey key, ILog log = null)
+        {
+            using (poolLock.Lock())
+            {
+                if (!pool.TryGetValue(key, out var connections))
+                    return;
+
+                foreach (var connection in connections)
+                {
+                    DestroyConnection(connection, log);
+                }
+
+                connections.Clear();
+                pool.Remove(key);
+            }
+        }
+
+        public async Task ClearAsync(TKey key, ILog log, CancellationToken cancellationToken)
+        {
+            using (await poolLock.LockAsync(cancellationToken))
+            {
+                if (!pool.TryGetValue(key, out var connections))
+                    return;
+
+                foreach (var connection in connections)
+                {
+                    await DestroyConnectionAsync(connection, log, cancellationToken);
+                }
+
+                connections.Clear();
+                pool.Remove(key);
+            }
+        }
+        
+        public void Dispose()
+        {
+            using (poolLock.Lock())
+            {
+                foreach (var connection in pool.SelectMany(kv => kv.Value))
+                {
+                    DestroyConnection(connection, null);
+                }
+
+                pool.Clear();
+            }
+        }
+
+        TPooledResource Take(HashSet<TPooledResource> connections)
+        {
+            if (connections.Count == 0)
+                return null;
+
+            var connection = connections.First();
+            connections.Remove(connection);
+            return connection;
+        }
+
+        HashSet<TPooledResource> GetOrAdd(TKey endPoint)
+        {
+            if (!pool.TryGetValue(endPoint, out var connections))
+            {
+                connections = new HashSet<TPooledResource>();
+                pool.Add(endPoint, connections);
+            }
+
+            return connections;
+        }
+
+        void DestroyConnection(TPooledResource connection, ILog log)
+        {
+            try
+            {
+                connection?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                log?.WriteException(EventType.Error, "Exception disposing connection from pool", ex);
+            }
+        }
+
+        async Task DestroyConnectionAsync(TPooledResource connection, ILog log, CancellationToken cancellationToken)
+        {
+            // TODO - ASYNC ME UP! This will come when the async disposal story is done
+            await Task.CompletedTask;
+
+            try
+            {
+                connection?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                log?.WriteException(EventType.Error, "Exception disposing connection from pool", ex);
+            }
+        }
+    }
+}

--- a/source/Halibut/Transport/IConnectionManager.cs
+++ b/source/Halibut/Transport/IConnectionManager.cs
@@ -10,13 +10,17 @@ namespace Halibut.Transport
     public interface IConnectionManager : IDisposable
     {
         bool IsDisposed { get; }
+        [Obsolete]
         IConnection AcquireConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
         Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
+        [Obsolete]
         void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection);
         Task ReleaseConnectionAsync(ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken);
+        [Obsolete]
         void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log);
         Task ClearPooledConnectionsAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken);
         IReadOnlyCollection<IConnection> GetActiveConnections(ServiceEndPoint serviceEndPoint);
+        [Obsolete]
         void Disconnect(ServiceEndPoint serviceEndPoint, ILog log);
         Task DisconnectAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken);
     }

--- a/source/Halibut/Transport/IConnectionManager.cs
+++ b/source/Halibut/Transport/IConnectionManager.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Diagnostics;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Transport
+{
+    public interface IConnectionManager : IDisposable
+    {
+        bool IsDisposed { get; }
+        IConnection AcquireConnection(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
+        Task<IConnection> AcquireConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, IConnectionFactory connectionFactory, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken);
+        void ReleaseConnection(ServiceEndPoint serviceEndpoint, IConnection connection);
+        Task ReleaseConnectionAsync(ServiceEndPoint serviceEndpoint, IConnection connection, CancellationToken cancellationToken);
+        void ClearPooledConnections(ServiceEndPoint serviceEndPoint, ILog log);
+        Task ClearPooledConnectionsAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken);
+        IReadOnlyCollection<IConnection> GetActiveConnections(ServiceEndPoint serviceEndPoint);
+        void Disconnect(ServiceEndPoint serviceEndPoint, ILog log);
+        Task DisconnectAsync(ServiceEndPoint serviceEndPoint, ILog log, CancellationToken cancellationToken);
+    }
+}

--- a/source/Halibut/Transport/IConnectionPool.cs
+++ b/source/Halibut/Transport/IConnectionPool.cs
@@ -14,6 +14,5 @@ namespace Halibut.Transport
         Task ReturnAsync(TKey endPoint, TPooledResource resource, CancellationToken cancellationToken);
         void Clear(TKey key, ILog log = null);
         Task ClearAsync(TKey key, ILog log, CancellationToken cancellationToken);
-        void Dispose();
     }
 }

--- a/source/Halibut/Transport/IConnectionPool.cs
+++ b/source/Halibut/Transport/IConnectionPool.cs
@@ -7,11 +7,13 @@ namespace Halibut.Transport
 {
     public interface IConnectionPool<TKey, TPooledResource> where TPooledResource : class, IPooledResource
     {
-        int GetTotalConnectionCount();
+        [Obsolete]
         TPooledResource Take(TKey endPoint);
         Task<TPooledResource> TakeAsync(TKey endPoint, CancellationToken cancellationToken);
+        [Obsolete]
         void Return(TKey endPoint, TPooledResource resource);
         Task ReturnAsync(TKey endPoint, TPooledResource resource, CancellationToken cancellationToken);
+        [Obsolete]
         void Clear(TKey key, ILog log = null);
         Task ClearAsync(TKey key, ILog log, CancellationToken cancellationToken);
     }

--- a/source/Halibut/Transport/IConnectionPool.cs
+++ b/source/Halibut/Transport/IConnectionPool.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Diagnostics;
+
+namespace Halibut.Transport
+{
+    public interface IConnectionPool<TKey, TPooledResource> where TPooledResource : class, IPooledResource
+    {
+        int GetTotalConnectionCount();
+        TPooledResource Take(TKey endPoint);
+        Task<TPooledResource> TakeAsync(TKey endPoint, CancellationToken cancellationToken);
+        void Return(TKey endPoint, TPooledResource resource);
+        Task ReturnAsync(TKey endPoint, TPooledResource resource, CancellationToken cancellationToken);
+        void Clear(TKey key, ILog log = null);
+        Task ClearAsync(TKey key, ILog log, CancellationToken cancellationToken);
+        void Dispose();
+    }
+}

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -18,11 +18,11 @@ namespace Halibut.Transport
     {
         [Obsolete("Replaced by HalibutLimits.RetryCountLimit")] public const int RetryCountLimit = 5;
         readonly ILog log;
-        readonly ConnectionManager connectionManager;
+        readonly IConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
         readonly ExchangeProtocolBuilder protocolBuilder;
 
-        public SecureClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, IConnectionManager connectionManager)
         {
             this.protocolBuilder = protocolBuilder;
             this.ServiceEndpoint = serviceEndpoint;

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -162,7 +162,6 @@ namespace Halibut.Transport
                             protocolBuilder, 
                             new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
                             ServiceEndpoint,
-                            halibutTimeoutsAndLimits,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
 

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -180,7 +180,7 @@ namespace Halibut.Transport
                     }
 
                     // Only return the connection to the pool if all went well
-                    await connectionManager.ReleaseConnectionAsync(ServiceEndpoint, connection, cancellationToken);
+                    await connectionManager.ReleaseConnectionAsync(ServiceEndpoint, connection, requestCancellationTokens.InProgressRequestCancellationToken);
                 }
                 catch (AuthenticationException ex)
                 {
@@ -214,7 +214,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, cancellationToken);
+                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, requestCancellationTokens.InProgressRequestCancellationToken);
                     }
                 }
                 catch (IOException ex) when (ex.IsSocketConnectionReset())

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -176,7 +176,7 @@ namespace Halibut.Transport
                     }
 
                     // Only return the connection to the pool if all went well
-                    connectionManager.ReleaseConnection(ServiceEndpoint, connection);
+                    await connectionManager.ReleaseConnectionAsync(ServiceEndpoint, connection, cancellationToken);
                 }
                 catch (AuthenticationException ex)
                 {
@@ -210,7 +210,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        connectionManager.ClearPooledConnections(ServiceEndpoint, log);
+                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, cancellationToken);
                     }
                 }
                 catch (IOException ex) when (ex.IsSocketConnectionReset())

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -190,7 +190,7 @@ namespace Halibut.Transport
                     }
 
                     // Only return the connection to the pool if all went well
-                    await connectionManager.ReleaseConnectionAsync(ServiceEndpoint, connection, cancellationToken);
+                    await connectionManager.ReleaseConnectionAsync(ServiceEndpoint, connection, requestCancellationTokens.InProgressRequestCancellationToken);
                 }
                 catch (AuthenticationException ex)
                 {
@@ -229,7 +229,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, cancellationToken);
+                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, requestCancellationTokens.InProgressRequestCancellationToken);
                     }
                 }
                 catch (IOException ex) when (ex.IsSocketConnectionReset())

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -186,7 +186,7 @@ namespace Halibut.Transport
                     }
 
                     // Only return the connection to the pool if all went well
-                    connectionManager.ReleaseConnection(ServiceEndpoint, connection);
+                    await connectionManager.ReleaseConnectionAsync(ServiceEndpoint, connection, cancellationToken);
                 }
                 catch (AuthenticationException ex)
                 {
@@ -225,7 +225,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        connectionManager.ClearPooledConnections(ServiceEndpoint, log);
+                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, cancellationToken);
                     }
                 }
                 catch (IOException ex) when (ex.IsSocketConnectionReset())

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -171,8 +171,7 @@ namespace Halibut.Transport
                         connection = await connectionManager.AcquireConnectionAsync(
                             exchangeProtocolBuilder, 
                             new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
-                            ServiceEndpoint, 
-                            halibutTimeoutsAndLimits,
+                            ServiceEndpoint,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
 

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -17,11 +17,11 @@ namespace Halibut.Transport
     class SecureListeningClient : ISecureClient
     {
         readonly ILog log;
-        readonly ConnectionManager connectionManager;
+        readonly IConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
         readonly ExchangeProtocolBuilder exchangeProtocolBuilder;
 
-        public SecureListeningClient(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureListeningClient(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, IConnectionManager connectionManager)
         {
             this.exchangeProtocolBuilder = exchangeProtocolBuilder;
             this.ServiceEndpoint = serviceEndpoint;

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -160,8 +160,7 @@ namespace Halibut.Transport
                         connection = await connectionManager.AcquireConnectionAsync(
                             protocolBuilder, 
                             new WebSocketConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
-                            serviceEndpoint, 
-                            halibutTimeoutsAndLimits,
+                            serviceEndpoint,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
 

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -176,7 +176,7 @@ namespace Halibut.Transport
                     }
 
                     // Only return the connection to the pool if all went well
-                    await connectionManager.ReleaseConnectionAsync(serviceEndpoint, connection, cancellationToken);
+                    await connectionManager.ReleaseConnectionAsync(serviceEndpoint, connection, requestCancellationTokens.InProgressRequestCancellationToken);
                 }
                 catch (AuthenticationException aex)
                 {
@@ -213,7 +213,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        await connectionManager.ClearPooledConnectionsAsync(serviceEndpoint, log, cancellationToken);
+                        await connectionManager.ClearPooledConnectionsAsync(serviceEndpoint, log, requestCancellationTokens.InProgressRequestCancellationToken);
                     }
 
                 }

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -26,10 +26,10 @@ namespace Halibut.Transport
         readonly ServiceEndPoint serviceEndpoint;
         readonly X509Certificate2 clientCertificate;
         readonly ILog log;
-        readonly ConnectionManager connectionManager;
+        readonly IConnectionManager connectionManager;
         readonly ExchangeProtocolBuilder protocolBuilder;
 
-        public SecureWebSocketClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureWebSocketClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, IConnectionManager connectionManager)
         {
             this.protocolBuilder = protocolBuilder;
             this.serviceEndpoint = serviceEndpoint;

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -172,7 +172,7 @@ namespace Halibut.Transport
                     }
 
                     // Only return the connection to the pool if all went well
-                    connectionManager.ReleaseConnection(serviceEndpoint, connection);
+                    await connectionManager.ReleaseConnectionAsync(serviceEndpoint, connection, cancellationToken);
                 }
                 catch (AuthenticationException aex)
                 {
@@ -209,7 +209,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        connectionManager.ClearPooledConnections(serviceEndpoint, log);
+                        await connectionManager.ClearPooledConnectionsAsync(serviceEndpoint, log, cancellationToken);
                     }
 
                 }


### PR DESCRIPTION
[sc-53211]

# Background
While converting Halibut over to async, we found that the connection manager and connection pool disposes connections while taking new ones. These are async operations, and as such, should be made async.


# Results
Related to https://github.com/OctopusDeploy/Issues/issues/8266

## Before
Connections were being disposed of synchronously. This is IO that would block any thread while disposable occurred.

## After
All methods that result in disposal of a connection within the `ConnectionPool` now has an async equivalent.

In the `ConnectionManager`, moving from a `lock` to a `SemaphoreSlim` introduced a deadlock. This all revolved around the lock in `OnConnectionDisposed`. This was focused around access to the `activeConnections`, so we rearranged the locks to ensure access to `activeConnections` would not result in a deadlock, and introduced a new lock for general access to the connections in general.

### ConnectionManagerFixture
The `ConnectionManagerFixture` tests had a very convoluted setup, with a mixture of mock and real objects. The real objects did not actually do anything related to the test. This included the `MessageExchangeProtocol` created by `GetProtocol`.  To show how unimportant these 'real' connections were, there was a bug where the async version of `EstablishNewConnection` was never configured, and all async tests were working fine with an NSubstitute version. We also needed to interrogate the connection, so this whole area was simplified.

To help identify the deadlocks mentioned above, extra test cases were added to `ConnectionManagerFixture` that caused the deadlock when using `SemaphoreSlim` as a pure replacement.

## Later
Some more work has to be done in regards to async disposal. But that will be done in the async disposal story.


# How to review this PR

`RequestCancellationTokens.InProgressRequestCancellationToken` was introduced while this was being worked on. I believe this is the correct cancellation token to use (as it is used in the same methods). But please verify that my choice was correct 😁 

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
