### PR TITLE
Remove unnecessary initialization of ILog from calls to LogProvider.GetLogger("Halibut")

### DIFF
--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -13,6 +13,7 @@ using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
 using Halibut.Tests.TestServices.SyncClientWithOptions;
 using Halibut.TestUtils.Contracts;
+using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
 namespace Halibut.Tests
@@ -167,7 +168,7 @@ namespace Halibut.Tests
 
                 countingService.GetCurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
 
-                serviceLoggers[serviceLoggers.Keys.First()].GetLogs().Should()
+                serviceLoggers[serviceLoggers.Keys.First(x => x != nameof(MessageSerializer))].GetLogs().Should()
                     .Contain(log => log.FormattedMessage
                         .Contains("and attempted a message exchange, but it presented a client certificate with the thumbprint " +
                                   "'76225C0717A16C1D0BA4A7FFA76519D286D8A248' which is not in the list of thumbprints that we trust"));

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -17,6 +17,7 @@ namespace Halibut.Tests
 {
     public static class ParallelRequestsFixture
     {
+        [Parallelizable(ParallelScope.None)]
         public class AsyncParallelRequestFixture : BaseTest
         {
             [Test]
@@ -118,7 +119,7 @@ namespace Halibut.Tests
             }
         }
 
-        [Parallelizable(ParallelScope.Children)]
+        [Parallelizable(ParallelScope.None)]
         public class SyncParallelRequestsFixture : BaseTest
         {
             [Test]

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -94,7 +94,7 @@ namespace Halibut.Tests.Transport
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog log, SyncOrAsync syncOrAsync)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), syncOrAsync.ToAsyncHalibutFeature(), log), log);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), syncOrAsync.ToAsyncHalibutFeature(), log), log);
         }
     }
 }

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Diagnostics;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Util;
@@ -19,7 +20,7 @@ namespace Halibut.Tests.Transport.Protocol
         [TestCaseSource(typeof(MessageSerializerTestCaseSource))]
         public async Task SendReceiveMessageShouldRoundTrip(MessageSerializerTestCase testCase)
         {
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
 
@@ -40,7 +41,7 @@ namespace Halibut.Tests.Transport.Protocol
         public async Task WriteMessage_ObservesThatMessageIsWritten(MessageSerializerTestCase testCase)
         {
             var messageSerializerObserver = new TestMessageSerializerObserver();
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .WithMessageSerializerObserver(messageSerializerObserver)
                 .Build();
@@ -62,14 +63,14 @@ namespace Halibut.Tests.Transport.Protocol
         public async Task ReadMessage_ObservesThatMessageIsRead(MessageSerializerTestCase testCase)
         {
             var messageSerializerObserver = new TestMessageSerializerObserver();
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .WithMessageSerializerObserver(messageSerializerObserver)
                 .Build();
 
             using (var stream = new MemoryStream())
             {
-                var writingSerializer = new MessageSerializerBuilder()
+                var writingSerializer = new MessageSerializerBuilder(new LogFactory())
                     .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                     .Build();
                 await WriteMessage(testCase, writingSerializer, stream, "Repeating phrase that compresses. Repeating phrase that compresses. Repeating phrase that compresses.");
@@ -93,7 +94,7 @@ namespace Halibut.Tests.Transport.Protocol
         [TestCaseSource(typeof(MessageSerializerTestCaseSource))]
         public async Task BackwardsCompatibility_ExtraParametersInServerErrorAreIgnored(MessageSerializerTestCase testCase)
         {
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
             // This is bson of a RequestMessage which contains a hacked ServerError which has an extra field which no version of Halibut will ever have.
@@ -113,7 +114,7 @@ namespace Halibut.Tests.Transport.Protocol
         [TestCaseSource(typeof(MessageSerializerTestCaseSource))]
         public async Task WhenTheStreamEndsBeforeAnyBytesAreRead_AnEndOfStreamExceptionIsThrown(MessageSerializerTestCase testCase)
         {
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
             using (var stream = new RewindableBufferStream(new MemoryStream(new byte[0])))
@@ -126,7 +127,7 @@ namespace Halibut.Tests.Transport.Protocol
         [TestCaseSource(typeof(MessageSerializerTestCaseSource))]
         public async Task WhenTheStreamEndsMidWayThroughReadingAMessage_AEndOfStreamExceptionIsThrown(MessageSerializerTestCase testCase)
         {
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
             var completeBytes = CreateBytesFromMessage("Hello this is the message");
@@ -141,7 +142,7 @@ namespace Halibut.Tests.Transport.Protocol
         [TestCaseSource(typeof(MessageSerializerTestCaseSource))]
         public async Task WhenTheStreamContainsAnIncompleteZipStream_SomeSortOfZipErrorIsThrown(MessageSerializerTestCase testCase)
         {
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
             var completeBytes = CreateBytesFromMessage(Some.RandomAsciiStringOfLength(22000));
@@ -158,7 +159,7 @@ namespace Halibut.Tests.Transport.Protocol
         [TestCaseSource(typeof(MessageSerializerTestCaseSource))]
         public async Task WhenTheStreamContainsAnInvalidObject_SomeSortOfJsonErrorsThrown(MessageSerializerTestCase testCase)
         {
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
 
@@ -176,7 +177,7 @@ namespace Halibut.Tests.Transport.Protocol
             using (var stream = new MemoryStream())
             using (var rewindableStream = new RewindableBufferStream(stream))
             {
-                var sut = new MessageSerializerBuilder()
+                var sut = new MessageSerializerBuilder(new LogFactory())
                     .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                     .Build();
                 await WriteMessage(testCase, sut, stream, "Test");
@@ -190,7 +191,7 @@ namespace Halibut.Tests.Transport.Protocol
         public async Task ReadMessage_Rewindable_ObservesThatMessageIsRead(MessageSerializerTestCase testCase)
         {
             var messageSerializerObserver = new TestMessageSerializerObserver();
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .WithMessageSerializerObserver(messageSerializerObserver)
                 .Build();
@@ -198,7 +199,7 @@ namespace Halibut.Tests.Transport.Protocol
             using (var stream = new MemoryStream())
             using (var rewindableStream = new RewindableBufferStream(stream))
             {
-                var writingSerializer = new MessageSerializerBuilder()
+                var writingSerializer = new MessageSerializerBuilder(new LogFactory())
                     .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                     .Build();
                 await WriteMessage(testCase, writingSerializer, stream, "Repeating phrase that compresses. Repeating phrase that compresses. Repeating phrase that compresses.");
@@ -221,7 +222,7 @@ namespace Halibut.Tests.Transport.Protocol
         {
             const string trailingData = "SomeOtherData";
 
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .Build();
 
@@ -249,7 +250,7 @@ namespace Halibut.Tests.Transport.Protocol
             const string trailingData = "SomeOtherData";
 
             var messageSerializerObserver = new TestMessageSerializerObserver();
-            var sut = new MessageSerializerBuilder()
+            var sut = new MessageSerializerBuilder(new LogFactory())
                 .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                 .WithMessageSerializerObserver(messageSerializerObserver)
                 .Build();
@@ -257,7 +258,7 @@ namespace Halibut.Tests.Transport.Protocol
             using (var stream = new MemoryStream())
             using (var rewindableStream = new RewindableBufferStream(stream))
             {
-                var writingSerializer = new MessageSerializerBuilder()
+                var writingSerializer = new MessageSerializerBuilder(new LogFactory())
                     .WithAsyncMemoryLimits(testCase.AsyncMemoryLimit, testCase.AsyncMemoryLimit)
                     .Build();
                 await WriteMessage(testCase, writingSerializer, stream, "Repeating phrase that compresses. Repeating phrase that compresses. Repeating phrase that compresses.");
@@ -278,7 +279,7 @@ namespace Halibut.Tests.Transport.Protocol
         
         static byte[] CreateBytesFromMessage(object message)
         {
-            var writingSerializer = new MessageSerializerBuilder().Build();
+            var writingSerializer = new MessageSerializerBuilder(new LogFactory()).Build();
 
             using (var stream = new MemoryStream())
             {

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -88,7 +88,7 @@ namespace Halibut.Tests.Transport
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog logger, SyncOrAsync syncOrAsync)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder().Build(), syncOrAsync.ToAsyncHalibutFeature(), logger), logger);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), syncOrAsync.ToAsyncHalibutFeature(), logger), logger);
         }
     }
 }

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -9,11 +9,19 @@ namespace Halibut.Diagnostics
     internal class InMemoryConnectionLog : ILog
     {
         readonly string endpoint;
-        readonly ConcurrentQueue<LogEvent> events = new ConcurrentQueue<LogEvent>();
+        readonly Logging.ILog logger;
+        readonly ConcurrentQueue<LogEvent> events = new();
 
         public InMemoryConnectionLog(string endpoint)
         {
             this.endpoint = endpoint;
+            this.logger = LogProvider.GetLogger("Halibut");
+        }
+
+        public InMemoryConnectionLog(string endpoint, Logging.ILog logger)
+        {
+            this.endpoint = endpoint;
+            this.logger = logger;
         }
 
         public void Write(EventType type, string message, params object[] args)
@@ -60,7 +68,6 @@ namespace Halibut.Diagnostics
 
         void SendToTrace(LogEvent logEvent, LogLevel level)
         {
-            var logger = LogProvider.GetLogger("Halibut");
             logger.Log(level, () => "{0,-30} {1,4}  {2}", logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage);
         }
     }

--- a/source/Halibut/Diagnostics/LogFactory.cs
+++ b/source/Halibut/Diagnostics/LogFactory.cs
@@ -2,14 +2,21 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Halibut.Logging;
 
 namespace Halibut.Diagnostics
 {
     public class LogFactory : ILogFactory
     {
-        readonly ConcurrentDictionary<string, InMemoryConnectionLog> events = new ConcurrentDictionary<string, InMemoryConnectionLog>();
-        readonly HashSet<Uri> endpoints = new HashSet<Uri>();
-        readonly HashSet<string> prefixes = new HashSet<string>();
+        readonly ConcurrentDictionary<string, InMemoryConnectionLog> events = new();
+        readonly HashSet<Uri> endpoints = new();
+        readonly HashSet<string> prefixes = new();
+        readonly Logging.ILog logger;
+
+        public LogFactory()
+        {
+            logger = LogProvider.GetLogger("Halibut");
+        }
 
         public Uri[] GetEndpoints()
         {
@@ -28,14 +35,14 @@ namespace Halibut.Diagnostics
             endpoint = NormalizeEndpoint(endpoint);
             lock (endpoints)
                 endpoints.Add(endpoint);
-            return events.GetOrAdd(endpoint.ToString(), e => new InMemoryConnectionLog(endpoint.ToString()));
+            return events.GetOrAdd(endpoint.ToString(), e => new InMemoryConnectionLog(endpoint.ToString(), logger));
         }
 
         public ILog ForPrefix(string prefix)
         {
             lock (prefixes)
                 prefixes.Add(prefix);
-            return events.GetOrAdd(prefix, e => new InMemoryConnectionLog(prefix));
+            return events.GetOrAdd(prefix, e => new InMemoryConnectionLog(prefix, logger));
         }
 
         static Uri NormalizeEndpoint(Uri endpoint)

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -65,7 +65,7 @@ namespace Halibut
             queueFactory = new DefaultPendingRequestQueueFactory(logs);
             typeRegistry = new TypeRegistry();
             typeRegistry.AddToMessageContract(serviceFactory.RegisteredServiceTypes.ToArray());
-            messageSerializer = new MessageSerializerBuilder()
+            messageSerializer = new MessageSerializerBuilder(logs)
                 .WithTypeRegistry(typeRegistry)
                 .Build();
             invoker = new ServiceInvoker(serviceFactory);

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -101,7 +101,7 @@ namespace Halibut
             var messageContracts = serviceFactory.RegisteredServiceTypes.ToArray();
             typeRegistry.AddToMessageContract(messageContracts);
 
-            var builder = new MessageSerializerBuilder();
+            var builder = new MessageSerializerBuilder(logFactory);
             configureMessageSerializerBuilder?.Invoke(builder);
             var messageSerializer = builder.WithTypeRegistry(typeRegistry).Build();
 

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -19,8 +19,9 @@ namespace Halibut.Transport.Protocol
         readonly long readIntoMemoryLimitBytes;
         readonly long writeIntoMemoryLimitBytes;
         readonly DeflateStreamInputBufferReflector deflateReflector;
-
-        public MessageSerializer() // kept for backwards compatibility.
+        
+        public MessageSerializer(
+            ILogFactory logFactory) // kept for backwards compatibility.
         {
             typeRegistry = new TypeRegistry();
             createSerializer = () =>
@@ -30,23 +31,23 @@ namespace Halibut.Transport.Protocol
                 settings.SerializationBinder = binder;
                 return JsonSerializer.Create(settings);
             };
-            deflateReflector = new DeflateStreamInputBufferReflector(new InMemoryConnectionLog("poll://foo/"));
+            deflateReflector = new DeflateStreamInputBufferReflector(logFactory.ForPrefix(nameof(MessageSerializer)));
             observer = new NoMessageSerializerObserver();
         }
-
         internal MessageSerializer(
             ITypeRegistry typeRegistry, 
             Func<JsonSerializer> createSerializer,
             IMessageSerializerObserver observer,
             long readIntoMemoryLimitBytes,
-            long writeIntoMemoryLimitBytes)
+            long writeIntoMemoryLimitBytes,
+            ILogFactory logFactory)
         {
             this.typeRegistry = typeRegistry;
             this.createSerializer = createSerializer;
             this.observer = observer;
             this.readIntoMemoryLimitBytes = readIntoMemoryLimitBytes;
             this.writeIntoMemoryLimitBytes = writeIntoMemoryLimitBytes;
-            deflateReflector = new DeflateStreamInputBufferReflector(new InMemoryConnectionLog("poll://foo/"));
+            deflateReflector = new DeflateStreamInputBufferReflector(logFactory.ForPrefix(nameof(MessageSerializer)));
         }
 
         public void AddToMessageContract(params Type[] types) // kept for backwards compatibility

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Halibut.Diagnostics;
 using Halibut.Transport.Observability;
 using Newtonsoft.Json;
 
@@ -6,6 +7,7 @@ namespace Halibut.Transport.Protocol
 {
     public class MessageSerializerBuilder
     {
+        readonly ILogFactory logFactory;
         ITypeRegistry typeRegistry;
         Action<JsonSerializerSettings> configureSerializer;
         IMessageSerializerObserver messageSerializerObserver;
@@ -14,6 +16,11 @@ namespace Halibut.Transport.Protocol
         long readIntoMemoryLimitBytes = 1024L * 64L;
         // Initial prod telemetry indicated values < 7K would be fine. But to be safe, 64K to future proof, and stay below the LOH threshold of 85K.
         long writeIntoMemoryLimitBytes = 1024L * 64L;
+
+        public MessageSerializerBuilder(ILogFactory logFactory)
+        {
+            this.logFactory = logFactory;
+        }
 
         public MessageSerializerBuilder WithTypeRegistry(ITypeRegistry typeRegistry)
         {
@@ -60,7 +67,8 @@ namespace Halibut.Transport.Protocol
                 Serializer, 
                 messageSerializerObserver,
                 readIntoMemoryLimitBytes,
-                writeIntoMemoryLimitBytes);
+                writeIntoMemoryLimitBytes,
+                logFactory);
 
             return messageSerializer;
         }


### PR DESCRIPTION
# Background

This PR changes the way `ILog` instances are created which are used by the `InMemoryConnectionLog` to improve a performance issue observed in Halibut.

Snippet of `pstacks` from a Server process dump showing the issue

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/b9988e4e-1c48-4045-8cf8-6f6d02cc78eb)

Before this change, an ILog would be constructed for every log message that Halibut wanted to write.

After this change, the LogFactory constructs an ILog which is reused for all InMemoryConnectionLogs and so all log messages halibut writes.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
