### PR TITLE
Add support for per HalibutRuntime timeouts and limits

### DIFF
--- a/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Halibut.Diagnostics;
+
+namespace Halibut.Tests.Support
+{
+    public static class HalibutTimeoutsAndLimitsExtensionMethods
+    {
+        public static HalibutTimeoutsAndLimits SetAllTcpTimeoutsTo(this HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, TimeSpan timeSpan)
+        {
+            halibutTimeoutsAndLimits.TcpClientConnectTimeout = timeSpan;
+            
+            halibutTimeoutsAndLimits.TcpClientReceiveTimeout = timeSpan;
+            halibutTimeoutsAndLimits.TcpClientSendTimeout = timeSpan;
+            
+            halibutTimeoutsAndLimits.TcpClientHeartbeatReceiveTimeout = timeSpan;
+            halibutTimeoutsAndLimits.TcpClientHeartbeatSendTimeout = timeSpan;
+            return halibutTimeoutsAndLimits;
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -47,6 +47,7 @@ namespace Halibut.Tests.Support
         ConcurrentDictionary<string, ILog>? serviceInMemoryLoggers;
         ITrustProvider clientTrustProvider;
         Func<string, string, UnauthorizedClientConnectResponse> clientOnUnauthorizedClientConnect;
+        HalibutTimeoutsAndLimits? halibutTimeoutsAndLimits;
 
 
         public LatestClientAndLatestServiceBuilder(ServiceConnectionType serviceConnectionType,
@@ -105,6 +106,12 @@ namespace Halibut.Tests.Support
         IClientAndServiceBuilder IClientAndServiceBuilder.NoService()
         {
             return NoService();
+        }
+
+        public LatestClientAndLatestServiceBuilder WithHalibutTimeoutsAndLimits(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        {
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+            return this;
         }
 
         public LatestClientAndLatestServiceBuilder WithServiceFactory(IServiceFactory serviceFactory)
@@ -314,6 +321,7 @@ namespace Halibut.Tests.Support
                 .WithPendingRequestQueueFactory(factory)
                 .WithTrustProvider(clientTrustProvider)
                 .WithAsyncHalibutFeatureEnabledIfForcingAsync(forceClientProxyType)
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                 .WithOnUnauthorizedClientConnect(clientOnUnauthorizedClientConnect);
 
             var client = clientBuilder.Build();
@@ -326,6 +334,7 @@ namespace Halibut.Tests.Support
                     .WithServiceFactory(serviceFactory)
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                     .WithAsyncHalibutFeature(serviceAsyncHalibutFeature)
+                    .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                     .WithLogFactory(BuildServiceLogger());
 
                 if(pollingReconnectRetryPolicy != null) serviceBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilderExtensionMethods.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices;
 using Halibut.TestUtils.Contracts;
 using Halibut.Util;
@@ -57,6 +59,16 @@ namespace Halibut.Tests.Support
         public static LatestClientAndLatestServiceBuilder WithInstantReconnectPollingRetryPolicy(this LatestClientAndLatestServiceBuilder builder)
         {
             return builder.WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero));
+        }
+
+        public static LatestClientAndLatestServiceBuilder WhenTestingAsyncClient(this LatestClientAndLatestServiceBuilder builder, ClientAndServiceTestCase clientAndServiceTestCase, Action<LatestClientAndLatestServiceBuilder> action)
+        {
+
+            if (clientAndServiceTestCase.SyncOrAsync == SyncOrAsync.Async)
+            {
+                action(builder);
+            }
+            return builder;
         }
     }
 }

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactoryBuilder.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactoryBuilder.cs
@@ -46,7 +46,7 @@ namespace Halibut.Tests.Support
             switch (syncOrAsync)
             {
                 case SyncOrAsync.Async:
-                    return new PendingRequestQueueFactoryAsync(logFactory);
+                    return new PendingRequestQueueFactoryAsync(new HalibutTimeoutsAndLimits(), logFactory);
                 case SyncOrAsync.Sync:
                     return new DefaultPendingRequestQueueFactory(logFactory);
                 default:

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
@@ -23,18 +23,19 @@ namespace Halibut.Tests.Support.TestAttributes
             bool testSyncClients = true,
             bool testAsyncClients = true,
             bool testAsyncServicesAsWell = false, // False means only the sync service will be tested.
+            bool testSyncService = true,
             params object[] additionalParameters
             ) :
             base(
                 typeof(LatestClientAndLatestServiceTestCases),
                 nameof(LatestClientAndLatestServiceTestCases.GetEnumerator),
-                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testSyncClients, testAsyncClients, testAsyncServicesAsWell, additionalParameters })
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testSyncClients, testAsyncClients, testAsyncServicesAsWell, testSyncService, additionalParameters })
         {
         }
 
         static class LatestClientAndLatestServiceTestCases
         {
-            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testSyncClients, bool testAsyncClients, bool testAsyncServicesAsWell, object[] additionalParameters)
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testSyncClients, bool testAsyncClients, bool testAsyncServicesAsWell, bool testSyncService, object[] additionalParameters)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -69,6 +70,11 @@ namespace Halibut.Tests.Support.TestAttributes
                 if (!testAsyncServicesAsWell)
                 {
                     serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Enabled);
+                }
+
+                if (!testSyncService)
+                {
+                    serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Disabled);
                 }
 
                 var builder = new ClientAndServiceTestCasesBuilder(

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -10,13 +10,58 @@ using Halibut.Tests.Util;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 using System.Runtime.InteropServices;
+using Halibut.Tests.Support.PortForwarding;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
+using Halibut.Util;
 
 namespace Halibut.Tests.Timeouts
 {
     public class SendingAndReceivingRequestMessagesTimeoutsFixture : BaseTest
     {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testAsyncServicesAsWell: true, testSyncService : false, testSyncClients: false, testAsyncClients: true)]
+        public async Task HalibutTimeoutsAndLimits_AppliesToTcpClientReceiveTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var expectedTimeout = clientAndServiceTestCase.SyncOrAsync == SyncOrAsync.Sync ? HalibutLimits.TcpClientReceiveTimeout : TimeSpan.FromSeconds(10);
+            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .As<LatestClientAndLatestServiceBuilder>()
+                       .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port).WithPortForwarderDataLogging(clientAndServiceTestCase.ServiceConnectionType).Build())
+                       .WithPortForwarding(out var portForwarderRef)
+                       .WithEchoService()
+                       .WithDoSomeActionService(() => portForwarderRef.Value.PauseExistingConnections())
+                       .WhenTestingAsyncClient(clientAndServiceTestCase, b =>
+                       {
+                           b.WithHalibutTimeoutsAndLimits(new HalibutTimeoutsAndLimits()
+                               .SetAllTcpTimeoutsTo(TimeSpan.FromSeconds(133))
+                               .WithTcpClientReceiveTimeout(expectedTimeout));
+                       })
+                       .WithInstantReconnectPollingRetryPolicy()
+                       .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                await echo.SayHelloAsync("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
+
+                var pauseConnections = clientAndService.CreateClient<IDoSomeActionService, IAsyncClientDoSomeActionService>(IncreasePollingQueueTimeout());
+
+                var sw = Stopwatch.StartNew();
+                var e = (await AssertAsync.Throws<HalibutClientException>(async () => await pauseConnections.ActionAsync())).And;
+                sw.Stop();
+                Logger.Error(e, "Received error");
+                AssertExceptionMessageLooksLikeAReadTimeout(e);
+                sw.Elapsed.Should().BeGreaterThan(expectedTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
+                    .And
+                    .BeLessThan(expectedTimeout + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
+                
+                // The polling tentacle, will not reconnect in time since it has a 133s receive control message timeout.
+                // To move it along we, kill the connection here.
+                // Interestingly this tests does not tests the service times out (the below test does).
+                clientAndService.PortForwarder.CloseExistingConnections();
+
+                await echo.SayHelloAsync("A new request can be made on a new unpaused TCP connection");
+            }
+        }
+        
         [Test]
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task WhenThenNetworkIsPaused_WhileReadingAResponseMessage_ATcpReadTimeoutOccurs_and_FurtherRequestsCanBeMade(ClientAndServiceTestCase clientAndServiceTestCase)

--- a/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerExtensionMethods.cs
@@ -15,7 +15,7 @@ namespace Halibut.Tests.Transport
 #pragma warning disable CS0612 // Type or member is obsolete
             return await syncOrAsync
                 .WhenSync(() => connectionManager.AcquireConnection(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken))
-                .WhenAsync(async () => await connectionManager.AcquireConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, log, cancellationToken));
+                .WhenAsync(async () => await connectionManager.AcquireConnectionAsync(exchangeProtocolBuilder, connectionFactory, serviceEndPoint, new HalibutTimeoutsAndLimits(), log, cancellationToken));
 #pragma warning restore CS0612 // Type or member is obsolete
         }
     }

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -34,7 +34,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            var connectionManager = new ConnectionManager(new HalibutTimeoutsAndLimits());
 
             //do it twice because this bug only triggers on multiple enumeration, having 1 in the collection doesn't trigger the bug
             await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
@@ -51,7 +51,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            var connectionManager = new ConnectionManager(new HalibutTimeoutsAndLimits());
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
@@ -67,7 +67,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            var connectionManager = new ConnectionManager(new HalibutTimeoutsAndLimits());
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
@@ -83,7 +83,7 @@ namespace Halibut.Tests.Transport
             var (connectionFactory, exchangeProtocolBuilder) = SetUp(syncOrAsync);
 
             var serviceEndpoint = new ServiceEndPoint("https://localhost:42", Certificates.TentacleListeningPublicThumbprint);
-            var connectionManager = new ConnectionManager();
+            var connectionManager = new ConnectionManager(new HalibutTimeoutsAndLimits());
 
             var activeConnection = await connectionManager.AcquireConnection_SyncOrAsync(syncOrAsync, exchangeProtocolBuilder, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken.None);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
@@ -94,7 +94,7 @@ namespace Halibut.Tests.Transport
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog log, SyncOrAsync syncOrAsync)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), syncOrAsync.ToAsyncHalibutFeature(), log), log);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), syncOrAsync.ToAsyncHalibutFeature(), new HalibutTimeoutsAndLimits(), log), log);
         }
     }
 }

--- a/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests.Transport
 #pragma warning disable CS0612
             var discovered = await clientAndServiceTestCase.SyncOrAsync
                 .WhenSync(() => client.Discover(new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, ""), CancellationToken))
-                .WhenAsync(async () => await client.DiscoverAsync(new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, ""), CancellationToken));
+                .WhenAsync(async () => await client.DiscoverAsync(new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, ""), clientAndService.Client.TimeoutsAndLimits, CancellationToken));
 #pragma warning restore CS0612
 
             discovered.RemoteThumbprint.Should().BeEquivalentTo(clientAndService.GetServiceEndPoint().RemoteThumbprint);
@@ -44,7 +44,7 @@ namespace Halibut.Tests.Transport
 #pragma warning disable CS0612
             await syncOrAsync
                 .WhenSync(() => Assert.Throws<HalibutClientException>(() => client.Discover(fakeEndpoint), "No such host is known")).IgnoreResult()
-                .WhenAsync(async () => await AssertAsync.Throws<HalibutClientException>(() => client.DiscoverAsync(fakeEndpoint, CancellationToken), "No such host is known"));
+                .WhenAsync(async () => await AssertAsync.Throws<HalibutClientException>(() => client.DiscoverAsync(fakeEndpoint, new HalibutTimeoutsAndLimits(), CancellationToken), "No such host is known"));
 #pragma warning restore CS0612
         }
         
@@ -86,7 +86,7 @@ namespace Halibut.Tests.Transport
 #pragma warning disable CS0612
             await AssertionExtensions.Should(() => clientAndServiceTestCase.SyncOrAsync
                 .WhenSync(() => client.Discover(new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, ""), CancellationToken))
-                .WhenAsync(async () => await client.DiscoverAsync(new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, ""), CancellationToken)))
+                .WhenAsync(async () => await client.DiscoverAsync(new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, ""), clientAndService.Client.TimeoutsAndLimits, CancellationToken)))
                 .ThrowAsync<HalibutClientException>();
 #pragma warning restore CS0612
 

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -65,7 +65,8 @@ namespace Halibut.Tests.Transport
                     () => "",
                     () => new Dictionary<string, string>(),
                     (_, _) => UnauthorizedClientConnectResponse.BlockConnection,
-                    syncOrAsync.ToAsyncHalibutFeature()
+                    syncOrAsync.ToAsyncHalibutFeature(),
+                    new HalibutTimeoutsAndLimits()
                 );
 
                 var idleAverage = CollectCounterValues(opsPerSec)

--- a/source/Halibut/Diagnostics/HalibutLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutLimits.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 
 namespace Halibut.Diagnostics
 {
+    [Obsolete]
     public class HalibutLimits
     {
         static HalibutLimits()
@@ -24,7 +25,7 @@ namespace Halibut.Diagnostics
         /// polling request queue before raising a TimeoutException. Can be overridden via the ServiceEndPoint.
         /// </summary>
         public static TimeSpan PollingRequestQueueTimeout = TimeSpan.FromMinutes(2);
-        
+
         /// <summary>
         /// The default amount of time the client will wait for the server to process a message collected
         /// from the polling request queue before it raises a TimeoutException. Can be overridden via the ServiceEndPoint.
@@ -104,6 +105,98 @@ namespace Halibut.Diagnostics
                     var timeout = TcpClientReceiveTimeout - TimeSpan.FromSeconds(10);
                     return timeout > TimeSpan.Zero ? timeout : TcpClientReceiveTimeout;
                 }
+            }
+        }
+    }
+#pragma warning disable CS0612
+    public class HalibutTimeoutsAndLimits
+    {
+        /// <summary>
+        ///     The default amount of time the client will wait for the server to collect a message from the
+        ///     polling request queue before raising a TimeoutException. Can be overridden via the ServiceEndPoint.
+        /// </summary>
+        public TimeSpan PollingRequestQueueTimeout { get; set; } = HalibutLimits.PollingRequestQueueTimeout;
+
+        /// <summary>
+        ///     The default amount of time the client will wait for the server to process a message collected
+        ///     from the polling request queue before it raises a TimeoutException. Can be overridden via the ServiceEndPoint.
+        /// </summary>
+        public TimeSpan PollingRequestMaximumMessageProcessingTimeout { get; set; } = HalibutLimits.PollingRequestMaximumMessageProcessingTimeout;
+
+        /// <summary>
+        ///     The amount of time to wait between connection requests to the remote endpoint (applies
+        ///     to both polling and listening connections). Can be overridden via the ServiceEndPoint.
+        /// </summary>
+        public TimeSpan RetryListeningSleepInterval { get; set; } = HalibutLimits.RetryListeningSleepInterval;
+
+        /// <summary>
+        ///     The number of times to try and connect to the remote endpoint. Can be overridden via the ServiceEndPoint.
+        /// </summary>
+        public int RetryCountLimit { get; set; } = HalibutLimits.RetryCountLimit;
+
+        /// <summary>
+        ///     Stops connection retries if this time period has been exceeded from the initial connection attempt. Can be
+        ///     overridden via the ServiceEndPoint.
+        /// </summary>
+        public TimeSpan ConnectionErrorRetryTimeout { get; set; } = HalibutLimits.ConnectionErrorRetryTimeout;
+
+        /// <summary>
+        ///     The size of the buffer, in bytes, of the rewind buffer when reading compressed message envelopes.
+        /// </summary>
+        /// <remarks>
+        ///     For safety, this should match the buffer size of the decorated stream (i.e. DeflateStream) to avoid unintended
+        ///     side-effects.
+        /// </remarks>
+        public int RewindableBufferStreamSize { get; set; } = HalibutLimits.RewindableBufferStreamSize;
+
+        /// <summary>
+        ///     Amount of time to wait for a TCP or SslStream write to complete successfully
+        /// </summary>
+        public TimeSpan TcpClientSendTimeout { get; set; } = HalibutLimits.TcpClientSendTimeout;
+
+        /// <summary>
+        ///     Amount of time to wait for a TCP or SslStream read to complete successfully
+        /// </summary>
+        public TimeSpan TcpClientReceiveTimeout { get; set; } = HalibutLimits.TcpClientReceiveTimeout;
+
+        /// <summary>
+        ///     Amount of time a connection can stay in the pool
+        /// </summary>
+        public TimeSpan TcpClientPooledConnectionTimeout { get; set; } = HalibutLimits.TcpClientPooledConnectionTimeout;
+
+        public TimeSpan TcpClientHeartbeatSendTimeout { get; set; } = HalibutLimits.TcpClientHeartbeatSendTimeout;
+        public TimeSpan TcpClientHeartbeatReceiveTimeout { get; set; } = HalibutLimits.TcpClientHeartbeatReceiveTimeout;
+
+        /// <summary>
+        ///     Amount of time to wait for a successful TCP or WSS connection
+        /// </summary>
+        public TimeSpan TcpClientConnectTimeout { get; set; } = HalibutLimits.TcpClientConnectTimeout;
+
+        /// <summary>
+        ///     The amount of time client will wait for a message to be added to the polling request queue
+        ///     before returning a null response to the server. This does not generate an error and the server would immediate
+        ///     re-request.
+        /// </summary>
+        public TimeSpan PollingQueueWaitTimeout { get; set; } = HalibutLimits.PollingQueueWaitTimeout;
+#pragma warning restore CS0612
+        // After a client/server message exchange is complete, the client returns
+        // the connection to the pool but the server continues to block and reads
+        // from the connection until the TcpClientReceiveTimeout.
+        // If TcpClientPooledConnectionTimeout is greater than TcpClientReceiveTimeout
+        // when the client goes to the pool to get a connection for the next
+        // exchange it can get one that has timed out, so make sure our pool
+        // timeout is smaller than the tcp timeout.
+        public TimeSpan SafeTcpClientPooledConnectionTimeout
+        {
+            get
+            {
+                if (TcpClientPooledConnectionTimeout < TcpClientReceiveTimeout)
+                {
+                    return TcpClientPooledConnectionTimeout;
+                }
+
+                var timeout = TcpClientReceiveTimeout - TimeSpan.FromSeconds(10);
+                return timeout > TimeSpan.Zero ? timeout : TcpClientReceiveTimeout;
             }
         }
     }

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -75,5 +75,7 @@ namespace Halibut
 
         OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
         AsyncHalibutFeature AsyncHalibutFeature { get; }
+        
+        public HalibutTimeoutsAndLimits TimeoutsAndLimits { get; }
     }
 }

--- a/source/Halibut/ServiceEndPoint.cs
+++ b/source/Halibut/ServiceEndPoint.cs
@@ -8,11 +8,15 @@ namespace Halibut
     {
         readonly string baseUriString;
 
+        // TODO - ASYNC ME UP!
+        // Mark as obsolete since it should be created by taking a HalibutRuntimeLimit
         public ServiceEndPoint(string baseUri, string remoteThumbprint)
             : this(new Uri(baseUri), remoteThumbprint)
         {
         }
 
+        // TODO - ASYNC ME UP!
+        // Mark as obsolete since it should be created by taking a HalibutRuntimeLimit
         public ServiceEndPoint(Uri baseUri, string remoteThumbprint)
             : this(baseUri, remoteThumbprint, null)
         {
@@ -35,11 +39,13 @@ namespace Halibut
             Proxy = proxy;
         }
 
+#pragma warning disable CS0612
         /// <summary>
         /// The amount of time the client will wait for the server to collect a message from the
         /// polling request queue before raising a TimeoutException
         /// </summary>
         public TimeSpan PollingRequestQueueTimeout { get; set; } = HalibutLimits.PollingRequestQueueTimeout;
+
 
         /// <summary>
         /// The amount of time the client will wait for the server to process a message collected
@@ -67,6 +73,7 @@ namespace Halibut
         /// Amount of time to wait for a successful TCP or WSS connection
         /// </summary>
         public TimeSpan TcpClientConnectTimeout { get; set; } = HalibutLimits.TcpClientConnectTimeout;
+#pragma warning restore CS0612
 
         public Uri BaseUri { get; }
 

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -18,7 +18,7 @@ namespace Halibut.ServiceModel
         readonly ILog log;
         readonly TimeSpan pollingQueueWaitTimeout;
 
-        public PendingRequestQueueAsync(ILog log) : this(log, HalibutLimits.PollingQueueWaitTimeout)
+        public PendingRequestQueueAsync(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log) : this(log, halibutTimeoutsAndLimits.PollingQueueWaitTimeout)
         {
             this.log = log;
         }

--- a/source/Halibut/ServiceModel/PendingRequestQueueFactoryAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueFactoryAsync.cs
@@ -6,15 +6,17 @@ namespace Halibut.ServiceModel
     class PendingRequestQueueFactoryAsync : IPendingRequestQueueFactory
     {
         readonly ILogFactory logFactory;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
 
-        public PendingRequestQueueFactoryAsync(ILogFactory logFactory)
+        public PendingRequestQueueFactoryAsync(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILogFactory logFactory)
         {
             this.logFactory = logFactory;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
 
         public IPendingRequestQueue CreateQueue(Uri endpoint)
         {
-            return new PendingRequestQueueAsync(logFactory.ForEndpoint(endpoint));
+            return new PendingRequestQueueAsync(halibutTimeoutsAndLimits, logFactory.ForEndpoint(endpoint));
         }
     }
 }

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -53,12 +53,12 @@ namespace Halibut.Transport
             }
         }
 
-        public async Task<ServiceEndPoint> DiscoverAsync(ServiceEndPoint serviceEndpoint, CancellationToken cancellationToken)
+        public async Task<ServiceEndPoint> DiscoverAsync(ServiceEndPoint serviceEndpoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, CancellationToken cancellationToken)
         {
             try
             {
                 var log = logs.ForEndpoint(serviceEndpoint.BaseUri);
-                using (var client = await TcpConnectionFactory.CreateConnectedTcpClientAsync(serviceEndpoint, log, cancellationToken))
+                using (var client = await TcpConnectionFactory.CreateConnectedTcpClientAsync(serviceEndpoint, halibutTimeoutsAndLimits, log, cancellationToken))
                 {
                     using (var networkStream = client.GetStream())
                     {

--- a/source/Halibut/Transport/Protocol/ControlMessageReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessageReader.cs
@@ -9,6 +9,13 @@ namespace Halibut.Transport.Protocol
 {
     internal class ControlMessageReader
     {
+        HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
+
+        public ControlMessageReader(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        {
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+        }
+
         [Obsolete]
         internal string ReadUntilNonEmptyControlMessage(Stream stream)
         {
@@ -106,7 +113,7 @@ namespace Halibut.Transport.Protocol
 
         internal async Task<string> ReadControlMessageAsync(Stream stream, CancellationToken cancellationToken)
         {
-            using var timeoutCts = GetCancellationTokenSourceFromStreamReadTimeout(stream);
+            using var timeoutCts = GetCancellationTokenSourceFromStreamReadTimeoutAsync(stream);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
             var sb = new StringBuilder();
 
@@ -142,6 +149,7 @@ namespace Halibut.Transport.Protocol
             }
         }
         
+        [Obsolete]
         static CancellationTokenSource GetCancellationTokenSourceFromStreamReadTimeout(Stream stream)
         {
             if (stream.CanTimeout)
@@ -150,6 +158,16 @@ namespace Halibut.Transport.Protocol
             }
 
             return new CancellationTokenSource(HalibutLimits.TcpClientReceiveTimeout); // Just default to a higher timeout, rather than be cancellation token none
+        }
+        
+        CancellationTokenSource GetCancellationTokenSourceFromStreamReadTimeoutAsync(Stream stream)
+        {
+            if (stream.CanTimeout)
+            {
+                return new CancellationTokenSource(stream.ReadTimeout);
+            }
+
+            return new CancellationTokenSource(halibutTimeoutsAndLimits.TcpClientReceiveTimeout); // Just default to a higher timeout, rather than be cancellation token none
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ControlMessageReader.cs
+++ b/source/Halibut/Transport/Protocol/ControlMessageReader.cs
@@ -162,6 +162,8 @@ namespace Halibut.Transport.Protocol
         
         CancellationTokenSource GetCancellationTokenSourceFromStreamReadTimeoutAsync(Stream stream)
         {
+            // TODO - ASYNC ME UP!
+            // We should always be given a stream that can timeout.
             if (stream.CanTimeout)
             {
                 return new CancellationTokenSource(stream.ReadTimeout);

--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -50,7 +50,11 @@ namespace Halibut.Transport.Protocol
             var buffer = new ArraySegment<byte>(new byte[10000]);
             while (true)
             {
+                // TODO - ASYNC ME UP!
+                // What should the timeout be here? thew new code that allows passing in a timeout or the static value?
+#pragma warning disable CS0612
                 using(var cts = new CancellationTokenSource(HalibutLimits.TcpClientReceiveTimeout))
+#pragma warning restore CS0612
                 using(var combined = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancel.Token))
                 {
                     var result = await context.ReceiveAsync(buffer, combined.Token).ConfigureAwait(false);

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -21,14 +21,16 @@ namespace Halibut.Transport
         readonly ConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
         readonly ExchangeProtocolBuilder protocolBuilder;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
 
-        public SecureClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log, ConnectionManager connectionManager)
         {
             this.protocolBuilder = protocolBuilder;
             this.ServiceEndpoint = serviceEndpoint;
             this.clientCertificate = clientCertificate;
             this.log = log;
             this.connectionManager = connectionManager;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
 
         public ServiceEndPoint ServiceEndpoint { get; }
@@ -58,7 +60,7 @@ namespace Halibut.Transport
                     IConnection connection = null;
                     try
                     {
-                        connection = connectionManager.AcquireConnection(protocolBuilder, new TcpConnectionFactory(clientCertificate), ServiceEndpoint, log, cancellationToken);
+                        connection = connectionManager.AcquireConnection(protocolBuilder, new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), ServiceEndpoint, log, cancellationToken);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;
@@ -158,8 +160,9 @@ namespace Halibut.Transport
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
                             protocolBuilder, 
-                            new TcpConnectionFactory(clientCertificate), 
-                            ServiceEndpoint, 
+                            new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
+                            ServiceEndpoint,
+                            halibutTimeoutsAndLimits,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
 

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -30,7 +30,11 @@ namespace Halibut.Transport
 
         public bool HasExpired()
         {
+            // TODO - ASYNC ME UP!
+            // Use the HalibutRuntimeLimits
+#pragma warning disable CS0612
             return lastUsed < DateTimeOffset.UtcNow.Subtract(HalibutLimits.SafeTcpClientPooledConnectionTimeout);
+#pragma warning restore CS0612
         }
         
         public void Dispose()

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -25,15 +25,17 @@ namespace Halibut.Transport
         [Obsolete("Replaced by HalibutLimits.RetryCountLimit")] public const int RetryCountLimit = 5;
         readonly ServiceEndPoint serviceEndpoint;
         readonly X509Certificate2 clientCertificate;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
         readonly ILog log;
         readonly ConnectionManager connectionManager;
         readonly ExchangeProtocolBuilder protocolBuilder;
 
-        public SecureWebSocketClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, ILog log, ConnectionManager connectionManager)
+        public SecureWebSocketClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log, ConnectionManager connectionManager)
         {
             this.protocolBuilder = protocolBuilder;
             this.serviceEndpoint = serviceEndpoint;
             this.clientCertificate = clientCertificate;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
             this.log = log;
             this.connectionManager = connectionManager;
         }
@@ -65,7 +67,7 @@ namespace Halibut.Transport
                     IConnection connection = null;
                     try
                     {
-                        connection = connectionManager.AcquireConnection(protocolBuilder, new WebSocketConnectionFactory(clientCertificate), serviceEndpoint, log, cancellationToken);
+                        connection = connectionManager.AcquireConnection(protocolBuilder, new WebSocketConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), serviceEndpoint, log, cancellationToken);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;
@@ -157,8 +159,9 @@ namespace Halibut.Transport
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
                             protocolBuilder, 
-                            new WebSocketConnectionFactory(clientCertificate), 
+                            new WebSocketConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
                             serviceEndpoint, 
+                            halibutTimeoutsAndLimits,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);
 

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -15,10 +15,12 @@ namespace Halibut.Transport
     public class WebSocketConnectionFactory : IConnectionFactory
     {
         readonly X509Certificate2 clientCertificate;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
 
-        public WebSocketConnectionFactory(X509Certificate2 clientCertificate)
+        public WebSocketConnectionFactory(X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             this.clientCertificate = clientCertificate;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
 
         [Obsolete]

--- a/source/Halibut/Util/AsyncHalibutFeature.cs
+++ b/source/Halibut/Util/AsyncHalibutFeature.cs
@@ -2,8 +2,8 @@
 {
     public enum AsyncHalibutFeature
     {
-        Enabled,
-        Disabled    
+        Disabled,
+        Enabled
     }
 
     public static class AsyncHalibutFeatureExtensionMethods

--- a/source/Halibut/Util/HalibutTimeoutsAndLimitsExtensionMethods.cs
+++ b/source/Halibut/Util/HalibutTimeoutsAndLimitsExtensionMethods.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Halibut.Diagnostics;
+
+namespace Halibut.Util
+{
+    public static class HalibutTimeoutsAndLimitsExtensionMethods
+    {
+        public static HalibutTimeoutsAndLimits WithTcpClientReceiveTimeout(this HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, TimeSpan tcpClientReceiveTimeout)
+        {
+            halibutTimeoutsAndLimits.TcpClientReceiveTimeout = tcpClientReceiveTimeout;
+            return halibutTimeoutsAndLimits;
+        }
+    }
+}


### PR DESCRIPTION
# Background

**Statics make testing hard**

HalibutLimits are statically set, which means all tests are using the same timeout. This is a problem since either we can have:
* High timeouts increasing reliability but with timeout tests taking longer to run.
* Low timeouts reducing the time it takes to run timeout test but with decreased reliability of tests.

This introduces a new type `HalibutTimeoutsAndLimits`, which holds timeouts and limits and is used only in async paths.

The existing `HalibutLimits` class is marked obsolete.

[SC-45207]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
