### PR TITLE
Make ServiceInvoker async

### DIFF
--- a/source/Halibut.TestUtils.Contracts/BrokenConventionService.cs
+++ b/source/Halibut.TestUtils.Contracts/BrokenConventionService.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public class BrokenConventionService : IBrokenConventionService
+    {
+        public string SayHello(string name)
+        {
+            return $"Hello {name}!";
+        }
+
+        public int GetRandomNumberMissingSuffix()
+        {
+            // https://xkcd.com/221
+            return 4;
+        }
+
+        public int GetRandomNumberMissingCancellationToken()
+        {
+            // https://xkcd.com/221
+            return 4;
+        }
+
+        public string SayHelloMissingSuffix(string name)
+        {
+            return $"Hello {name}!";
+        }
+
+        public string SayHelloMissingCancellationToken(string name)
+        {
+            return $"Hello {name}!";
+        }
+    }
+
+    public class AsyncBrokenConventionService : IAsyncBrokenConventionService
+    {
+        IBrokenConventionService service = new BrokenConventionService();
+
+        public async Task<int> GetRandomNumberMissingSuffix(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.GetRandomNumberMissingSuffix();
+        }
+
+        public async Task<int> GetRandomNumberMissingCancellationTokenAsync()
+        {
+            await Task.CompletedTask;
+            return service.GetRandomNumberMissingCancellationToken();
+        }
+
+        public async Task<string> SayHelloMissingSuffix(string name, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.SayHelloMissingSuffix(name);
+        }
+
+        public async Task<string> SayHelloMissingCancellationTokenAsync(string name)
+        {
+            await Task.CompletedTask;
+            return service.SayHelloMissingCancellationToken(name);
+        }
+    }
+}

--- a/source/Halibut.TestUtils.Contracts/CountingService.cs
+++ b/source/Halibut.TestUtils.Contracts/CountingService.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -13,6 +14,22 @@ namespace Halibut.TestUtils.Contracts
         public int GetCurrentValue()
         {
             return count;
+        }
+    }
+    
+    public class AsyncCountingService : IAsyncCountingService
+    {
+        ICountingService service = new CountingService();
+        public async Task<int> IncrementAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.Increment();
+        }
+
+        public async Task<int> GetCurrentValueAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.GetCurrentValue();
         }
     }
 }

--- a/source/Halibut.TestUtils.Contracts/EchoService.cs
+++ b/source/Halibut.TestUtils.Contracts/EchoService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -31,4 +32,34 @@ namespace Halibut.TestUtils.Contracts
             return length;
         }
     }
+
+    public class AsyncEchoService : IAsyncEchoService
+    {
+        readonly EchoService service = new EchoService();
+        
+        public async Task<int> LongRunningOperationAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(10000, cancellationToken);
+            return 16;
+        }
+
+        public async Task<string> SayHelloAsync(string name, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.SayHello(name + "Async");
+        }
+
+        public async Task<bool> CrashAsync(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.Crash();
+        }
+
+        public async Task<int> CountBytesAsync(DataStream dataStream, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return service.CountBytes(dataStream);
+        }
+    }
 }
+

--- a/source/Halibut.TestUtils.Contracts/IBrokenConventionService.cs
+++ b/source/Halibut.TestUtils.Contracts/IBrokenConventionService.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public interface IBrokenConventionService
+    {
+        int GetRandomNumberMissingSuffix();
+        int GetRandomNumberMissingCancellationToken();
+        string SayHelloMissingSuffix(string name);
+        string SayHelloMissingCancellationToken(string name);
+    }
+
+    public interface IAsyncBrokenConventionService
+    {
+        // Convention says these async methods should finish with 'Async'
+        // and take a CancellationToken
+        Task<int> GetRandomNumberMissingSuffix(CancellationToken cancellationToken);
+        Task<int> GetRandomNumberMissingCancellationTokenAsync();
+        
+        Task<string> SayHelloMissingSuffix(string name, CancellationToken cancellationToken);
+        Task<string> SayHelloMissingCancellationTokenAsync(string name);
+    }
+}

--- a/source/Halibut.TestUtils.Contracts/ICountingService.cs
+++ b/source/Halibut.TestUtils.Contracts/ICountingService.cs
@@ -1,8 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Halibut.TestUtils.Contracts
 {
     public interface ICountingService
     {
         public int Increment();
         public int GetCurrentValue();
+    }
+
+    public interface IAsyncCountingService
+    {
+        public Task<int> IncrementAsync(CancellationToken cancellationToken);
+        public Task<int> GetCurrentValueAsync(CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut.TestUtils.Contracts/IEchoService.cs
+++ b/source/Halibut.TestUtils.Contracts/IEchoService.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -11,5 +13,16 @@ namespace Halibut.TestUtils.Contracts
         bool Crash();
 
         int CountBytes(DataStream stream);
+    }
+
+    public interface IAsyncEchoService
+    {
+        Task<int> LongRunningOperationAsync(CancellationToken cancellationToken);
+
+        Task<string> SayHelloAsync(string name, CancellationToken cancellationToken);
+
+        Task<bool> CrashAsync(CancellationToken cancellationToken);
+
+        Task<int> CountBytesAsync(DataStream dataStream, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut.TestUtils.Contracts/ILockService.cs
+++ b/source/Halibut.TestUtils.Contracts/ILockService.cs
@@ -1,7 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Halibut.TestUtils.Contracts
 {
     public interface ILockService
     {
         public void WaitForFileToBeDeleted(string fileToWaitFor, string fileSignalWhenRequestIsStarted);
+    }
+    
+    public interface IAsyncLockService
+    {
+        public Task WaitForFileToBeDeletedAsync(string fileToWaitFor, string fileSignalWhenRequestIsStarted, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut.TestUtils.Contracts/LockService.cs
+++ b/source/Halibut.TestUtils.Contracts/LockService.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -12,6 +13,17 @@ namespace Halibut.TestUtils.Contracts
             {
                 Thread.Sleep(20);
             }
+        }
+    }
+
+    public class AsyncLockService : IAsyncLockService
+    {
+        LockService service = new();
+        
+        public async Task WaitForFileToBeDeletedAsync(string fileToWaitFor, string fileSignalWhenRequestIsStarted, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            service.WaitForFileToBeDeleted(fileToWaitFor, fileSignalWhenRequestIsStarted);
         }
     }
 }

--- a/source/Halibut.Tests/AsyncServiceVerifierFixture.cs
+++ b/source/Halibut.Tests/AsyncServiceVerifierFixture.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Exceptions;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class AsyncServiceVerifierFixture
+    {
+        [Test]
+        public async Task AsyncMatchesSync()
+        {
+            AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncGoodService>();
+        }
+
+        [Test]
+        public async Task AsyncBreaksCancellationTokenConvention()
+        {
+            Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>
+                (AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncBrokenCancellationTokenConventionService>);
+        }
+
+        [Test]
+        public async Task AsyncBreaksSuffixConvention()
+        {
+            Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>
+                (AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncBrokenSuffixConventionService>);
+        }
+
+        [Test]
+        public async Task AsyncBreaksReturnTypeConvention()
+        {
+            Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>
+                (AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncBrokenReturnTypeConventionService>);
+        }
+        
+    }
+
+    public interface IGoodService
+    {
+        int DoSomething();
+        string SaySomething(string name);
+    }
+
+    public interface IAsyncGoodService
+    {
+        Task<int> DoSomethingAsync(CancellationToken cancellationToken);
+        Task<string> SaySomethingAsync(string name, CancellationToken cancellationToken);
+    }
+    
+    public interface IAsyncBrokenCancellationTokenConventionService
+    {
+        Task<int> DoSomethingAsync();
+        Task<string> SaySomethingAsync(string name);
+    }
+
+    public interface IAsyncBrokenSuffixConventionService
+    {
+        Task<int> DoSomething(CancellationToken cancellationToken);
+        Task<string> SaySomething(string name, CancellationToken cancellationToken);
+    }
+
+    public interface IAsyncBrokenReturnTypeConventionService
+    {
+        int DoSomethingAsync(CancellationToken cancellationToken);
+        string SaySomethingAsync(string name, CancellationToken cancellationToken);
+    }
+}

--- a/source/Halibut.Tests/AsyncServicesFixture.cs
+++ b/source/Halibut.Tests/AsyncServicesFixture.cs
@@ -19,21 +19,10 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService:false, testNetworkConditions: false)]
         public async Task AsyncServiceWithReturnType_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            var clientAndServiceBuilder = clientAndServiceTestCase.CreateTestCaseBuilder()
-                .AsLatestClientAndLatestServiceBuilder();
-
-            if (clientAndServiceTestCase.ServiceAsyncHalibutFeature.IsEnabled())
-            {
-                clientAndServiceBuilder = clientAndServiceBuilder
-                    .WithAsyncService<IEchoService, IAsyncEchoService>(() => new AsyncEchoService());
-            }
-            else
-            {
-                clientAndServiceBuilder = clientAndServiceBuilder
-                    .WithService<IEchoService>(() => new EchoService());
-            }
-
-            var clientAndService = await clientAndServiceBuilder.Build(CancellationToken);
+            var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithAsyncService<IEchoService, IAsyncEchoService>(() => new AsyncEchoService())
+                .Build(CancellationToken);
 
             var value = Some.RandomAsciiStringOfLength(8);
             var echoServiceClient = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
@@ -53,21 +42,10 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService: false, testNetworkConditions: false)]
         public async Task AsyncServiceWithNoReturnType_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            var clientAndServiceBuilder = clientAndServiceTestCase.CreateTestCaseBuilder()
-                .AsLatestClientAndLatestServiceBuilder();
-
-            if (clientAndServiceTestCase.ServiceAsyncHalibutFeature.IsEnabled())
-            {
-                clientAndServiceBuilder = clientAndServiceBuilder
-                    .WithAsyncService<ILockService, IAsyncLockService>(() => new AsyncLockService());
-            }
-            else
-            {
-                clientAndServiceBuilder = clientAndServiceBuilder
-                    .WithService<ILockService>(() => new LockService());
-            }
-
-            using var clientAndService = await clientAndServiceBuilder.Build(CancellationToken);
+            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithAsyncService<ILockService, IAsyncLockService>(() => new AsyncLockService())
+                .Build(CancellationToken);
 
             string fileToWaitFor = Path.GetTempFileName();
             string fileWhenRequestStarted = Path.GetTempFileName();
@@ -78,6 +56,21 @@ namespace Halibut.Tests
             await lockServiceClient.WaitForFileToBeDeletedAsync(fileToWaitFor, fileWhenRequestStarted);
 
             File.Exists(fileWhenRequestStarted).Should().BeTrue();
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService: false, testNetworkConditions: false)]
+        public async Task AsyncServiceWithNoParams_CanBeRegisteredAndResolve(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithAsyncService<ICountingService, IAsyncCountingService>(() => new AsyncCountingService())
+                .Build(CancellationToken);
+
+            var countingService = clientAndService.CreateClient<ICountingService, IAsyncClientCountingService>();
+            var result = await countingService.IncrementAsync();
+            result.Should().Be(1);
+
         }
     }
 }

--- a/source/Halibut.Tests/AsyncServicesFixture.cs
+++ b/source/Halibut.Tests/AsyncServicesFixture.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
+using Halibut.Tests.Util;
+using Halibut.TestUtils.Contracts;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class AsyncServicesFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true)]
+        public async Task AsyncServicesCanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var clientAndServiceBuilder = clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder();
+
+            if (clientAndServiceTestCase.ServiceAsyncHalibutFeature.IsEnabled())
+            {
+                clientAndServiceBuilder = clientAndServiceBuilder
+                    .WithAsyncService<IEchoService, IAsyncEchoService>(() => new AsyncEchoService());
+            }
+            else
+            {
+                clientAndServiceBuilder = clientAndServiceBuilder
+                    .WithService<IEchoService>(() => new EchoService());
+            }
+
+            var clientAndService = await clientAndServiceBuilder.Build(CancellationToken);
+
+            var value = Some.RandomAsciiStringOfLength(8);
+            string result = null;
+            await clientAndServiceTestCase.ForceClientProxyType.ToSyncOrAsync()
+                .WhenSync(() =>
+                {
+                    var echoServiceClient = clientAndService.Client.CreateClient<IEchoService>(clientAndService.ServiceEndPoint, CancellationToken);
+                    result = echoServiceClient.SayHello(value);
+                })
+                .WhenAsync(async () =>
+                {
+                    var echoServiceClient = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                    result = await echoServiceClient.SayHelloAsync(value);
+                });
+
+            if (clientAndServiceTestCase.ServiceAsyncHalibutFeature.IsEnabled())
+            {
+                result.Should().Be($"{value}Async...");
+            }
+            else
+            {
+                result.Should().Be($"{value}...");
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/AsyncServicesFixture.cs
+++ b/source/Halibut.Tests/AsyncServicesFixture.cs
@@ -16,8 +16,8 @@ namespace Halibut.Tests
     public class AsyncServicesFixture : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testNetworkConditions: false)]
-        public async Task AsyncServiceWithParams_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
+        [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService:false, testNetworkConditions: false)]
+        public async Task AsyncServiceWithReturnType_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var clientAndServiceBuilder = clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder();
@@ -50,8 +50,8 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testNetworkConditions: false)]
-        public async Task AsyncServiceWithNoParams_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
+        [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService: false, testNetworkConditions: false)]
+        public async Task AsyncServiceWithNoReturnType_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var clientAndServiceBuilder = clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder();
@@ -67,7 +67,7 @@ namespace Halibut.Tests
                     .WithService<ILockService>(() => new LockService());
             }
 
-            var clientAndService = await clientAndServiceBuilder.Build(CancellationToken);
+            using var clientAndService = await clientAndServiceBuilder.Build(CancellationToken);
 
             string fileToWaitFor = Path.GetTempFileName();
             string fileWhenRequestStarted = Path.GetTempFileName();

--- a/source/Halibut.Tests/Builders/ServiceFactoryBuilder.cs
+++ b/source/Halibut.Tests/Builders/ServiceFactoryBuilder.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Halibut.ServiceModel;
+using Halibut.Tests.Util;
+
+namespace Halibut.Tests.Builders
+{
+    public class ServiceFactoryBuilder
+    {
+        bool _conventionVerificationDisabled;
+        DelegateServiceFactory factoryWithConventionVerification = new();
+        NaiveDelegateServiceFactory factoryWithNoConventionVerification = new();
+        
+
+        public ServiceFactoryBuilder WithService<TContract>(Func<TContract> factoryFunc)
+        {
+            factoryWithConventionVerification.Register(factoryFunc);
+            factoryWithNoConventionVerification.Register(factoryFunc);
+            return this;
+        }
+        
+
+        public ServiceFactoryBuilder WithService<TContract, TClientContract>(Func<TClientContract> factoryFunc)
+        {
+            try
+            {
+                factoryWithConventionVerification.Register<TContract, TClientContract>(factoryFunc);
+            }
+            // Convention verification may throw, but that just means we're probably going to use
+            // the other factory anyway, so we don't care!
+            catch
+            {
+            }
+
+            factoryWithNoConventionVerification.Register<TContract, TClientContract>(factoryFunc);
+            return this;
+        }
+
+        public ServiceFactoryBuilder WithConventionVerificationDisabled()
+        {
+            _conventionVerificationDisabled = true;
+            return this;
+        }
+
+        public IServiceFactory Build()
+        {
+            if (_conventionVerificationDisabled)
+            {
+                return factoryWithNoConventionVerification;
+            }
+            else
+            {
+                return factoryWithConventionVerification;
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Builders/ServiceFactoryBuilder.cs
+++ b/source/Halibut.Tests/Builders/ServiceFactoryBuilder.cs
@@ -8,7 +8,7 @@ namespace Halibut.Tests.Builders
     {
         bool _conventionVerificationDisabled;
         DelegateServiceFactory factoryWithConventionVerification = new();
-        NaiveDelegateServiceFactory factoryWithNoConventionVerification = new();
+        NoSanityCheckingDelegateServiceFactory factoryWithNoConventionVerification = new();
         
 
         public ServiceFactoryBuilder WithService<TContract>(Func<TContract> factoryFunc)

--- a/source/Halibut.Tests/ServiceModel/ServiceInvokerFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/ServiceInvokerFixture.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Exceptions;
 using Halibut.ServiceModel;
+using Halibut.Tests.Builders;
 using Halibut.Tests.Support;
 using Halibut.Tests.Util;
 using Halibut.TestUtils.Contracts;
@@ -17,8 +17,9 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public void InvokeWithParams()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .Register<IEchoService>(() => new EchoService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithService<IEchoService>(() => new EchoService())
+                .Build();
 
             var value = Some.RandomAsciiStringOfLength(8);
             var sut = new ServiceInvoker(serviceFactory);
@@ -36,8 +37,9 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public void InvokeWithNoParams()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .Register<ICountingService>(() => new CountingService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithService<ICountingService>(() => new CountingService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var request = new RequestMessage
@@ -53,8 +55,9 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithParamsOnAsyncService()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .Register<IEchoService, IAsyncEchoService>(() => new AsyncEchoService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithService<IEchoService, IAsyncEchoService>(() => new AsyncEchoService())
+                .Build();
 
             var value = Some.RandomAsciiStringOfLength(8);
             var sut = new ServiceInvoker(serviceFactory);
@@ -72,8 +75,9 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithNoParamsOnAsyncService()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .Register<ICountingService, IAsyncCountingService>(() => new AsyncCountingService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithService<ICountingService, IAsyncCountingService>(() => new AsyncCountingService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var request = new RequestMessage
@@ -89,8 +93,9 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithParamsOnSyncService()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .Register<IEchoService>(() => new EchoService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithService<IEchoService>(() => new EchoService())
+                .Build();
 
             var value = Some.RandomAsciiStringOfLength(8);
             var sut = new ServiceInvoker(serviceFactory);
@@ -108,8 +113,9 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithNoParamsOnSyncService()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .Register<ICountingService, IAsyncCountingService>(() => new AsyncCountingService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithService<ICountingService, IAsyncCountingService>(() => new AsyncCountingService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var request = new RequestMessage
@@ -125,8 +131,10 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithNoParams_AsyncServiceMissingSuffix()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithConventionVerificationDisabled()
+                .WithService<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var request = new RequestMessage()
@@ -141,8 +149,10 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithNoParams_AsyncServiceMissingCancellationToken()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithConventionVerificationDisabled()
+                .WithService<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var request = new RequestMessage()
@@ -157,8 +167,10 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithParams_AsyncServiceMissingSuffix()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithConventionVerificationDisabled()
+                .WithService<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var value = Some.RandomAsciiStringOfLength(8);
@@ -175,8 +187,10 @@ namespace Halibut.Tests.ServiceModel
         [Test]
         public async Task AsyncInvokeWithParams_AsyncServiceMissingCancellationToken()
         {
-            var serviceFactory = new DelegateServiceFactory()
-                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+            var serviceFactory = new ServiceFactoryBuilder()
+                .WithConventionVerificationDisabled()
+                .WithService<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService())
+                .Build();
 
             var sut = new ServiceInvoker(serviceFactory);
             var request = new RequestMessage()

--- a/source/Halibut.Tests/ServiceModel/ServiceInvokerFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/ServiceInvokerFixture.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Exceptions;
+using Halibut.ServiceModel;
+using Halibut.Tests.Support;
+using Halibut.Tests.Util;
+using Halibut.TestUtils.Contracts;
+using Halibut.Transport.Protocol;
+using NUnit.Framework;
+
+namespace Halibut.Tests.ServiceModel
+{
+        
+    public class ServiceInvokerFixture : BaseTest
+    {
+        [Test]
+        public void InvokeWithParams()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .Register<IEchoService>(() => new EchoService());
+
+            var value = Some.RandomAsciiStringOfLength(8);
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage
+            {
+                ServiceName = nameof(IEchoService),
+                MethodName = nameof(IEchoService.SayHello),
+                Params = new[] { value }
+            };
+
+            var response = sut.Invoke(request);
+            response.Result.Should().Be($"{value}...");
+        }
+        
+        [Test]
+        public void InvokeWithNoParams()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .Register<ICountingService>(() => new CountingService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage
+            {
+                ServiceName = nameof(ICountingService),
+                MethodName = nameof(ICountingService.Increment)
+            };
+
+            var response = sut.Invoke(request);
+            response.Result.Should().Be(1);
+        }
+        
+        [Test]
+        public async Task AsyncInvokeWithParamsOnAsyncService()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .Register<IEchoService, IAsyncEchoService>(() => new AsyncEchoService());
+
+            var value = Some.RandomAsciiStringOfLength(8);
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage
+            {
+                ServiceName = nameof(IEchoService),
+                MethodName = nameof(IEchoService.SayHello),
+                Params = new[] { value }
+            };
+
+            var response = await sut.InvokeAsync(request);
+            response.Result.Should().Be($"{value}Async...");
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithNoParamsOnAsyncService()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .Register<ICountingService, IAsyncCountingService>(() => new AsyncCountingService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage
+            {
+                ServiceName = nameof(ICountingService),
+                MethodName = nameof(ICountingService.Increment)
+            };
+
+            var response = await sut.InvokeAsync(request);
+            response.Result.Should().Be(1);
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithParamsOnSyncService()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .Register<IEchoService>(() => new EchoService());
+
+            var value = Some.RandomAsciiStringOfLength(8);
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage
+            {
+                ServiceName = nameof(IEchoService),
+                MethodName = nameof(IEchoService.SayHello),
+                Params = new[] { value }
+            };
+
+            var response = await sut.InvokeAsync(request);
+            response.Result.Should().Be($"{value}...");
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithNoParamsOnSyncService()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .Register<ICountingService, IAsyncCountingService>(() => new AsyncCountingService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage
+            {
+                ServiceName = nameof(ICountingService),
+                MethodName = nameof(ICountingService.Increment)
+            };
+
+            var response = await sut.InvokeAsync(request);
+            response.Result.Should().Be(1);
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithNoParams_AsyncServiceMissingSuffix()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage()
+            {
+                ServiceName = nameof(IBrokenConventionService),
+                MethodName = nameof(IBrokenConventionService.GetRandomNumberMissingSuffix)
+            };
+
+            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithNoParams_AsyncServiceMissingCancellationToken()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage()
+            {
+                ServiceName = nameof(IBrokenConventionService),
+                MethodName = nameof(IBrokenConventionService.GetRandomNumberMissingCancellationToken)
+            };
+
+            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithParams_AsyncServiceMissingSuffix()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var value = Some.RandomAsciiStringOfLength(8);
+            var request = new RequestMessage()
+            {
+                ServiceName = nameof(IBrokenConventionService),
+                MethodName = nameof(IBrokenConventionService.SayHelloMissingSuffix),
+                Params = new[] { value }
+            };
+
+            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+        }
+
+        [Test]
+        public async Task AsyncInvokeWithParams_AsyncServiceMissingCancellationToken()
+        {
+            var serviceFactory = new DelegateServiceFactory()
+                .RegisterWithNoVerification<IBrokenConventionService, IAsyncBrokenConventionService>(() => new AsyncBrokenConventionService());
+
+            var sut = new ServiceInvoker(serviceFactory);
+            var request = new RequestMessage()
+            {
+                ServiceName = nameof(IBrokenConventionService),
+                MethodName = nameof(IBrokenConventionService.SayHelloMissingCancellationToken)
+            };
+
+            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -6,6 +6,7 @@ using Halibut.Diagnostics;
 using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.TestProxy;
+using Halibut.Tests.Builders;
 using Halibut.Tests.Support.Logging;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.TestServices.AsyncSyncCompat;
@@ -25,6 +26,7 @@ namespace Halibut.Tests.Support
 {
     public class LatestClientAndLatestServiceBuilder : IClientAndServiceBuilder
     {
+        ServiceFactoryBuilder serviceFactoryBuilder = new();
         IServiceFactory? serviceFactory;
         readonly ServiceConnectionType serviceConnectionType;
         readonly CertAndThumbprint serviceCertAndThumbprint;
@@ -114,6 +116,12 @@ namespace Halibut.Tests.Support
             return this;
         }
 
+        public LatestClientAndLatestServiceBuilder WithAsyncConventionsDisabled()
+        {
+            serviceFactoryBuilder = serviceFactoryBuilder.WithConventionVerificationDisabled();
+            return this;
+        }
+
         public LatestClientAndLatestServiceBuilder WithServiceFactory(IServiceFactory serviceFactory)
         {
             this.serviceFactory = serviceFactory;
@@ -122,9 +130,38 @@ namespace Halibut.Tests.Support
         
         public LatestClientAndLatestServiceBuilder WithService<TContract>(Func<TContract> implementation)
         {
-            if (serviceFactory == null) serviceFactory = new DelegateServiceFactory();
-            if (serviceFactory is not DelegateServiceFactory) throw new Exception("WithService can only be used with a delegate service factory");
-            (serviceFactory as DelegateServiceFactory)?.Register(implementation);
+            serviceFactoryBuilder.WithService(implementation);
+            
+            if (serviceFactory != null)
+            {
+                if (serviceFactory is DelegateServiceFactory delegateServiceFactory)
+                {
+                    delegateServiceFactory.Register(implementation);
+                }
+                else
+                {
+                    throw new Exception("WithService can only be used with a custom ServiceFactory if it is a DelegateServiceFactory");
+                }
+            }
+
+            return this;
+        }
+
+        public LatestClientAndLatestServiceBuilder WithAsyncService<TContract, TClientContract>(Func<TClientContract> implementation)
+        {
+            serviceFactoryBuilder.WithService<TContract, TClientContract>(implementation);
+            
+            if (serviceFactory != null)
+            {
+                if (serviceFactory is DelegateServiceFactory delegateServiceFactory)
+                {
+                    delegateServiceFactory.Register<TContract, TClientContract>(implementation);
+                }
+                else
+                {
+                    throw new Exception("WithService can only be used with a custom ServiceFactory if it is a DelegateServiceFactory");
+                }
+            }
 
             return this;
         }
@@ -310,7 +347,7 @@ namespace Halibut.Tests.Support
             var logger = new SerilogLoggerBuilder().Build().ForContext<LatestClientAndLatestServiceBuilder>();
             CancellationTokenSource cancellationTokenSource = new();
             
-            serviceFactory ??= new DelegateServiceFactory();
+            serviceFactory ??= serviceFactoryBuilder.Build();
             var octopusLogFactory = BuildClientLogger();
 
             var factory = CreatePendingRequestQueueFactory(octopusLogFactory);

--- a/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
@@ -71,7 +71,7 @@ namespace Halibut.Tests.Transport.Protocol
             stream.NextReadReturns(new RequestMessage());
             stream.SetNumberOfReads(1);
 
-            await protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")), CancellationToken.None);
+            await protocol.ExchangeAsServerAsync(req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")), CancellationToken.None);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -156,7 +156,7 @@ namespace Halibut.Tests.Transport.Protocol
             stream.NextReadReturns(new RequestMessage());
             stream.NextReadReturns(new RequestMessage());
 
-            await protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")), CancellationToken.None);
+            await protocol.ExchangeAsServerAsync(req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), ri => new PendingRequestQueue(new InMemoryConnectionLog("x")), CancellationToken.None);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -248,7 +248,7 @@ namespace Halibut.Tests.Transport.Protocol
             requestQueue.DequeueAsync(CancellationToken.None).Returns(ci => queue.Count > 0 ? queue.Dequeue() : null);
             stream.SetNumberOfReads(2);
 
-            await protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue, CancellationToken.None);
+            await protocol.ExchangeAsServerAsync(req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), ri => requestQueue, CancellationToken.None);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId
@@ -373,13 +373,13 @@ namespace Halibut.Tests.Transport.Protocol
             queue.Enqueue(new RequestMessage());
             stream.SetNumberOfReads(2);
 
-            await protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue, CancellationToken.None);
+            await protocol.ExchangeAsServerAsync(req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), ri => requestQueue, CancellationToken.None);
 
             queue.Enqueue(new RequestMessage());
 
             stream.SetNumberOfReads(1);
 
-            await protocol.ExchangeAsServerAsync(req => ResponseMessage.FromException(req, new Exception("Divide by zero")), ri => requestQueue, CancellationToken.None);
+            await protocol.ExchangeAsServerAsync(req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), ri => requestQueue, CancellationToken.None);
 
             AssertOutput(@"
 <-- MX-CLIENT || MX-SUBSCRIBE subscriptionId

--- a/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
@@ -185,7 +185,7 @@ namespace Halibut.Tests.Transport.Protocol
 #pragma warning disable CS0612
             await syncOrAsync
                 .WhenSync(() => protocol.ExchangeAsSubscriber(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5))
-                .WhenAsync(async () => await protocol.ExchangeAsSubscriberAsync(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5, CancellationToken.None));
+                .WhenAsync(async () => await protocol.ExchangeAsSubscriberAsync(new Uri("poll://12831"), req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), 5, CancellationToken.None));
 #pragma warning restore CS0612
             
             AssertOutput(@"
@@ -280,9 +280,9 @@ namespace Halibut.Tests.Transport.Protocol
                 })
                 .WhenAsync(async () =>
                 {
-                    await protocol.ExchangeAsSubscriberAsync(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5, CancellationToken.None);
+                    await protocol.ExchangeAsSubscriberAsync(new Uri("poll://12831"), req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), 5, CancellationToken.None);
                     stream.NextReadReturns(new RequestMessage());
-                    await protocol.ExchangeAsSubscriberAsync(new Uri("poll://12831"), req => ResponseMessage.FromException(req, new Exception("Divide by zero")), 5, CancellationToken.None);
+                    await protocol.ExchangeAsSubscriberAsync(new Uri("poll://12831"), req => Task.FromResult(ResponseMessage.FromException(req, new Exception("Divide by zero"))), 5, CancellationToken.None);
                 });
 
             AssertOutput(@"

--- a/source/Halibut.Tests/Util/NaiveDelegateServiceFactory.cs
+++ b/source/Halibut.Tests/Util/NaiveDelegateServiceFactory.cs
@@ -1,32 +1,32 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Halibut.Exceptions;
-using Halibut.Util;
+using Halibut.ServiceModel;
 
-namespace Halibut.ServiceModel
+namespace Halibut.Tests.Util
 {
-    public class DelegateServiceFactory : IServiceFactory
+    // Just like the DelegateServiceFactory, but without any sanity checking
+    // when registering async implementations of sync services.
+    public class NaiveDelegateServiceFactory : IServiceFactory
     {
-        readonly Dictionary<string, Func<object>> services = new Dictionary<string, Func<object>>(StringComparer.OrdinalIgnoreCase);
-        readonly HashSet<Type> serviceTypes = new HashSet<Type>();
+        readonly Dictionary<string, Func<object>> services = new(StringComparer.OrdinalIgnoreCase);
+        readonly HashSet<Type> serviceTypes = new();
 
-        public DelegateServiceFactory Register<TContract>(Func<TContract> implementation)
+        public NaiveDelegateServiceFactory Register<TContract>(Func<TContract> implementation)
         {
             var serviceType = typeof(TContract);
             services.Add(serviceType.Name, () => implementation());
             lock (serviceTypes)
             {
-                serviceTypes.Add(serviceType);    
+                serviceTypes.Add(serviceType);
             }
 
             return this;
         }
 
-        public DelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
+        public NaiveDelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
         {
-            AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<TContract, TAsyncContract>();
-            
             var serviceType = typeof(TContract);
             services.Add(serviceType.Name, () => implementation());
             lock (serviceTypes)
@@ -58,40 +58,36 @@ namespace Halibut.ServiceModel
             var service = serviceBuilder();
             return new Lease(service);
         }
-        
+
         public IReadOnlyList<Type> RegisteredServiceTypes
         {
             get
             {
                 lock (serviceTypes)
                 {
-                    return serviceTypes.ToList();    
+                    return serviceTypes.ToList();
                 }
             }
         }
+    }
 
-        #region Nested type: Lease
+    class Lease : IServiceLease
+    {
+        readonly object service;
 
-        class Lease : IServiceLease
+        public Lease(object service)
         {
-            readonly object service;
-
-            public Lease(object service)
-            {
-                this.service = service;
-            }
-
-            public object Service => service;
-
-            public void Dispose()
-            {
-                if (service is IDisposable disposable)
-                {
-                    disposable.Dispose();
-                }
-            }
+            this.service = service;
         }
 
-        #endregion
+        public object Service => service;
+
+        public void Dispose()
+        {
+            if (service is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
     }
 }

--- a/source/Halibut.Tests/Util/NoSanityCheckingDelegateServiceFactory.cs
+++ b/source/Halibut.Tests/Util/NoSanityCheckingDelegateServiceFactory.cs
@@ -8,12 +8,12 @@ namespace Halibut.Tests.Util
 {
     // Just like the DelegateServiceFactory, but without any sanity checking
     // when registering async implementations of sync services.
-    public class NaiveDelegateServiceFactory : IServiceFactory
+    public class NoSanityCheckingDelegateServiceFactory : IServiceFactory
     {
         readonly Dictionary<string, Func<object>> services = new(StringComparer.OrdinalIgnoreCase);
         readonly HashSet<Type> serviceTypes = new();
 
-        public NaiveDelegateServiceFactory Register<TContract>(Func<TContract> implementation)
+        public NoSanityCheckingDelegateServiceFactory Register<TContract>(Func<TContract> implementation)
         {
             var serviceType = typeof(TContract);
             services.Add(serviceType.Name, () => implementation());
@@ -25,7 +25,7 @@ namespace Halibut.Tests.Util
             return this;
         }
 
-        public NaiveDelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
+        public NoSanityCheckingDelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
         {
             var serviceType = typeof(TContract);
             services.Add(serviceType.Name, () => implementation());

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -181,7 +181,7 @@ namespace Halibut
 
         Task HandleMessageAsync(MessageExchangeProtocol protocol, CancellationToken cancellationToken)
         {
-            return protocol.ExchangeAsServerAsync(HandleIncomingRequest, id => GetQueue(id.SubscriptionId), cancellationToken);
+            return protocol.ExchangeAsServerAsync(HandleIncomingRequestAsync, id => GetQueue(id.SubscriptionId), cancellationToken);
         }
 
         public void Poll(Uri subscription, ServiceEndPoint endPoint)
@@ -413,6 +413,11 @@ namespace Halibut
         ResponseMessage HandleIncomingRequest(RequestMessage request)
         {
             return invoker.Invoke(request);
+        }
+
+        async Task<ResponseMessage> HandleIncomingRequestAsync(RequestMessage request)
+        {
+            return await invoker.InvokeAsync(request);
         }
 
         public void Trust(string clientThumbprint)

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -205,7 +205,15 @@ namespace Halibut
             {
                 client = new SecureClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, AsyncHalibutFeature, TimeoutsAndLimits, log, connectionManager);
             }
-            pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log, cancellationToken, pollingReconnectRetryPolicy, AsyncHalibutFeature));
+
+            if (AsyncHalibutFeature.IsEnabled())
+            {
+                pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequestAsync, log, cancellationToken, pollingReconnectRetryPolicy, AsyncHalibutFeature));
+            }
+            else
+            {
+                pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log, cancellationToken, pollingReconnectRetryPolicy, AsyncHalibutFeature));
+            }
         }
 
         [Obsolete]

--- a/source/Halibut/ServiceModel/AsyncCompatibilityHelper.cs
+++ b/source/Halibut/ServiceModel/AsyncCompatibilityHelper.cs
@@ -40,5 +40,10 @@ namespace Halibut.ServiceModel
 
             return syncMethodInfo;
         }
+
+        public static string GetAsyncMethodName(string methodName)
+        {
+            return methodName + "Async";
+        }
     }
 }

--- a/source/Halibut/ServiceModel/DelegateServiceFactory.cs
+++ b/source/Halibut/ServiceModel/DelegateServiceFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Halibut.Exceptions;
+using Halibut.Util;
 
 namespace Halibut.ServiceModel
 {
@@ -17,6 +18,33 @@ namespace Halibut.ServiceModel
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);    
+            }
+
+            return this;
+        }
+
+        public DelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
+        {
+            AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<TContract, TAsyncContract>();
+            
+            var serviceType = typeof(TContract);
+            services.Add(serviceType.Name, () => implementation());
+            lock (serviceTypes)
+            {
+                serviceTypes.Add(serviceType);
+            }
+
+            return this;
+        }
+        
+        // Used for testing badly-registered sync/async contracts
+        internal DelegateServiceFactory RegisterWithNoVerification<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
+        {
+            var serviceType = typeof(TContract);
+            services.Add(serviceType.Name, () => implementation());
+            lock (serviceTypes)
+            {
+                serviceTypes.Add(serviceType);
             }
 
             return this;

--- a/source/Halibut/ServiceModel/IServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/IServiceInvoker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.ServiceModel
@@ -6,5 +7,6 @@ namespace Halibut.ServiceModel
     public interface IServiceInvoker
     {
         ResponseMessage Invoke(RequestMessage requestMessage);
+        Task<ResponseMessage> InvokeAsync(RequestMessage requestMessage);
     }
 }

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Halibut.Exceptions;
 using Halibut.Portability;
 using Halibut.Transport.Protocol;
@@ -36,9 +38,111 @@ namespace Halibut.ServiceModel
             }
         }
 
+        public async Task<ResponseMessage> InvokeAsync(RequestMessage requestMessage)
+        {
+            using var lease = factory.CreateService(requestMessage.ServiceName);
+            var methods = lease.Service.GetType().GetHalibutServiceMethods().Where(m => string.Equals(m.Name, requestMessage.MethodName, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (methods.Count != 0)
+            {
+                var method = SelectMethod(methods, requestMessage);
+                var args = GetArguments(requestMessage, method);
+                var result = method.Invoke(lease.Service, args);
+                return ResponseMessage.FromResult(requestMessage, result);
+            }
+
+            var asyncMethodName = requestMessage.MethodName + "Async";
+            var asyncMethods = lease.Service.GetType().GetHalibutServiceMethods().Where(m => string.Equals(m.Name, asyncMethodName, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (asyncMethods.Count == 0)
+            {
+                throw new MethodNotFoundHalibutClientException(string.Format("Method {0}::{1} not found", lease.Service.GetType().FullName, asyncMethodName));
+            }
+
+            var asyncMethod = SelectAsyncMethod(asyncMethods, requestMessage);
+            var asyncArgs = GetArguments(requestMessage, asyncMethod);
+            asyncArgs[asyncArgs.Length - 1] = CancellationToken.None;
+            var asyncResult = await InvokeAsyncMethod(asyncMethod, lease.Service, asyncArgs);
+            return ResponseMessage.FromResult(requestMessage, asyncResult);
+        }
+
+        static MethodInfo SelectAsyncMethod(IList<MethodInfo> methods, RequestMessage requestMessage)
+        {
+            var argumentTypes = requestMessage.Params?.Select(s => s == null ? null : s.GetType()).ToList() ?? new List<Type>();
+
+            var matches = new List<MethodInfo>();
+
+            foreach (var method in methods)
+            {
+                var parameters = method.GetParameters();
+                if (parameters.Any() && parameters.Last().ParameterType == typeof(CancellationToken))
+                {
+                    parameters = parameters.Take(parameters.Length - 1).ToArray();
+                }
+                else
+                {
+                    continue;
+                }
+
+                if (parameters.Length != argumentTypes.Count)
+                {
+                    continue;
+                }
+
+                var isMatch = true;
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var paramType = parameters[i].ParameterType;
+                    var argType = argumentTypes[i];
+                    if (argType == null && paramType.IsValueType())
+                    {
+                        isMatch = false;
+                        break;
+                    }
+
+                    if (argType != null && !paramType.IsAssignableFrom(argType))
+                    {
+                        isMatch = false;
+                        break;
+                    }
+                }
+
+                if (isMatch)
+                {
+                    matches.Add(method);
+                }
+            }
+
+            if (matches.Count == 1)
+                return matches[0];
+
+            var message = new StringBuilder();
+            if (matches.Count > 1)
+            {
+                message.AppendLine("More than one possible match for the requested service method was found given the argument types. The matches were:");
+
+                foreach (var match in matches)
+                {
+                    message.AppendLine(" - " + match);
+                }
+            }
+            else
+            {
+                message.AppendLine("Could not decide which candidate to call out of the following methods:");
+
+                foreach (var match in methods)
+                {
+                    message.AppendLine(" - " + match);
+                }
+            }
+
+            message.AppendLine("The request arguments were:");
+            message.AppendLine(string.Join(", ", argumentTypes.Select(t => t == null ? "<null>" : t.Name)));
+
+            throw new AmbiguousMethodMatchHalibutClientException(message.ToString(), new AmbiguousMatchException(message.ToString()));
+        }
+
         static MethodInfo SelectMethod(IList<MethodInfo> methods, RequestMessage requestMessage)
         {
-            var argumentTypes = requestMessage.Params.Select(s => s == null ? null : s.GetType()).ToList();
+            var argumentTypes = requestMessage.Params?.Select(s => s == null ? null : s.GetType()).ToList() ?? new List<Type>();
 
             var matches = new List<MethodInfo>();
 
@@ -103,15 +207,24 @@ namespace Halibut.ServiceModel
             throw new AmbiguousMethodMatchHalibutClientException(message.ToString(), new AmbiguousMatchException(message.ToString()));
         }
 
+        async Task<object> InvokeAsyncMethod(MethodInfo method, object obj, params object[] parameters)
+        {
+            var task = (Task)method.Invoke(obj, parameters);
+            await task.ConfigureAwait(false);
+            var resultProperty = task.GetType().GetProperty("Result");
+            return resultProperty.GetValue(task);
+        }
+
         public static object[] GetArguments(RequestMessage requestMessage, MethodInfo methodInfo)
         {
             var methodParams = methodInfo.GetParameters();
             var args = new object[methodParams.Length];
+            var requestMessageParams = requestMessage.Params ?? Array.Empty<ParameterInfo>();
             for (var i = 0; i < methodParams.Length; i++)
             {
-                if (i >= requestMessage.Params.Length) continue;
+                if (i >= requestMessageParams.Length) continue;
 
-                var jsonArg = requestMessage.Params[i];
+                var jsonArg = requestMessageParams[i];
                 args[i] = jsonArg;
             }
 

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -216,7 +216,7 @@ namespace Halibut.ServiceModel
             // If the return type is not Task or Task<T>, then shrug and explode!
             if (!typeof(Task).IsAssignableFrom(returnType))
             {
-                throw new Exception();
+                throw new InvalidOperationException($"InvokeAsyncMethod cannot be called on a method that does not return Task or Task<T> ({returnType.Name})");
             }
 
             var task = (Task)method.Invoke(obj, parameters);

--- a/source/Halibut/Util/AsyncServiceVerifier.cs
+++ b/source/Halibut/Util/AsyncServiceVerifier.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Exceptions;
+
+namespace Halibut.Util
+{
+    public class AsyncServiceVerifier
+    {
+        /// <summary>
+        /// This method enforces that all methods on the sync service have a corresponding method on the async service which adheres to the following conventions:
+        /// (1) Name must contain 'Async' suffix
+        /// (2) Return Type must be Task (if sync method return type is 'void') or Task&lt;T&gt; (where T is sync method return type)
+        /// (3) Last parameter must be of type CancellationToken
+        /// </summary>
+        /// <typeparam name="TSyncService">The type of the sync service</typeparam>
+        /// <typeparam name="TAsyncService">The type of the async service</typeparam>
+        /// <exception cref="NoMatchingServiceOrMethodHalibutClientException">Thrown when the async service does not map to the sync service according to the expected conventions.</exception>
+        public static void VerifyAsyncSurfaceAreaFollowsConventions<TSyncService, TAsyncService>()
+        {
+            const string Async = "Async";
+            
+            Type syncService = typeof(TSyncService);
+            Type asyncService = typeof(TAsyncService);
+            
+            var syncServiceMethods = syncService.GetMethods();
+
+            bool ReturnTypesMatch(MethodInfo syncMethod, MethodInfo asyncMethod)
+            {
+                if (syncMethod.ReturnType == typeof(void))
+                {
+                    return typeof(Task).IsAssignableFrom(asyncMethod.ReturnType);
+                }
+
+                return typeof(Task<>).MakeGenericType(syncMethod.ReturnType)
+                    .IsAssignableFrom(asyncMethod.ReturnType);
+            }
+
+            foreach (var syncMethod in syncServiceMethods)
+            {
+                var asyncMethod = asyncService.GetMethod(
+                    syncMethod.Name + Async,
+                    syncMethod.GetParameters().Select(p => p.ParameterType).Append(typeof(CancellationToken)).ToArray());
+
+                if (asyncMethod != null && ReturnTypesMatch(syncMethod, asyncMethod))
+                {
+                    continue;
+                }
+
+                throw new NoMatchingServiceOrMethodHalibutClientException(
+                    $"The service '{asyncService.Name} does not follow the conventions for providing an async implementation of '{syncService.Name}.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a `InvokeAsync` method to `IServiceInvoker` and `ServiceInvoker`, as part of [sc-53211]. This allows the ServiceInvoker to invoke async implementations of services with sync interfaces.

Upon succesfully acquiring a lease from the `IServiceFactory`, `InvokeAsync` will search for an async method on the registered service which matches the name of requested method, but also follows these conventions:
* Must end with `Async`
* Must have a `CancellationToken` as its last argument
* Must return either `Task` or `Task<T>`, depending on whether the originally requested method returns `void` or a result.

This feature is dependant on the implementation of `IServiceFactory` being used (Octopus Server and Tentacle use their own implementations), but we can now register async implementations of sync services in the `DelegateServiceFactory`:

```
var serviceFactory = new DelegateServiceFactory();
serviceFactory.Register<IMySyncService, IMyAsyncService>(() => new MyAsyncServiceImpl());
```

In the above example, there is no formal relationship between `IMySyncService` and `IMyAsyncService`, but the async interface must replicate the sync interface whilst adhering to the conventions listed above.

The `DelegateServiceFactory` will throw an exception upon registration if the async interface does not follow the conventions, via the new `AsyncServiceVerifier` helper class.

### Main changes:
* Add async code path to `IServiceInvoker`
* Add `AsyncServiceVerifier` for verifying the mapping between sync and async service interfaces.
* Add tests for ServiceInvoker and AsyncServiceVerifier
* Fixed bug in sync code of ServiceInvoker, where method lookup could fail if params array was `null` rather than empty
* Added overload method `DelegateServiceFactory` to allow registering async implementations against a sync service interface, and verify that mapping conforms to conventions.
* Added additional internal method to `DelegateServiceFactory` for purposefully registering non-comforming sync/async service interfaces (used in testing)