### PR TITLE
Support HalibutTimeoutsAndLimits in SecureConnection

### DIFF
--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -10,6 +10,7 @@ using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Transport;
 using Halibut.Transport.Protocol;
+using Halibut.Util;
 using NSubstitute;
 using NUnit.Framework;
 

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -12,6 +12,7 @@ using Halibut.Tests.Support.TestAttributes;
 using Halibut.TestUtils.Contracts;
 using Halibut.Transport;
 using Halibut.Transport.Protocol;
+using Halibut.Util;
 using NSubstitute;
 using NUnit.Framework;
 using ILog = Halibut.Diagnostics.ILog;
@@ -48,6 +49,10 @@ namespace Halibut.Tests.Transport
         [SyncAndAsync]
         public async Task SecureClientClearsPoolWhenAllConnectionsCorrupt(SyncOrAsync syncOrAsync)
         {
+            AsyncHalibutFeature asyncHalibutFeature = syncOrAsync == SyncOrAsync.Sync ? AsyncHalibutFeature.Disabled : AsyncHalibutFeature.Enabled;
+            HalibutTimeoutsAndLimits halibutTimeoutsAndLimits = null;
+            if (asyncHalibutFeature.IsEnabled()) halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
+
             using var connectionManager = syncOrAsync.CreateConnectionManager();
             var stream = Substitute.For<IMessageExchangeStream>();
 
@@ -70,7 +75,7 @@ namespace Halibut.Tests.Transport
                 Params = new object[] { "Fred" }
             };
 
-            var secureClient = new SecureListeningClient((s, l)  => GetProtocol(s, l, syncOrAsync), endpoint, Certificates.Octopus, new HalibutTimeoutsAndLimits(), log, connectionManager);
+            var secureClient = new SecureListeningClient((s, l)  => GetProtocol(s, l, syncOrAsync), endpoint, Certificates.Octopus, asyncHalibutFeature, halibutTimeoutsAndLimits, log, connectionManager);
             ResponseMessage response = null!;
 
             using var requestCancellationTokens = new RequestCancellationTokens(CancellationToken.None, CancellationToken.None);

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -196,14 +196,14 @@ namespace Halibut
             if (endPoint.IsWebSocketEndpoint)
             {
 #if SUPPORTS_WEB_SOCKET_CLIENT
-                client = new SecureWebSocketClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, TimeoutsAndLimits, log, connectionManager);
+                client = new SecureWebSocketClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, AsyncHalibutFeature, TimeoutsAndLimits, log, connectionManager);
 #else
                 throw new NotSupportedException("The netstandard build of this library cannot act as the client in a WebSocket polling setup");
 #endif
             }
             else
             {
-                client = new SecureClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, TimeoutsAndLimits, log, connectionManager);
+                client = new SecureClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, AsyncHalibutFeature, TimeoutsAndLimits, log, connectionManager);
             }
             pollingClients.Add(new PollingClient(subscription, client, HandleIncomingRequest, log, cancellationToken, pollingReconnectRetryPolicy, AsyncHalibutFeature));
         }
@@ -372,7 +372,7 @@ namespace Halibut
         [Obsolete]
         ResponseMessage SendOutgoingHttpsRequest(RequestMessage request, CancellationToken cancellationToken)
         {
-            var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, TimeoutsAndLimits, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
+            var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, AsyncHalibutFeature, TimeoutsAndLimits, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
 
             ResponseMessage response = null;
             client.ExecuteTransaction(protocol =>
@@ -384,7 +384,7 @@ namespace Halibut
 
         async Task<ResponseMessage> SendOutgoingHttpsRequestAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
         {
-            var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, TimeoutsAndLimits, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
+            var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, AsyncHalibutFeature, TimeoutsAndLimits, logs.ForEndpoint(request.Destination.BaseUri), connectionManager);
 
             ResponseMessage response = null;
 

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -21,15 +21,23 @@ namespace Halibut.Transport
         readonly IConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
         readonly ExchangeProtocolBuilder protocolBuilder;
+        readonly AsyncHalibutFeature asyncHalibutFeature;
         readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
-
-        public SecureClient(ExchangeProtocolBuilder protocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log, IConnectionManager connectionManager)
+        
+        public SecureClient(ExchangeProtocolBuilder protocolBuilder, 
+            ServiceEndPoint serviceEndpoint,
+            X509Certificate2 clientCertificate,
+            AsyncHalibutFeature asyncHalibutFeature,
+            HalibutTimeoutsAndLimits halibutTimeoutsAndLimits,
+            ILog log,
+            IConnectionManager connectionManager)
         {
             this.protocolBuilder = protocolBuilder;
             this.ServiceEndpoint = serviceEndpoint;
             this.clientCertificate = clientCertificate;
             this.log = log;
             this.connectionManager = connectionManager;
+            this.asyncHalibutFeature = asyncHalibutFeature;
             this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
 
@@ -60,7 +68,7 @@ namespace Halibut.Transport
                     IConnection connection = null;
                     try
                     {
-                        connection = connectionManager.AcquireConnection(protocolBuilder, new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), ServiceEndpoint, log, cancellationToken);
+                        connection = connectionManager.AcquireConnection(protocolBuilder, new TcpConnectionFactory(clientCertificate, asyncHalibutFeature, halibutTimeoutsAndLimits), ServiceEndpoint, log, cancellationToken);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;
@@ -160,7 +168,7 @@ namespace Halibut.Transport
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
                             protocolBuilder, 
-                            new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
+                            new TcpConnectionFactory(clientCertificate, asyncHalibutFeature, halibutTimeoutsAndLimits), 
                             ServiceEndpoint,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -20,15 +20,23 @@ namespace Halibut.Transport
         readonly IConnectionManager connectionManager;
         readonly X509Certificate2 clientCertificate;
         readonly ExchangeProtocolBuilder exchangeProtocolBuilder;
-        HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
-
-        public SecureListeningClient(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log, IConnectionManager connectionManager)
+        readonly AsyncHalibutFeature asyncHalibutFeature;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
+        
+        public SecureListeningClient(ExchangeProtocolBuilder exchangeProtocolBuilder,
+            ServiceEndPoint serviceEndpoint,
+            X509Certificate2 clientCertificate,
+            AsyncHalibutFeature asyncHalibutFeature,
+            HalibutTimeoutsAndLimits halibutTimeoutsAndLimits,
+            ILog log,
+            IConnectionManager connectionManager)
         {
             this.exchangeProtocolBuilder = exchangeProtocolBuilder;
             this.ServiceEndpoint = serviceEndpoint;
             this.clientCertificate = clientCertificate;
             this.log = log;
             this.connectionManager = connectionManager;
+            this.asyncHalibutFeature = asyncHalibutFeature;
             this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
 
@@ -59,7 +67,7 @@ namespace Halibut.Transport
                     IConnection connection = null;
                     try
                     {
-                        connection = connectionManager.AcquireConnection(exchangeProtocolBuilder, new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), ServiceEndpoint, log, cancellationToken);
+                        connection = connectionManager.AcquireConnection(exchangeProtocolBuilder, new TcpConnectionFactory(clientCertificate, asyncHalibutFeature, halibutTimeoutsAndLimits), ServiceEndpoint, log, cancellationToken);
 
                         // Beyond this point, we have no way to be certain that the server hasn't tried to process a request; therefore, we can't retry after this point
                         retryAllowed = false;
@@ -169,8 +177,8 @@ namespace Halibut.Transport
                     try
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
-                            exchangeProtocolBuilder, 
-                            new TcpConnectionFactory(clientCertificate, halibutTimeoutsAndLimits), 
+                            exchangeProtocolBuilder,
+                            new TcpConnectionFactory(clientCertificate, asyncHalibutFeature, halibutTimeoutsAndLimits), 
                             ServiceEndpoint,
                             log, 
                             requestCancellationTokens.LinkedCancellationToken).ConfigureAwait(false);

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -11,6 +11,7 @@ using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
 using Halibut.Transport.Proxy;
 using Halibut.Transport.Streams;
+using Halibut.Util;
 
 namespace Halibut.Transport
 {
@@ -19,12 +20,14 @@ namespace Halibut.Transport
         static readonly byte[] MxLine = Encoding.ASCII.GetBytes("MX" + Environment.NewLine + Environment.NewLine);
 
         readonly X509Certificate2 clientCertificate;
+        readonly AsyncHalibutFeature asyncHalibutFeature;
         readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
 
-        public TcpConnectionFactory(X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        public TcpConnectionFactory(X509Certificate2 clientCertificate, AsyncHalibutFeature asyncHalibutFeature, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             this.clientCertificate = clientCertificate;
             this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+            this.asyncHalibutFeature = asyncHalibutFeature;
         }
 
         [Obsolete]
@@ -46,7 +49,7 @@ namespace Halibut.Transport
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
 
-            return new SecureConnection(client, ssl, exchangeProtocolBuilder, log);
+            return new SecureConnection(client, ssl, exchangeProtocolBuilder, asyncHalibutFeature, halibutTimeoutsAndLimits, log);
         }
         
         public async Task<IConnection> EstablishNewConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
@@ -76,7 +79,7 @@ namespace Halibut.Transport
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
 
-            return new SecureConnection(client, ssl, exchangeProtocolBuilder, log);
+            return new SecureConnection(client, ssl, exchangeProtocolBuilder, asyncHalibutFeature, halibutTimeoutsAndLimits, log);
         }
 
         [Obsolete]

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -9,6 +9,7 @@ using Halibut.Diagnostics;
 using Halibut.Transport.Protocol;
 using Halibut.Transport.Proxy;
 using Halibut.Transport.Proxy.Exceptions;
+using Halibut.Util;
 
 namespace Halibut.Transport
 {
@@ -16,11 +17,15 @@ namespace Halibut.Transport
     {
         readonly X509Certificate2 clientCertificate;
         readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
+        readonly AsyncHalibutFeature asyncHalibutFeature;
 
-        public WebSocketConnectionFactory(X509Certificate2 clientCertificate, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        public WebSocketConnectionFactory(X509Certificate2 clientCertificate,
+            AsyncHalibutFeature asyncHalibutFeature,
+            HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             this.clientCertificate = clientCertificate;
             this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+            this.asyncHalibutFeature = asyncHalibutFeature;
         }
 
         [Obsolete]
@@ -39,7 +44,7 @@ namespace Halibut.Transport
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}", serviceEndpoint.BaseUri, serviceEndpoint.RemoteThumbprint);
 
-            return new SecureConnection(client, stream, exchangeProtocolBuilder, log);
+            return new SecureConnection(client, stream, exchangeProtocolBuilder, asyncHalibutFeature, halibutTimeoutsAndLimits, log);
         }
         
         public async Task<IConnection> EstablishNewConnectionAsync(ExchangeProtocolBuilder exchangeProtocolBuilder, ServiceEndPoint serviceEndpoint, ILog log, CancellationToken cancellationToken)
@@ -57,7 +62,7 @@ namespace Halibut.Transport
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}", serviceEndpoint.BaseUri, serviceEndpoint.RemoteThumbprint);
 
-            return new SecureConnection(client, stream, exchangeProtocolBuilder, log);
+            return new SecureConnection(client, stream, exchangeProtocolBuilder,  asyncHalibutFeature, halibutTimeoutsAndLimits, log);
         }
 
         [Obsolete]


### PR DESCRIPTION
# Background

Fixes one of the TODOs left in https://github.com/OctopusDeploy/Halibut/pull/427

by making SecureConnection support the per runtime timeouts 

[SC-45207]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
