### PR TITLE
Enable websocket polling for netcore

### DIFF
--- a/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
+++ b/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
@@ -43,7 +43,7 @@
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
-        <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT;DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
+        <DefineConstants>$(DefineConstants);DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Halibut.Tests.DotMemory/MemoryFixture.cs
+++ b/source/Halibut.Tests.DotMemory/MemoryFixture.cs
@@ -59,10 +59,8 @@ namespace Halibut.Tests.DotMemory
                     RunPollingClient(server, Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint);
                 }
 
-#if SUPPORTS_WEB_SOCKET_CLIENT
                 for (var i = 0; i < NumberOfClients; i++)
                     RunWebSocketPollingClient(server, Certificates.TentaclePolling, Certificates.TentaclePollingPublicThumbprint, Certificates.OctopusPublicThumbprint);
-#endif
 
                 //https://dotnettools-support.jetbrains.com/hc/en-us/community/posts/360000088690-How-reproduce-DotMemory-s-Force-GC-button-s-behaviour-on-code-with-c-?page=1#community_comment_360000072750
                 for (var i = 0; i < 4; i++)

--- a/source/Halibut.Tests/BindCertificatesForAllTests.cs
+++ b/source/Halibut.Tests/BindCertificatesForAllTests.cs
@@ -11,9 +11,7 @@ namespace Halibut.Tests
             [OneTimeSetUp]
             public void GlobalSetup()
             {
-#if SUPPORTS_WEB_SOCKET_CLIENT
                 WebSocketSslCertificateHelper.AddSslCertToLocalStore();
-#endif
             }
         }
     }

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_WEB_SOCKET_CLIENT;DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
+    <DefineConstants>$(DefineConstants);DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Halibut.Tests/Support/ServiceConnectionType.cs
+++ b/source/Halibut.Tests/Support/ServiceConnectionType.cs
@@ -10,12 +10,10 @@ namespace Halibut.Tests.Support
     public static class ServiceConnectionTypes
     {
         public static ServiceConnectionType[] All => new[]
-            {
-               ServiceConnectionType.Listening,
-               ServiceConnectionType.Polling,
-#if SUPPORTS_WEB_SOCKET_CLIENT
-             ServiceConnectionType.PollingOverWebSocket
-#endif
+        {
+            ServiceConnectionType.Listening,
+            ServiceConnectionType.Polling,
+            ServiceConnectionType.PollingOverWebSocket
         };
 
         public static ServiceConnectionType[] AllExceptWebSockets => new[]

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
-    <DefineConstants>$(DefineConstants);HAS_REAL_PROXY;SUPPORTS_WEB_SOCKET_CLIENT</DefineConstants>
+    <DefineConstants>$(DefineConstants);HAS_REAL_PROXY</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -186,11 +186,7 @@ namespace Halibut
             var log = logs.ForEndpoint(endPoint.BaseUri);
             if (endPoint.IsWebSocketEndpoint)
             {
-#if SUPPORTS_WEB_SOCKET_CLIENT
                 client = new SecureWebSocketClient(ExchangeProtocolBuilder(), endPoint, serverCertificate, TimeoutsAndLimits, log, connectionManager);
-#else
-                throw new NotSupportedException("The netstandard build of this library cannot act as the client in a WebSocket polling setup");
-#endif
             }
             else
             {

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -4,7 +4,6 @@
 // See https://github.com/dotnet/corefx/issues/12038
 
 using Halibut.Util;
-#if SUPPORTS_WEB_SOCKET_CLIENT
 using System;
 using System.Diagnostics;
 using System.Net.Sockets;
@@ -255,4 +254,3 @@ namespace Halibut.Transport
         }
     }
 }
-#endif

--- a/source/Halibut/Transport/ServerCertificateInterceptor.cs
+++ b/source/Halibut/Transport/ServerCertificateInterceptor.cs
@@ -1,4 +1,3 @@
-#if SUPPORTS_WEB_SOCKET_CLIENT
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -69,4 +68,3 @@ namespace Halibut.Transport
         }
     }
 }
-#endif


### PR DESCRIPTION
# Background

Our team want to use this framework in a polling fashion over websockets. This is currently not supported in the dotnet6 package due to an issue with custom certificate handling in early dotnet core versions https://github.com/OctopusDeploy/Halibut/pull/47

This issue has since been fixed by exposing `ClientWebSocketOptions.RemoteCertificateValidationCallback` https://github.com/dotnet/corefx/pull/28141

# Results

Fixes https://github.com/OctopusDeploy/Halibut/issues/170

## Before

Polling with a websocket connection on dotnet6 would throw `NotSupportedException("The netstandard build of this library cannot act as the client in a WebSocket polling setup");`

## After

Polling with a websocket connection on net6 will now use `ClientWebSocketOptions.RemoteCertificateValidationCallback` to validate the remote certificate

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
