### PR TITLE
Create ApmToTapStream

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -75,8 +75,9 @@ namespace Halibut.Transport.Protocol
         {
             using var compressedByteCountingStream = new ByteCountingStream(stream, OnDispose.LeaveInputStreamOpen);
             using var compressedInMemoryBuffer = new WriteIntoMemoryBufferStream(compressedByteCountingStream, writeIntoMemoryLimitBytes, OnDispose.LeaveInputStreamOpen);
+            using var apmToTapStream = new ApmToTapStream(compressedInMemoryBuffer);
 
-            using (var zip = new DeflateStream(compressedInMemoryBuffer, CompressionMode.Compress, true))
+            using (var zip = new DeflateStream(apmToTapStream, CompressionMode.Compress, true))
             using (var bson = new BsonDataWriter(zip) { CloseOutput = false })
             {
                 // for the moment this MUST be object so that the $type property is included
@@ -201,8 +202,9 @@ namespace Halibut.Transport.Protocol
             {
                 using var compressedByteCountingStream = new ByteCountingStream(stream, OnDispose.LeaveInputStreamOpen);
 
+                using var apmToTapStream = new ApmToTapStream(compressedByteCountingStream);
                 
-                using var zip = new DeflateStream(compressedByteCountingStream, CompressionMode.Decompress, true);
+                using var zip = new DeflateStream(apmToTapStream, CompressionMode.Decompress, true);
                 using var decompressedByteCountingStream = new ByteCountingStream(zip, OnDispose.LeaveInputStreamOpen);
 
                 using var deflatedInMemoryStream = new ReadIntoMemoryBufferStream(decompressedByteCountingStream, readIntoMemoryLimitBytes, OnDispose.LeaveInputStreamOpen);

--- a/source/Halibut/Transport/Streams/ApmToTapStream.cs
+++ b/source/Halibut/Transport/Streams/ApmToTapStream.cs
@@ -1,0 +1,127 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Runtime.Remoting;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Util;
+
+namespace Halibut.Transport.Streams
+{
+    class ApmToTapStream : AsyncDisposableStream
+    {
+        readonly Stream inner;
+
+        public ApmToTapStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public override async ValueTask DisposeAsync() => await inner.DisposeAsync();
+
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await inner.FlushAsync(cancellationToken);
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => await inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => await inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+#if !NETFRAMEWORK
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => await inner.ReadAsync(buffer, cancellationToken);
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => await inner.WriteAsync(buffer, cancellationToken);
+#endif
+
+        public override void Close() => inner.Close();
+
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => await inner.CopyToAsync(destination, bufferSize, cancellationToken);
+        
+        public override int ReadByte() => inner.ReadByte();
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            // BeginRead does not respect timeouts. So force it to use ReadAsync, which does.
+            return ReadAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            try
+            {
+                return ((Task<int>)asyncResult).Result;
+            }
+            catch (AggregateException e) when (e.InnerExceptions.Count == 1 && e.InnerException is not null)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            // BeginWrite does not respect timeouts. So force it to use WriteAsync, which does.
+            return WriteAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            var task = (Task)asyncResult;
+            try
+            {
+                Task.WaitAll(task);
+            }
+            catch (AggregateException e) when (e.InnerExceptions.Count == 1 && e.InnerException is not null)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        public override void WriteByte(byte value) => inner.WriteByte(value);
+
+#if !NETFRAMEWORK
+        public override void CopyTo(Stream destination, int bufferSize) => inner.CopyTo(destination, bufferSize);
+        
+        public override int Read(Span<byte> buffer) => inner.Read(buffer);
+
+        public override void Write(ReadOnlySpan<byte> buffer) => inner.Write(buffer);
+#endif
+
+#if NETFRAMEWORK
+        public override ObjRef CreateObjRef(Type requestedType) => inner.CreateObjRef(requestedType);
+
+        public override object? InitializeLifetimeService() => inner.InitializeLifetimeService();
+#endif
+
+        public override int ReadTimeout
+        {
+            get => inner.ReadTimeout;
+            set => inner.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => inner.WriteTimeout;
+            set => inner.WriteTimeout = value;
+        }
+
+        public override bool CanTimeout => inner.CanTimeout;
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+    }
+}


### PR DESCRIPTION
# Background

This PR introduces a new stream `ApmToTapStream`, which can ensure that execution doesn’t unintentionally go down sync code paths when using some streams in .NET Framework 4.8.

Some streams in net48 do not override the modern TAP async methods (e.g. `ReadAsync`, `WriteAsync`) and thus fallback to the default implementation in the `Stream` base class when they are called. This default implementation uses the APM async methods (e.g. `BeginRead`, `EndRead`), which in turn calls the sync methods like `Read` and `Write`. This has the unintended consequence of causing a call to `ReadAsync` on an outer stream eventually calling `Read` on an inner stream, therefore making the execution path go from async to sync.

`DeflateStream` is one of these streams, and the usage of this type in Halibut’s `MessageSerializer` class means that many of our async calls in net48 were not truly async. By wrapping `DeflateStream`'s inner stream in a `ApmToTapStream`, this problem can be mitigated.

# Results

Fixes [sc-57049]

## Before

```
async Task<T> ReadCompressedMessageAsync<T>(Stream stream, IRewindableBuffer rewindableBuffer, CancellationToken cancellationToken)
{
    // Do some stuff

    try
    {
        using var compressedByteCountingStream = new ByteCountingStream(stream, OnDispose.LeaveInputStreamOpen);
        using var zip = new DeflateStream(compressedByteCountingStream, CompressionMode.Decompress, true);
        using var decompressedByteCountingStream = new ByteCountingStream(zip, OnDispose.LeaveInputStreamOpen);
        using var deflatedInMemoryStream = new ReadIntoMemoryBufferStream(decompressedByteCountingStream, readIntoMemoryLimitBytes, OnDispose.LeaveInputStreamOpen);
        
        // Read the stream(s) here
        await deflatedInMemoryStream.BufferIntoMemoryFromSourceStreamUntilLimitReached(cancellationToken);

        // Do some more stuff
    }
}

```
![ApmToTapStream Before](https://github.com/OctopusDeploy/Halibut/assets/277700/ad0b0d31-b3f9-48e6-9285-b5d7e1e8770b)

## After

```
async Task<T> ReadCompressedMessageAsync<T>(Stream stream, IRewindableBuffer rewindableBuffer, CancellationToken cancellationToken)
{
    // Do some stuff

    try
    {
        using var compressedByteCountingStream = new ByteCountingStream(stream, OnDispose.LeaveInputStreamOpen);
        using var apmToTapStream = new ApmToTapStream(compressedByteCountingStream);
        using var zip = new DeflateStream(apmToTapStream, CompressionMode.Decompress, true);
        using var decompressedByteCountingStream = new ByteCountingStream(zip, OnDispose.LeaveInputStreamOpen);
        using var deflatedInMemoryStream = new ReadIntoMemoryBufferStream(decompressedByteCountingStream, readIntoMemoryLimitBytes, OnDispose.LeaveInputStreamOpen);

        // Read the stream(s) here
        await deflatedInMemoryStream.BufferIntoMemoryFromSourceStreamUntilLimitReached(cancellationToken);

        // Do some more stuff
    }
}
```
![ApmToTapStream After](https://github.com/OctopusDeploy/Halibut/assets/277700/07faae73-1e71-433e-adef-a2c953f1d7b9)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
