### PR TITLE
NetworkTimeoutStream should DisposeAsync the inner stream instead of Close when an async operation is being called.

### DIFF
--- a/source/Halibut.Tests/Support/DisposableCollection.cs
+++ b/source/Halibut.Tests/Support/DisposableCollection.cs
@@ -14,6 +14,11 @@ namespace Halibut.Tests.Support
             disposables.Push(disposable);
         }
 
+        public void AddIgnoringDisposalError(IDisposable disposable)
+        {
+            disposables.Push(new SilentDisposable(disposable));
+        }
+
         public void Dispose()
         {
             var exceptions = new List<Exception>();
@@ -28,6 +33,21 @@ namespace Halibut.Tests.Support
                 }
 
             if (exceptions.Any()) throw new AggregateException(exceptions);
+        }
+
+        class SilentDisposable : IDisposable
+        {
+            IDisposable inner;
+
+            public SilentDisposable(IDisposable inner)
+            {
+                this.inner = inner;
+            }
+
+            public void Dispose()
+            {
+                Try.CatchingError(() => inner.Dispose(), _ => { });
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -159,16 +159,33 @@ namespace Halibut.Tests.Timeouts
                     addControlMessageTimeout += HalibutLimits.TcpClientHeartbeatSendTimeout;
                 }
 
-                var expectedTimeOut = HalibutLimits.TcpClientSendTimeout // What we actually expected. 
-                                     + HalibutLimits.TcpClientSendTimeout // an extra timeout because of the dispose method of the zip stream (see below)
-                                     + addControlMessageTimeout;
-                sw.Elapsed.Should().BeGreaterThan( expectedTimeOut- TimeSpan.FromSeconds(2), 
-                        "We 'should' wait the send timeout amount of time NOT the heart beat timeout, however when an error occurs writing to the zip (deflate)" +
-                                "stream we also call dispose which again attempts to write to the stream. Thus we wait 2 times the TcpClientSendTimeout.") // -2s give it a little slack to avoid it timed out slightly too early.
-                    .And
-                    .BeLessThan(expectedTimeOut + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout, 
-                        "We 'should' wait the send timeout amount of time, however when an error occurs writing to the zip (deflate)" +
+                if (clientAndServiceTestCase.ForceClientProxyType == ForceClientProxyType.SyncClient)
+                {
+                    var expectedTimeOut = HalibutLimits.TcpClientSendTimeout // What we actually expected. 
+                                          + HalibutLimits.TcpClientSendTimeout // an extra timeout because of the dispose method of the zip stream (see below)
+                                          + addControlMessageTimeout;
+
+                    sw.Elapsed.Should().BeGreaterThan(expectedTimeOut - TimeSpan.FromSeconds(2),
+                            "We 'should' wait the send timeout amount of time NOT the heart beat timeout, however when an error occurs writing to the zip (deflate)" +
+                            "stream we also call dispose which again attempts to write to the stream. Thus we wait 2 times the TcpClientSendTimeout.") // -2s give it a little slack to avoid it timed out slightly too early.
+                        .And
+                        .BeLessThan(expectedTimeOut + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout,
+                            "We 'should' wait the send timeout amount of time, however when an error occurs writing to the zip (deflate)" +
                             "stream we also call dispose which again attempts to write to the stream. Thus we wait 2 times the TcpClientSendTimeout.");
+                }
+                else
+                {
+                    
+                    var expectedTimeOut = HalibutLimits.TcpClientSendTimeout;
+
+                    sw.Elapsed.Should().BeGreaterThan(
+                            expectedTimeOut - TimeSpan.FromSeconds(2), 
+                            "Should wait the send timeout amount of time NOT the heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
+                        .And
+                        .BeLessThan(
+                            expectedTimeOut + LowerHalibutLimitsForAllTests.HalfTheTcpReceiveTimeout,
+                            "Should wait the send timeout amount of time");
+                }
 
                 await echo.SayHelloAsync("A new request can be made on a new unpaused TCP connection");
             }
@@ -194,9 +211,10 @@ namespace Halibut.Tests.Timeouts
                     firstSend: "hello",
                     andThenRun: portForwarderRef.Value!.PauseExistingConnections,
                     thenSend: "All done" + Some.RandomAsciiStringOfLength(10*1024*1024)
-                ))))
-                    .And;
+                )))).And;
+
                 AssertExceptionLooksLikeAWriteTimeout(e);
+                
                 sw.Stop();
                 Logger.Error(e, "Received error when making the request (as expected)");
                 
@@ -225,6 +243,8 @@ namespace Halibut.Tests.Timeouts
             e.Message.Should().ContainAny(
                 "Unable to write data to the transport connection: Connection timed out.",
                 " Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
+
+            e.IsNetworkError().Should().Be(HalibutNetworkExceptionType.IsNetworkError);
         }
 
         static void AssertExceptionMessageLooksLikeAReadTimeout(HalibutClientException? e)
@@ -232,6 +252,8 @@ namespace Halibut.Tests.Timeouts
             e.Message.Should().ContainAny(
                 "Unable to read data from the transport connection: Connection timed out.",
                 "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+            
+            e.IsNetworkError().Should().Be(HalibutNetworkExceptionType.IsNetworkError);
         }
 
         static Action<ServiceEndPoint> IncreasePollingQueueTimeout()

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -58,9 +58,17 @@ namespace Halibut.Tests.Transport.Streams
                 actualException!.Message.Should().ContainAny(
                     "Unable to read data from the transport connection: Connection timed out.",
                     "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
-
+                
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
-                callCountingStream.CloseCallCount.Should().Be(1, "The Stream should have been closed on Timeout");
+
+                if (streamMethod == StreamMethod.Sync)
+                {
+                    callCountingStream.CloseCallCount.Should().Be(1, "The Stream should have been Closed on Timeout");
+                }
+                else
+                {
+                    callCountingStream.DisposeAsyncCallCount.Should().Be(1, "The Stream should have been DisposedAsync on Timeout");
+                }
             }
         }
 
@@ -152,7 +160,15 @@ namespace Halibut.Tests.Transport.Streams
                     "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
-                callCountingStream.CloseCallCount.Should().Be(1, "The Stream should have been closed on Timeout");
+                
+                if (streamMethod == StreamMethod.Sync)
+                {
+                    callCountingStream.CloseCallCount.Should().Be(1, "The Stream should have been Closed on Timeout");
+                }
+                else
+                {
+                    callCountingStream.DisposeAsyncCallCount.Should().Be(1, "The Stream should have been DisposedAsync on Timeout");
+                }
             }
         }
         

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -280,11 +280,10 @@ namespace Halibut.Tests.Transport.Streams
             await client.ConnectAsync("localhost", ((IPEndPoint)service.LocalEndpoint).Port);
             
             var clientStream = client.GetStream();
-            disposableCollection.Add(clientStream);
-
             var callCountingStream = new CallCountingStream(clientStream);
             var sut = new NetworkTimeoutStream(callCountingStream);
-            disposableCollection.Add(sut);
+
+            disposableCollection.AddIgnoringDisposalError(sut);
 
             while (performServiceWriteFunc == null)
             { 

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -62,9 +62,9 @@ namespace Halibut.Diagnostics
             {
                 if (exception.Message.Contains("System.IO.EndOfStreamException")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("System.Net.Sockets.SocketException (110): Connection timed out")) return HalibutNetworkExceptionType.IsNetworkError;
-                if (exception.Message.Contains("Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("An existing connection was forcibly closed by the remote host.")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("The I/O operation has been aborted because of either a thread exit or an application request")) return HalibutNetworkExceptionType.IsNetworkError;
-                if (exception.Message.Contains("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.")) return HalibutNetworkExceptionType.IsNetworkError;
             }
 
             return HalibutNetworkExceptionType.UnknownError;

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -60,10 +60,9 @@ namespace Halibut.Transport
                 var log = logs.ForEndpoint(serviceEndpoint.BaseUri);
                 using (var client = await TcpConnectionFactory.CreateConnectedTcpClientAsync(serviceEndpoint, halibutTimeoutsAndLimits, log, cancellationToken))
                 {
-                    using (var networkStream = client.GetStream())
+                    using (var networkStream = client.GetStream().AsNetworkTimeoutStream())
                     {
-                        var networkTimeoutStream = new NetworkTimeoutStream(networkStream);
-                        using (var ssl = new SslStream(networkTimeoutStream, false, ValidateCertificate))
+                        using (var ssl = new SslStream(networkStream, false, ValidateCertificate))
                         {
 #if NETFRAMEWORK
                             // TODO: ASYNC ME UP!

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -34,7 +34,7 @@ namespace Halibut.Transport.Protocol
         public MessageExchangeStream(Stream stream, IMessageSerializer serializer, AsyncHalibutFeature asyncHalibutFeature, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log)
         {
             this.stream = asyncHalibutFeature.IsEnabled() ? 
-                new RewindableBufferStream(new NetworkTimeoutStream(stream), halibutTimeoutsAndLimits.RewindableBufferStreamSize) : 
+                new RewindableBufferStream(stream, halibutTimeoutsAndLimits.RewindableBufferStreamSize) : 
 #pragma warning disable CS0612
                 new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
 #pragma warning restore CS0612

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -340,7 +340,7 @@ namespace Halibut.Transport.Proxy
         
         async Task SendConnectionCommandAsync(string host, int port, CancellationToken cancellationToken)
         {
-            var stream = new NetworkTimeoutStream(TcpClient.GetStream());
+            var stream = TcpClient.GetStream().AsNetworkTimeoutStream();
             var connectCmd = GetConnectCmd(host, port);
             var request = Encoding.ASCII.GetBytes(connectCmd);
 

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -207,7 +207,13 @@ namespace Halibut.Transport
         async Task ExecuteRequest(TcpClient client)
         {
             var clientName = client.Client.RemoteEndPoint;
-            var stream = client.GetStream();
+            Stream stream = client.GetStream();
+
+            if (asyncHalibutFeature.IsEnabled())
+            {
+                stream = ((NetworkStream)stream).AsNetworkTimeoutStream();
+            }
+
             using (var ssl = new SslStream(stream, true, AcceptAnySslCertificate))
             {
                 try
@@ -295,7 +301,7 @@ namespace Halibut.Transport
             }
         }
 
-        void SafelyCloseStream(NetworkStream stream, EndPoint clientName)
+        void SafelyCloseStream(Stream stream, EndPoint clientName)
         {
             try
             {

--- a/source/Halibut/Transport/Streams/NetworkStreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/NetworkStreamExtensionMethods.cs
@@ -1,0 +1,12 @@
+﻿using System.Net.Sockets;
+
+namespace Halibut.Transport.Streams
+{
+    public static class NetworkStreamExtensionMethods
+    {
+        internal static NetworkTimeoutStream AsNetworkTimeoutStream(this NetworkStream networkStream)
+        {
+            return new NetworkTimeoutStream(networkStream);
+        }
+    }
+}

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -252,7 +252,7 @@ namespace Halibut.Transport.Streams
 
                     try
                     {
-                        inner.Close();
+                        await inner.DisposeAsync();
                     }
                     catch { }
 

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -60,9 +60,8 @@ namespace Halibut.Transport
             var client = await CreateConnectedTcpClientAsync(serviceEndpoint, halibutTimeoutsAndLimits, log, cancellationToken);
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
             
-            var networkStream = client.GetStream();
-            var networkTimeoutStream = new NetworkTimeoutStream(networkStream);
-            var ssl = new SslStream(networkTimeoutStream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
+            var networkStream = client.GetStream().AsNetworkTimeoutStream();
+            var ssl = new SslStream(networkStream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
 


### PR DESCRIPTION
# Background

NetworkTimeoutStream should DisposeAsync of the inner stream instead of Close when an async operation is being called.

## Under net48

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/0239ad82-0a20-4553-b68c-430ae75f95fe)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/d36d1900-3ad1-4264-b4d9-2f5ac0c621c5)

## Under net6.0

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/7ad19901-55b2-488e-b040-3e27a1e01703)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/fb22b434-e648-4480-afff-c89c3fb16aff)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
