### PR TITLE
Don't throw an exception whem the compat bin is stopped by cancellation token

### DIFF
--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -120,7 +120,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
                         if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
                     }
-                    
+
                     await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version))
                         .WithArguments(new string[0])
                         .WithWorkingDirectory(tmp.FullPath)
@@ -128,6 +128,10 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         .WithStandardErrorPipe(PipeTarget.ToDelegate(ProcessLogs))
                         .WithEnvironmentVariables(settings)
                         .ExecuteAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Don't throw when we cancel the running of the binary, this is an expected way of killing it.
                 }
                 catch (Exception e)
                 {

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -132,6 +132,10 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         .WithEnvironmentVariables(settings)
                         .ExecuteAsync(cancellationToken);
                 }
+                catch (OperationCanceledException)
+                {
+                    // Don't throw when we cancel the running of the binary, this is an expected way of killing it.
+                }
                 catch (Exception e)
                 {
                     logger.Error(e, "Error waiting for external process to start");


### PR DESCRIPTION
# Background

Cli.Wrap throws if the exe is stopped by cancellation token, this is not what silent process runner did and so is not what we want.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
