### PR TITLE
Don't fall into a sync read when the end of stream was found

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -194,7 +194,7 @@ namespace Halibut.Transport.Protocol
             }
         }
         
-        async Task<T> ReadCompressedMessageAsync<T>(Stream stream, IRewindableBuffer rewindableBuffer, CancellationToken cancellationToken)
+        async Task<T> ReadCompressedMessageAsync<T>(ErrorRecordingStream stream, IRewindableBuffer rewindableBuffer, CancellationToken cancellationToken)
         {
             rewindableBuffer.StartBuffer();
             try
@@ -207,6 +207,14 @@ namespace Halibut.Transport.Protocol
 
                 using var deflatedInMemoryStream = new ReadIntoMemoryBufferStream(decompressedByteCountingStream, readIntoMemoryLimitBytes, OnDispose.LeaveInputStreamOpen);
                 await deflatedInMemoryStream.BufferIntoMemoryFromSourceStreamUntilLimitReached(cancellationToken);
+                
+                // If the end of stream was found and we read nothing from the streams
+                if (stream.WasTheEndOfStreamEncountered && compressedByteCountingStream.BytesRead == 0 && decompressedByteCountingStream.BytesRead == 0)
+                {
+                    // Return null since that is what this would do.
+                    // However doing this if here means we don't do sync IO
+                    return new MessageEnvelope<T>().Message; // And hack around we can't return null
+                }
 
                 using (var bson = new BsonDataReader(deflatedInMemoryStream) { CloseInput = false })
                 {

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -211,8 +211,10 @@ namespace Halibut.Transport.Protocol
                 // If the end of stream was found and we read nothing from the streams
                 if (stream.WasTheEndOfStreamEncountered && compressedByteCountingStream.BytesRead == 0 && decompressedByteCountingStream.BytesRead == 0)
                 {
-                    // Return null since that is what this would do.
-                    // However doing this if here means we don't do sync IO
+                    // When this happens we would normally continue to the BsonDataReader which would
+                    // do a sync read(), to find that the stream had ended. We avoid that sync call by
+                    // short circuiting to what would happen which is:  
+                    // The BsonReader would return a non null MessageEnvelope with a null message, which is what we do here.
                     return new MessageEnvelope<T>().Message; // And hack around we can't return null
                 }
 


### PR DESCRIPTION
# Background

The test in https://github.com/OctopusDeploy/Halibut/pull/439 found that a sync read can occur if the stream end of stream is encountered which can happen when the stream is terminated. The change here is to return a null Request/Response message when the end of stream is encountered when we also read no bytes of the wire.

# Results

## Before

```
Halibut.Tests.Support.Streams.NoSyncIoStream.NoteSyncCall()
   at Halibut.Tests.Support.Streams.NoSyncIoStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Streams.NetworkTimeoutStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.Net.FixedSizeReader.ReadPacket(Byte[] buffer, Int32 offset, Int32 count)
   at System.Net.Security._SslStream.StartFrameHeader(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security._SslStream.StartReading(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security._SslStream.ProcessRead(Byte[] buffer, Int32 offset, Int32 count, AsyncProtocolRequest asyncRequest)
   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Streams.NetworkTimeoutStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.RewindableBufferStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Streams.ErrorRecordingStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Observability.ByteCountingStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Streams.ApmToTapStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Compression.DeflateStream.Read(Byte[] array, Int32 offset, Int32 count)
   at Halibut.Transport.Observability.ByteCountingStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Halibut.Transport.Streams.ReadIntoMemoryBufferStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.BinaryReader.FillBuffer(Int32 numBytes)
   at System.IO.BinaryReader.ReadInt32()
   at Newtonsoft.Json.Bson.BsonDataReader.ReadNormal()
   at Newtonsoft.Json.Bson.BsonDataReader.Read()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Halibut.Transport.Protocol.MessageSerializer.DeserializeMessage[T](JsonReader reader)
   at Halibut.Transport.Protocol.MessageSerializer.<ReadCompressedMessageAsync>d__14`1.MoveNext()
   at Halibut.Transport.Streams.ReadIntoMemoryBufferStream.<BufferIntoMemoryFromSourceStreamUntilLimitReached>d__36.MoveNext()
   at Halibut.Transport.Observability.ByteCountingStream.<ReadAsync>d__37.MoveNext()
   at System.IO.Compression.DeflateStreamAsyncResult.Complete(Object result)
   at System.IO.Compression.DeflateStream.ReadCallback(IAsyncResult baseStreamResult)
   at Halibut.Util.TaskExtensionMethods.<>c__DisplayClass1_0`1.<AsAsynchronousProgrammingModel>b__0(Task`1 t)
```
## After

We don't see that sync IO call.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
