### PR TITLE
Improve the NetworkTimeoutStream closing and disposal on timeout

### DIFF
--- a/source/Halibut.Tests/Support/DisposableCollection.cs
+++ b/source/Halibut.Tests/Support/DisposableCollection.cs
@@ -14,6 +14,11 @@ namespace Halibut.Tests.Support
             disposables.Push(disposable);
         }
 
+        public void AddIgnoringDisposalError(IDisposable disposable)
+        {
+            disposables.Push(new SilentDisposable(disposable));
+        }
+
         public void Dispose()
         {
             var exceptions = new List<Exception>();
@@ -28,6 +33,21 @@ namespace Halibut.Tests.Support
                 }
 
             if (exceptions.Any()) throw new AggregateException(exceptions);
+        }
+
+        class SilentDisposable : IDisposable
+        {
+            IDisposable inner;
+
+            public SilentDisposable(IDisposable inner)
+            {
+                this.inner = inner;
+            }
+
+            public void Dispose()
+            {
+                Try.CatchingError(() => inner.Dispose(), _ => { });
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Support/TestAttributes/StreamCopyToMethodTestCaseAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/StreamCopyToMethodTestCaseAttribute.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections;
+using Halibut.Tests.Transport.Streams;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class StreamCopyToMethodTestCaseAttribute : TestCaseSourceAttribute
+    {
+        public StreamCopyToMethodTestCaseAttribute(bool testSync = true) : base(
+            typeof(TestCases),
+            nameof(TestCases.GetEnumerator),
+            new object[] { testSync })
+        {
+        }
+
+        static class TestCases
+        {
+            public static IEnumerable GetEnumerator(bool testSync)
+            {
+                if (testSync)
+                {
+                    yield return StreamCopyToMethod.CopyTo;
+                    yield return StreamCopyToMethod.CopyToWithBufferSize;
+                }
+
+                yield return StreamCopyToMethod.CopyToAsync;
+                yield return StreamCopyToMethod.CopyToAsyncWithBufferSize;
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/TestAttributes/StreamReadMethodTestCaseAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/StreamReadMethodTestCaseAttribute.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections;
+using Halibut.Tests.Transport.Streams;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class StreamReadMethodTestCaseAttribute : TestCaseSourceAttribute
+    {
+        public StreamReadMethodTestCaseAttribute(bool testSync = true) : base(
+            typeof(TestCases),
+            nameof(TestCases.GetEnumerator),
+            new object[] { testSync })
+        {
+        }
+
+        static class TestCases
+        {
+            public static IEnumerable GetEnumerator(bool testSync)
+            {
+                if (testSync)
+                {
+                    yield return StreamReadMethod.Read;
+                    yield return StreamReadMethod.ReadByte;
+                    yield return StreamReadMethod.BeginReadEndOutsideCallback;
+                    yield return StreamReadMethod.BeginReadEndWithinCallback;
+                }
+
+                yield return StreamReadMethod.ReadAsync;
+#if !NETFRAMEWORK
+                yield return StreamReadMethod.ReadAsyncForMemoryByteArray;
+#endif
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/TestAttributes/StreamWriteMethodTestCaseAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/StreamWriteMethodTestCaseAttribute.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections;
+using Halibut.Tests.Transport.Streams;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class StreamWriteMethodTestCaseAttribute : TestCaseSourceAttribute
+    {
+        public StreamWriteMethodTestCaseAttribute(bool testSync = true) : base(
+            typeof(TestCases),
+            nameof(TestCases.GetEnumerator),
+            new object[] { testSync })
+        {
+        }
+
+        static class TestCases
+        {
+            public static IEnumerable GetEnumerator(bool testSync)
+            {
+                if (testSync)
+                {
+                    yield return StreamWriteMethod.Write;
+                    yield return StreamWriteMethod.WriteByte;
+                    yield return StreamWriteMethod.BeginWriteEndOutsideCallback;
+                    yield return StreamWriteMethod.BeginWriteEndWithinCallback;
+                }
+
+                yield return StreamWriteMethod.WriteAsync;
+#if !NETFRAMEWORK
+                yield return StreamWriteMethod.WriteAsyncForMemoryByteArray;
+#endif
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/CallCountingStream.cs
+++ b/source/Halibut.Tests/Transport/Streams/CallCountingStream.cs
@@ -1,0 +1,255 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Transport.Streams;
+#if NETFRAMEWORK
+using System.Runtime.Remoting;
+#endif
+
+namespace Halibut.Tests.Transport.Streams
+{
+    class CallCountingStream : AsyncDisposableStream
+    {
+        readonly Stream inner;
+
+        public volatile int CloseCallCount;
+        public volatile int DisposeBoolCallCount;
+        public volatile int DisposeAsyncCallCount;
+        public volatile int FlushAsyncCallCount;
+        public volatile int ReadAsyncCallCount;
+        public volatile int WriteAsyncCallCount;
+        public volatile int ReadMemoryAsyncCallCount;
+        public volatile int WriteMemoryAsyncCallCount;
+        public volatile int CopyToAsyncCallCount;
+        public volatile int ReadByteCallCount;
+        public volatile int BeginReadCallCount;
+        public volatile int EndReadCallCount;
+        public volatile int BeginWriteCallCount;
+        public volatile int EndWriteCallCount;
+        public volatile int FlushCallCount;
+        public volatile int ReadCallCount;
+        public volatile int SeekCallCount;
+        public volatile int SetLengthCallCount;
+        public volatile int WriteCallCount;
+        public volatile int WriteByteCallCount;
+        public volatile int CopyToCallCount;
+        public volatile int ReadSpanCallCount;
+        public volatile int WriteSpanCallCount;
+        public volatile int CreateObjRefCallCount;
+        public volatile int InitializeLifetimeServiceCallCount;
+
+        public CallCountingStream(Stream inner)
+        {
+            this.inner = inner;
+        }
+
+        public void Reset()
+        {
+            CloseCallCount = 0;
+            DisposeBoolCallCount = 0;
+            DisposeAsyncCallCount = 0;
+            FlushAsyncCallCount = 0;
+            ReadAsyncCallCount = 0;
+            WriteAsyncCallCount = 0;
+            ReadMemoryAsyncCallCount = 0;
+            WriteMemoryAsyncCallCount = 0;
+            CopyToAsyncCallCount = 0;
+            ReadByteCallCount = 0;
+            BeginReadCallCount = 0;
+            EndReadCallCount = 0;
+            BeginWriteCallCount = 0;
+            EndWriteCallCount = 0;
+            FlushCallCount = 0;
+            ReadCallCount = 0;
+            SeekCallCount = 0;
+            SetLengthCallCount = 0;
+            WriteCallCount = 0;
+            WriteByteCallCount = 0;
+            CopyToCallCount = 0;
+            ReadSpanCallCount = 0;
+            WriteSpanCallCount = 0;
+            CreateObjRefCallCount = 0;
+            InitializeLifetimeServiceCallCount = 0;
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref DisposeAsyncCallCount);
+            await inner.DisposeAsync();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Interlocked.Increment(ref DisposeBoolCallCount);
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref FlushAsyncCallCount);
+            await inner.FlushAsync(cancellationToken);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref ReadAsyncCallCount);
+            return await inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref WriteAsyncCallCount);
+            await inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if !NETFRAMEWORK
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref ReadMemoryAsyncCallCount);
+            return await inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref WriteMemoryAsyncCallCount);
+            await inner.WriteAsync(buffer, cancellationToken);
+        }
+#endif
+
+        public override void Close()
+        {
+            Interlocked.Increment(ref CloseCallCount);
+            inner.Close();
+        }
+
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref CopyToAsyncCallCount);
+            await inner.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override int ReadByte()
+        {
+            Interlocked.Increment(ref ReadByteCallCount);
+            return inner.ReadByte();
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            Interlocked.Increment(ref BeginReadCallCount);
+            return inner.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            Interlocked.Increment(ref EndReadCallCount);
+            return inner.EndRead(asyncResult);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            Interlocked.Increment(ref BeginWriteCallCount);
+            return inner.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            Interlocked.Increment(ref EndWriteCallCount);
+            inner.EndWrite(asyncResult);
+        }
+
+        public override void Flush()
+        {
+            Interlocked.Increment(ref FlushCallCount);
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Interlocked.Increment(ref ReadCallCount);
+            return inner.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            Interlocked.Increment(ref SeekCallCount);
+            return inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            Interlocked.Increment(ref SetLengthCallCount);
+            inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            Interlocked.Increment(ref WriteCallCount);
+            inner.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            Interlocked.Increment(ref WriteByteCallCount);
+            inner.WriteByte(value);
+        }
+
+#if !NETFRAMEWORK
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            Interlocked.Increment(ref CopyToCallCount);
+            inner.CopyTo(destination, bufferSize);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            Interlocked.Increment(ref ReadSpanCallCount);
+            return inner.Read(buffer);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            Interlocked.Increment(ref WriteSpanCallCount);
+            inner.Write(buffer);
+        }
+#endif
+
+#if NETFRAMEWORK
+        public override ObjRef CreateObjRef(Type requestedType)
+        {
+            Interlocked.Increment(ref CreateObjRefCallCount);
+            return inner.CreateObjRef(requestedType);
+        }
+
+        public override object? InitializeLifetimeService()
+        {
+            Interlocked.Increment(ref InitializeLifetimeServiceCallCount);
+            return inner.InitializeLifetimeService();
+        }
+#endif
+
+        public override int ReadTimeout
+        {
+            get => inner.ReadTimeout;
+            set => inner.ReadTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => inner.WriteTimeout;
+            set => inner.WriteTimeout = value;
+        }
+
+        public override bool CanTimeout => inner.CanTimeout;
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -19,28 +19,37 @@ namespace Halibut.Tests.Transport.Streams
     public class NetworkTimeoutStreamFixture : BaseTest
     {
         [Test]
-        [StreamMethodTestCase]
-        public async Task ReadingFromStreamShouldPassThrough(StreamMethod streamMethod)
+        [StreamReadMethodTestCase]
+        public async Task ReadCalls_ShouldPassThrough(StreamReadMethod streamReadMethod)
         {
-            var (disposables, sut, performListenerWrite) = await BuildTcpClientAndTcpListener(CancellationToken);
+            var (disposables, sut, _, _, performListenerWrite) = await BuildTcpClientAndTcpListener(CancellationToken);
 
             using (disposables)
             {
                 await performListenerWrite("Test");
 
-                var buffer = new byte[19];
-                var readBytes = await sut.ReadFromStream(streamMethod, buffer, 0, 19, CancellationToken);
-                var readData = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                if (streamReadMethod == StreamReadMethod.ReadByte)
+                {
+                    var readByte = sut.ReadByte();
                 
-                Assert.AreEqual("Test", readData);
+                    Assert.AreEqual("Test".GetBytesUtf8()[0], readByte);
+                }
+                else
+                {
+                    var buffer = new byte[19];
+                    var readBytes = await sut.ReadFromStream(streamReadMethod, buffer, 0, 19, CancellationToken);
+                    var readData = Encoding.UTF8.GetString(buffer, 0, readBytes);
+
+                    Assert.AreEqual("Test", readData);
+                }
             }
         }
 
         [Test]
-        [StreamMethodTestCase(testSync:false)]
-        public async Task ReadingFromStreamAsyncShouldTimeout_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamMethod streamMethod)
+        [StreamReadMethodTestCase]
+        public async Task ReadCalls_ShouldTimeout_AndCloseTheStream_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamReadMethod streamReadMethod)
         {
-            var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
 
             using (disposables)
             {
@@ -50,7 +59,7 @@ namespace Halibut.Tests.Transport.Streams
 
                 var stopWatch = Stopwatch.StartNew();
 
-                var actualException = await Try.CatchingError(async () => await sut.ReadFromStream(streamMethod, new byte[19], 0, 19, CancellationToken));
+                var actualException = await Try.CatchingError(async () => await sut.ReadFromStream(streamReadMethod, new byte[19], 0, 19, CancellationToken));
                 
                 stopWatch.Stop();
 
@@ -58,17 +67,20 @@ namespace Halibut.Tests.Transport.Streams
                 actualException!.Message.Should().ContainAny(
                     "Unable to read data from the transport connection: Connection timed out.",
                     "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
-
+                
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
+
+                AssertStreamWasClosed(streamReadMethod, callCountingStream);
             }
         }
 
         [Test]
-        public async Task ReadAsyncShouldCancel()
+        [StreamReadMethodTestCase(testSync: false)]
+        public async Task ReadAsyncCalls_ShouldCancel(StreamReadMethod streamReadMethod)
         {
             using (var readTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
             {
-                var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+                var (disposables, sut, _, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
 
                 using (disposables)
                 {
@@ -78,7 +90,7 @@ namespace Halibut.Tests.Transport.Streams
 
                     var stopWatch = Stopwatch.StartNew();
 
-                    var actualException = await Try.CatchingError(async () => await sut.ReadAsync(new byte[19], 0, 19, readTokenSource.Token));
+                    var actualException = await Try.CatchingError(async () => await sut.ReadFromStream(streamReadMethod, new byte[19], 0, 19, readTokenSource.Token));
 
                     stopWatch.Stop();
 
@@ -91,12 +103,12 @@ namespace Halibut.Tests.Transport.Streams
         }
         
         [Test]
-        [StreamMethodTestCase]
-        public async Task WritingToStreamShouldPassThrough(StreamMethod streamMethod)
+        [StreamWriteMethodTestCase]
+        public async Task WriteCalls_ShouldPassThrough(StreamWriteMethod streamWriteMethod)
         {
             string? readData = null;
             
-            var (disposables, sut, _) = await BuildTcpClientAndTcpListener(
+            var (disposables, sut, _, _, _) = await BuildTcpClientAndTcpListener(
                 CancellationToken,
                 onListenerRead: async data =>
                 {
@@ -107,22 +119,39 @@ namespace Halibut.Tests.Transport.Streams
             using (disposables)
             {
                 var buffer = Encoding.UTF8.GetBytes("Test");
-                await sut.WriteToStream(streamMethod, buffer, 0, buffer.Length, CancellationToken);
+                await sut.WriteToStream(streamWriteMethod, buffer, 0, buffer.Length, CancellationToken);
 
-                while ((readData?.Length ?? 0) < 4 && !CancellationToken.IsCancellationRequested)
+                if (streamWriteMethod == StreamWriteMethod.WriteByte)
                 {
-                    await Task.Delay(10, CancellationToken);
-                }
+                    while ((readData?.Length ?? 0) < 1 && !CancellationToken.IsCancellationRequested)
+                    {
+                        await Task.Delay(10, CancellationToken);
+                    }
 
-                Assert.AreEqual("Test", readData);
+                    Assert.AreEqual("Test"[0], readData.ToCharArray()[0]);  
+                }
+                else
+                {
+                    while ((readData?.Length ?? 0) < 4 && !CancellationToken.IsCancellationRequested)
+                    {
+                        await Task.Delay(10, CancellationToken);
+                    }
+
+                    Assert.AreEqual("Test", readData);   
+                }
             }
         }
         
         [Test]
-        [StreamMethodTestCase(testSync: false)]
-        public async Task WritingToStreamAsyncShouldTimeout_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamMethod streamMethod)
+        [StreamWriteMethodTestCase]
+        public async Task WriteCalls_ShouldTimeout_AndCloseTheStream_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamWriteMethod streamWriteMethod)
         {
-            var (disposables, sut, _) = await BuildTcpClientAndTcpListener(
+            if (streamWriteMethod == StreamWriteMethod.WriteByte)
+            {
+                Assert.Inconclusive("This test is unable to brute force enough writes for WriteByte to timeout");
+            }
+
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(
                 CancellationToken, 
                 onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
 
@@ -140,7 +169,7 @@ namespace Halibut.Tests.Transport.Streams
 
                 // Brute force attempt to get the Write to be slow
                 var actualException = await Try.RunTillExceptionOrCancellation(
-                    async () => await sut.WriteToStream(streamMethod, data, 0, data.Length, CancellationToken), 
+                    async () => await sut.WriteToStream(streamWriteMethod, data, 0, data.Length, CancellationToken), 
                     CancellationToken);
 
                 stopWatch.Stop();
@@ -151,15 +180,18 @@ namespace Halibut.Tests.Transport.Streams
                     "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
 
                 stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
+                
+                AssertStreamWasClosed(streamWriteMethod, callCountingStream);
             }
         }
         
         [Test]
-        public async Task WriteAsyncShouldCancel()
+        [StreamWriteMethodTestCase(testSync: false)]
+        public async Task WriteAsyncCalls_ShouldCancel(StreamWriteMethod streamWriteMethod)
         {
             using (var writeTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
             {
-                var (disposables, sut, _) = await BuildTcpClientAndTcpListener(
+                var (disposables, sut, _, _, _) = await BuildTcpClientAndTcpListener(
                     CancellationToken,
                     onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
 
@@ -177,7 +209,7 @@ namespace Halibut.Tests.Transport.Streams
 
                     // Brute force attempt to get the Write to be slow
                     var actualException = await Try.RunTillExceptionOrCancellation(
-                        async () => await sut.WriteAsync(data, 0, data.Length, writeTokenSource.Token),
+                        async () => await sut.WriteToStream(streamWriteMethod, data, 0, data.Length, writeTokenSource.Token),
                         CancellationToken);
 
                     stopWatch.Stop();
@@ -191,9 +223,9 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task CloseShouldPassThrough()
+        public async Task Close_ShouldPassThrough()
         {
-            var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+            var (disposables, sut, _, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
 
             using (disposables)
             {
@@ -205,9 +237,9 @@ namespace Halibut.Tests.Transport.Streams
         }
 
         [Test]
-        public async Task DisposeShouldPassThrough()
+        public async Task Dispose_ShouldPassThrough()
         {
-            var (disposables, sut, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+            var (disposables, sut, _, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
 
             using (disposables)
             {
@@ -218,12 +250,404 @@ namespace Halibut.Tests.Transport.Streams
             }
         }
 
+        [Test]
+        public async Task DisposeAsync_ShouldPassThrough()
+        {
+            var (disposables, sut, _, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                await sut.DisposeAsync();
+
+                Action read = () => sut.Read(new byte[1], 0, 1);
+                read.Should().Throw<ObjectDisposedException>("Because the stream is closed");
+            }
+        }
+
+        [Test]
+        public async Task Flush_ShouldPassThrough()
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                sut.Flush();
+                callCountingStream.FlushCallCount.Should().Be(1);
+            }
+        }
+
+        [Test]
+        public async Task FlushAsync_ShouldPassThrough()
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                await sut.FlushAsync();
+                callCountingStream.FlushAsyncCallCount.Should().Be(1);
+            }
+        }
+
+        [Test]
+        [SyncAndAsync]
+        public async Task FlushOrFlushAsync_ShouldTimeout_AndCloseTheStream_AndThrowExceptionThatLooksLikeANetworkTimeoutException(SyncOrAsync syncOrAsync)
+        {
+            var (disposables, sut, callCountingStream, pausingStream, _) = await BuildTcpClientAndTcpListener(
+                CancellationToken, 
+                onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
+
+            using (disposables)
+            {
+                sut.WriteTimeout = (int)TimeSpan.FromSeconds(5).TotalMilliseconds;
+                // Ensure the correct timeout is used
+                sut.ReadTimeout = (int)TimeSpan.FromSeconds(120).TotalMilliseconds;
+
+                // NetworkStream implementation of Flush and FlushAsync is a NoOp so pause to make sure our wrapper is working
+                pausingStream.PauseUntilTimeout(CancellationToken, pauseDisposeOrClose: false);
+
+                (await AssertAsync.Throws<IOException>(async () =>
+                    {
+                        switch (syncOrAsync)
+                        {
+                            case SyncOrAsync.Async:
+                                await sut.FlushAsync(CancellationToken);
+                                return;
+                            case SyncOrAsync.Sync:
+                                sut.Flush();
+                                return;
+                        }
+                    }))
+                    .And.Message.Should().ContainAny(
+                    "Unable to write data to the transport connection: Connection timed out.",
+                    "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+                                
+                AssertStreamWasClosed(syncOrAsync, callCountingStream);
+            }
+        }
+
+        [Test]
+        public async Task Seek_ShouldPassThrough()
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                Try.CatchingError(() => sut.Seek(0, SeekOrigin.Begin), _ => { });
+                callCountingStream.SeekCallCount.Should().Be(1);
+            }
+        }
+
+        [Test]
+        public async Task SetLength_ShouldPassThrough()
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                Try.CatchingError(() => sut.SetLength(0), _ => { });
+                callCountingStream.SetLengthCallCount.Should().Be(1);
+            }
+        }
+
+#if NETFRAMEWORK
+        [Test]
+        public async Task CreateObjRef_ShouldPassThrough()
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                Try.CatchingError(() => sut.CreateObjRef(typeof(NetworkTimeoutStream)), _ => { });
+                callCountingStream.CreateObjRefCallCount.Should().Be(1);
+            }
+        }
+
+        [Test]
+        public async Task InitializeLifetimeService_ShouldPassThrough()
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                sut.InitializeLifetimeService();
+                callCountingStream.InitializeLifetimeServiceCallCount.Should().Be(1);
+            }
+        }
+#endif
+
+        [Test]
+        [StreamCopyToMethodTestCase]
+        public async Task CopyToCalls_ShouldPassThrough(StreamCopyToMethod streamCopyToMethod)
+        {
+            using var source = new MemoryStream();
+            await using var sut = new NetworkTimeoutStream(source);
+            
+            var buffer = Encoding.UTF8.GetBytes("Test");
+            await source.WriteAsync(buffer, 0, buffer.Length, CancellationToken);
+            source.Position = 0;
+
+            var destinationStream = new MemoryStream();
+            await sut.CopyToStream(streamCopyToMethod, destinationStream, buffer.Length, CancellationToken);
+
+            sut.Position = 0;
+            using var reader = new StreamReader(sut);
+            var readData = await reader.ReadToEndAsync();
+
+            Assert.AreEqual("Test", readData);
+        }
+
+        [Test]
+        [StreamCopyToMethodTestCase]
+        public async Task CopyToCalls_ShouldTimeout_AndCloseTheStream_AndThrowExceptionThatLooksLikeANetworkTimeoutException(StreamCopyToMethod streamCopyToMethod)
+        {
+            using var source = new MemoryStream();
+            await using var supportsTimeoutsStream = new SupportsTimeoutsStream(source, TimeSpan.FromDays(1), TimeSpan.FromDays(1));
+            await using var pausableStream = new PausingStream(supportsTimeoutsStream);
+            await using var callCountingStream = new CallCountingStream(pausableStream);
+            var sut = new NetworkTimeoutStream(callCountingStream);
+            
+            sut.ReadTimeout = (int)TimeSpan.FromSeconds(5).TotalMilliseconds;
+            // Ensure the correct timeout is used
+            sut.WriteTimeout = (int)TimeSpan.FromSeconds(120).TotalMilliseconds;
+
+            var buffer = Encoding.UTF8.GetBytes("Test");
+            await source.WriteAsync(buffer, 0, buffer.Length, CancellationToken);
+            source.Position = 0;
+
+            var destinationStream = new MemoryStream();
+            
+            var stopWatch = Stopwatch.StartNew();
+            
+            pausableStream.PauseUntilTimeout(CancellationToken, pauseDisposeOrClose: false);
+
+            var actualException = await Try.CatchingError(async () => await sut.CopyToStream(streamCopyToMethod, destinationStream, buffer.Length, CancellationToken));
+
+            stopWatch.Stop();
+
+            actualException.Should().NotBeNull().And.BeOfType<IOException>();
+            actualException!.Message.Should().ContainAny(
+                "Unable to read data from the transport connection: Connection timed out.",
+                "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
+
+            stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
+
+            AssertStreamWasClosed(streamCopyToMethod, callCountingStream);
+        }
+
+        [Test]
+        [StreamCopyToMethodTestCase(testSync: false)]
+        public async Task CopyAsyncCalls_ShouldCancel(StreamCopyToMethod streamCopyToMethod)
+        {
+#if NETFRAMEWORK
+            if (streamCopyToMethod == StreamCopyToMethod.CopyToAsync)
+            {
+                Assert.Inconclusive("CopyToAsync in net48 does not accept a cancellation token");
+            }
+#endif
+
+            using (var timeoutTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            {
+                using var source = new MemoryStream();
+                await using var supportsTimeoutsStream = new SupportsTimeoutsStream(source, TimeSpan.FromDays(1), TimeSpan.FromDays(1));
+                await using var pausableStream = new PausingStream(supportsTimeoutsStream);
+                await using var callCountingStream = new CallCountingStream(pausableStream);
+                var sut = new NetworkTimeoutStream(callCountingStream);
+            
+                sut.ReadTimeout = (int)TimeSpan.FromSeconds(120).TotalMilliseconds;
+                sut.WriteTimeout = (int)TimeSpan.FromSeconds(120).TotalMilliseconds;
+
+                var buffer = Encoding.UTF8.GetBytes("Test");
+                await source.WriteAsync(buffer, 0, buffer.Length, CancellationToken);
+                source.Position = 0;
+
+                var destinationStream = new MemoryStream();
+            
+                var stopWatch = Stopwatch.StartNew();
+            
+                pausableStream.PauseUntilTimeout(CancellationToken, pauseDisposeOrClose: false);
+
+                var actualException = await Try.CatchingError(async () => await sut.CopyToStream(streamCopyToMethod, destinationStream, buffer.Length, timeoutTokenSource.Token));
+
+                stopWatch.Stop();
+
+                actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>();
+                actualException!.Message.Should().Be("The ReadAsync operation was cancelled.");
+
+                stopWatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10));
+            }
+        }
+
+        [Test]
+        [StreamMethodTestCase]
+        public async Task UsingAStreamThatHasAlreadyTimedOutShouldRethrowTheTimeoutException(StreamMethod streamMethod)
+        {
+            var (disposables, sut, callCountingStream, _, _) = await BuildTcpClientAndTcpListener(CancellationToken);
+
+            using (disposables)
+            {
+                sut.WriteTimeout = (int)TimeSpan.FromSeconds(1).TotalMilliseconds;
+                sut.ReadTimeout = (int)TimeSpan.FromSeconds(1).TotalMilliseconds;
+                
+                var exception = await Try.CatchingError(async () => await sut.ReadFromStream(streamMethod, new byte[19], 0, 19, CancellationToken));
+                
+                callCountingStream.Reset();
+
+                exception.Should().NotBeNull();
+                AssertExceptionsAreEqual(exception!, AssertionExtensions.Should(() => sut.Position).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Position = 0).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CanRead).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CanSeek).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CanTimeout).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CanWrite).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Length).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.ReadTimeout).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.ReadTimeout = 1).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.WriteTimeout).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.WriteTimeout = 1).Throw<Exception>().And);
+
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.DataAvailable).Throw<Exception>().And);
+
+                var memoryStream = new MemoryStream();
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.ReadByte()).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Flush()).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Read(new byte[1], 0, 1)).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Seek(0, SeekOrigin.Begin)).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.SetLength(0)).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Write(new byte[1], 0, 1)).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.WriteByte(0)).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CopyTo(memoryStream)).Throw<Exception>().And);
+
+#if !NETFRAMEWORK
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Read(new Span<byte>(new byte[1]))).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Write(new ReadOnlySpan<byte>(new byte[1]))).Throw<Exception>().And);
+#endif
+
+#if NETFRAMEWORK
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CreateObjRef(typeof(NetworkTimeoutStream))).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.InitializeLifetimeService()).Throw<Exception>().And);
+#endif
+                
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.CopyToAsync(memoryStream, 0, CancellationToken.None)).ThrowAsync<Exception>()).And);
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.FlushAsync()).ThrowAsync<Exception>()).And);
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.ReadAsync(new byte[1], 0, 1, CancellationToken.None)).ThrowAsync<Exception>()).And);
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.WriteAsync(new byte[1], 0, 1, CancellationToken.None)).ThrowAsync<Exception>()).And);
+                
+#if !NETFRAMEWORK
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.ReadAsync(new Memory<byte>(new byte[1]), CancellationToken.None).AsTask()).ThrowAsync<Exception>()).And);
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.WriteAsync(new ReadOnlyMemory<byte>(new byte[1]), CancellationToken.None).AsTask()).ThrowAsync<Exception>()).And);
+#endif
+
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Close()).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Dispose()).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, (await AssertionExtensions.Should(() => sut.DisposeAsync().AsTask()).ThrowAsync<Exception>()).And);
+
+                callCountingStream.CloseCallCount.Should().Be(0);
+                callCountingStream.DisposeBoolCallCount.Should().Be(0);
+                callCountingStream.DisposeAsyncCallCount.Should().Be(0);
+                callCountingStream.FlushAsyncCallCount.Should().Be(0);
+                callCountingStream.ReadAsyncCallCount.Should().Be(0);
+                callCountingStream.WriteAsyncCallCount.Should().Be(0);
+                callCountingStream.ReadMemoryAsyncCallCount.Should().Be(0);
+                callCountingStream.WriteMemoryAsyncCallCount.Should().Be(0);
+                callCountingStream.CopyToAsyncCallCount.Should().Be(0);
+                callCountingStream.ReadByteCallCount.Should().Be(0);
+                callCountingStream.BeginReadCallCount.Should().Be(0);
+                callCountingStream.EndReadCallCount.Should().Be(0);
+                callCountingStream.BeginWriteCallCount.Should().Be(0);
+                callCountingStream.EndWriteCallCount.Should().Be(0);
+                callCountingStream.FlushCallCount.Should().Be(0);
+                callCountingStream.ReadCallCount.Should().Be(0);
+                callCountingStream.SeekCallCount.Should().Be(0);
+                callCountingStream.SetLengthCallCount.Should().Be(0);
+                callCountingStream.WriteCallCount.Should().Be(0);
+                callCountingStream.WriteByteCallCount.Should().Be(0);
+                callCountingStream.CopyToCallCount.Should().Be(0);
+                callCountingStream.ReadSpanCallCount.Should().Be(0);
+                callCountingStream.WriteSpanCallCount.Should().Be(0);
+                callCountingStream.CreateObjRefCallCount.Should().Be(0);
+                callCountingStream.InitializeLifetimeServiceCallCount.Should().Be(0);
+            }
+        }
+
+        static void AssertStreamWasClosed(SyncOrAsync syncOrAsync, CallCountingStream callCountingStream)
+        {
+            if (syncOrAsync == SyncOrAsync.Sync)
+            {
+                callCountingStream.CloseCallCount.Should().Be(1, "The Stream should have been Closed on Timeout");
+            }
+            else
+            {
+                callCountingStream.DisposeAsyncCallCount.Should().Be(1, "The Stream should have been DisposedAsync on Timeout");
+            }
+        }
+
+        static void AssertStreamWasClosed(StreamMethod streamMethod, CallCountingStream callCountingStream)
+        {
+            AssertStreamWasClosed(streamMethod == StreamMethod.Sync ? SyncOrAsync.Sync : SyncOrAsync.Async, callCountingStream);
+        }
+
+        static void AssertStreamWasClosed(StreamReadMethod streamReadMethod, CallCountingStream callCountingStream)
+        {
+            switch (streamReadMethod)
+            {
+                case StreamReadMethod.ReadAsync: 
+#if !NETFRAMEWORK
+                case StreamReadMethod.ReadAsyncForMemoryByteArray:
+#endif
+                case StreamReadMethod.BeginReadEndOutsideCallback: 
+                case StreamReadMethod.BeginReadEndWithinCallback: 
+                    AssertStreamWasClosed(SyncOrAsync.Async, callCountingStream);
+                    break;
+                default:
+                    AssertStreamWasClosed(SyncOrAsync.Sync, callCountingStream);
+                    break;
+            }
+        }
+
+        static void AssertStreamWasClosed(StreamWriteMethod streamWriteMethod, CallCountingStream callCountingStream)
+        {
+            switch (streamWriteMethod)
+            {
+                case StreamWriteMethod.WriteAsync: 
+#if !NETFRAMEWORK
+                case StreamWriteMethod.WriteAsyncForMemoryByteArray:
+#endif
+                case StreamWriteMethod.BeginWriteEndOutsideCallback: 
+                case StreamWriteMethod.BeginWriteEndWithinCallback: 
+                    AssertStreamWasClosed(SyncOrAsync.Async, callCountingStream);
+                    break;
+                default:
+                    AssertStreamWasClosed(SyncOrAsync.Sync, callCountingStream);
+                    break;
+            }
+        }
+
+        static void AssertStreamWasClosed(StreamCopyToMethod streamCopyToMethod, CallCountingStream callCountingStream)
+        {
+            switch (streamCopyToMethod)
+            {
+                case StreamCopyToMethod.CopyToAsync:
+                case StreamCopyToMethod.CopyToAsyncWithBufferSize:
+                    AssertStreamWasClosed(SyncOrAsync.Async, callCountingStream);
+                    break;
+                default:
+                    AssertStreamWasClosed(SyncOrAsync.Sync, callCountingStream);
+                    break;
+            }
+        }
+
+        void AssertExceptionsAreEqual(Exception expected, Exception actual)
+        {
+            expected.GetType().Should().Be(actual.GetType());
+            expected.Message.Should().Be(actual.Message);
+        }
+
         static async Task DelayForeverToTryAndDelayWriting(CancellationToken cancellationToken)
         {
             await Task.Delay(-1, cancellationToken);
         }
 
-        async Task<(IDisposable Disposables, Stream SystemUnderTest, Func<string, Task> PerformServiceWriteFunc)> BuildTcpClientAndTcpListener(
+        async Task<(IDisposable Disposables, NetworkTimeoutStream SystemUnderTest, CallCountingStream callCountingStream, PausingStream pausingStream, Func<string, Task> PerformServiceWriteFunc)> BuildTcpClientAndTcpListener(
             CancellationToken cancellationToken, 
             Func<string, Task>? onListenerRead = null)
         {
@@ -262,17 +686,18 @@ namespace Halibut.Tests.Transport.Streams
             await client.ConnectAsync("localhost", ((IPEndPoint)service.LocalEndpoint).Port);
             
             var clientStream = client.GetStream();
-            disposableCollection.Add(clientStream);
+            var pausableStream = new PausingStream(clientStream);
+            var callCountingStream = new CallCountingStream(pausableStream);
+            var sut = new NetworkTimeoutStream(callCountingStream);
 
-            var sut = new NetworkTimeoutStream(clientStream);
-            disposableCollection.Add(sut);
+            disposableCollection.AddIgnoringDisposalError(sut);
 
             while (performServiceWriteFunc == null)
             { 
                 await Task.Delay(10, cancellationToken);
             }
 
-            return (disposableCollection, sut, performServiceWriteFunc!);
+            return (disposableCollection, sut, callCountingStream, pausableStream, performServiceWriteFunc!);
         }
     }
 }

--- a/source/Halibut.Tests/Transport/Streams/PausingStream.cs
+++ b/source/Halibut.Tests/Transport/Streams/PausingStream.cs
@@ -1,0 +1,273 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Transport.Streams;
+#if NETFRAMEWORK
+using System.Runtime.Remoting;
+#endif
+
+namespace Halibut.Tests.Transport.Streams
+{
+    class PausingStream : AsyncDisposableStream
+    {
+        readonly Stream inner;
+        bool paused;
+        CancellationTokenSource syncReadPauseCancellationTokenSource;
+        CancellationTokenSource syncWritePauseCancellationTokenSource;
+        CancellationToken asyncCancellationToken;
+
+        bool pauseDisposeOrClose;
+        int readTimeout;
+        int writeTimeout;
+
+        public PausingStream(Stream inner)
+        {
+            this.inner = inner;
+            this.readTimeout = inner.ReadTimeout;
+            this.writeTimeout = inner.WriteTimeout;
+        }
+
+        public void PauseUntilTimeout(CancellationToken asyncCancellationToken, bool pauseDisposeOrClose = true)
+        {
+            this.asyncCancellationToken = asyncCancellationToken;
+            syncReadPauseCancellationTokenSource = new CancellationTokenSource(this.readTimeout);
+            syncWritePauseCancellationTokenSource = new CancellationTokenSource(this.writeTimeout);
+            this.pauseDisposeOrClose = pauseDisposeOrClose;
+            paused = true;
+        }
+        
+        async Task PauseForeverIfPaused()
+        {
+            if (paused)
+            {
+                await Task.Delay(-1, asyncCancellationToken);
+            }
+        }
+
+        void PauseUntilTimeoutIfPausedSync(bool read, CancellationToken? cancellationToken)
+        {
+            if (paused)
+            {
+                if (cancellationToken == null)
+                {
+                    throw new NotSupportedException("Cancellation token must be provided or this will sleep forever");
+                }
+
+                while (!cancellationToken!.Value.IsCancellationRequested)
+                {
+                    Thread.Sleep(10);
+                }
+
+                // For sync we need to mimic a socket timing out as we don't we rely on the correct timeout behaviour for sync
+                // Simulating this exception
+                // actualException.GetType().Name
+                // "IOException"
+                // actualException.Message
+                // "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.."
+                // actualException.InnerException.GetType().Name
+                // "SocketException"
+                // (actualException.InnerException).Message
+                // "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond."
+                // ((SocketException)actualException.InnerException).ErrorCode
+                // 10060 
+                throw new IOException(
+                    $"Unable to {(read ? "read" : "write")} data {(read ? "from" : "to")} the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.",
+                    new SocketException((int)SocketError.TimedOut));
+            }
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if(pauseDisposeOrClose)
+                await PauseForeverIfPaused();
+
+            await inner.DisposeAsync();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if(pauseDisposeOrClose)
+                PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await PauseForeverIfPaused();
+            await inner.FlushAsync(cancellationToken);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await PauseForeverIfPaused();
+            return await inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await PauseForeverIfPaused();
+            await inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if !NETFRAMEWORK
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await PauseForeverIfPaused();
+            return await inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await PauseForeverIfPaused();
+            await inner.WriteAsync(buffer, cancellationToken);
+        }
+#endif
+
+        public override void Close()
+        {
+            if(pauseDisposeOrClose)
+                PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+
+            inner.Close();
+        }
+
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            await PauseForeverIfPaused();
+            await inner.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override int ReadByte()
+        {
+            PauseUntilTimeoutIfPausedSync(true, syncReadPauseCancellationTokenSource?.Token);
+            return inner.ReadByte();
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            PauseUntilTimeoutIfPausedSync(true, syncReadPauseCancellationTokenSource?.Token);
+            return inner.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            PauseUntilTimeoutIfPausedSync(true, syncReadPauseCancellationTokenSource?.Token);
+            return inner.EndRead(asyncResult);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            return inner.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.EndWrite(asyncResult);
+        }
+
+        public override void Flush()
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            PauseUntilTimeoutIfPausedSync(true, syncReadPauseCancellationTokenSource?.Token);
+            return inner.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            return inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.WriteByte(value);
+        }
+
+#if !NETFRAMEWORK
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.CopyTo(destination, bufferSize);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            PauseUntilTimeoutIfPausedSync(true, syncReadPauseCancellationTokenSource?.Token);
+            return inner.Read(buffer);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            inner.Write(buffer);
+        }
+#endif
+
+#if NETFRAMEWORK
+        public override ObjRef CreateObjRef(Type requestedType)
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            return inner.CreateObjRef(requestedType);
+        }
+
+        public override object? InitializeLifetimeService()
+        {
+            PauseUntilTimeoutIfPausedSync(false, syncWritePauseCancellationTokenSource?.Token);
+            return inner.InitializeLifetimeService();
+        }
+#endif
+
+        public override int ReadTimeout
+        {
+            get => inner.ReadTimeout;
+            set
+            {
+                readTimeout = value;
+                inner.ReadTimeout = value;
+            }
+        }
+
+        public override int WriteTimeout
+        {
+            get => inner.WriteTimeout;
+            set
+            {
+                writeTimeout = value;
+                inner.WriteTimeout = value;
+            }
+        }
+
+        public override bool CanTimeout => inner.CanTimeout;
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/StreamCopyToMethod.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamCopyToMethod.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Halibut.Tests.Transport.Streams
+{
+    public enum StreamCopyToMethod
+    {
+        CopyTo,
+        CopyToWithBufferSize,
+        CopyToAsync,
+        CopyToAsyncWithBufferSize,
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/StreamReadMethod.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamReadMethod.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Halibut.Tests.Transport.Streams
+{
+    public enum StreamReadMethod
+    {
+        Read,
+        ReadByte,
+        ReadAsync,
+#if !NETFRAMEWORK
+        ReadAsyncForMemoryByteArray,
+#endif
+        BeginReadEndWithinCallback,
+        BeginReadEndOutsideCallback
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/StreamWriteMethod.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamWriteMethod.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Halibut.Tests.Transport.Streams
+{
+    public enum StreamWriteMethod
+    {
+        Write,
+        WriteByte,
+        WriteAsync,
+#if !NETFRAMEWORK
+        WriteAsyncForMemoryByteArray,
+#endif
+        BeginWriteEndWithinCallback,
+        BeginWriteEndOutsideCallback
+    }
+}

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -62,9 +62,9 @@ namespace Halibut.Diagnostics
             {
                 if (exception.Message.Contains("System.IO.EndOfStreamException")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("System.Net.Sockets.SocketException (110): Connection timed out")) return HalibutNetworkExceptionType.IsNetworkError;
-                if (exception.Message.Contains("Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("An existing connection was forcibly closed by the remote host.")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("The I/O operation has been aborted because of either a thread exit or an application request")) return HalibutNetworkExceptionType.IsNetworkError;
-                if (exception.Message.Contains("Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.")) return HalibutNetworkExceptionType.IsNetworkError;
             }
 
             return HalibutNetworkExceptionType.UnknownError;

--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -114,7 +114,7 @@ namespace Halibut.Transport.Protocol
 
                         return new { Completed = result.EndOfMessage, Successful = true };
                     },
-                    onCancellationAction: () => { },
+                    onCancellationAction: async () => { await Task.CompletedTask; },
                     getExceptionOnTimeout: () =>
                     {
                         var socketException = new SocketException(10060);

--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -14,7 +14,7 @@ namespace Halibut.Transport.Protocol
     {
         readonly WebSocket context;
         bool isDisposed;
-        readonly CancellationTokenSource cancel = new CancellationTokenSource();
+        readonly CancellationTokenSource cancel = new();
 
         static readonly TimeSpan SendCancelTimeout = TimeSpan.FromSeconds(1);
 
@@ -114,7 +114,8 @@ namespace Halibut.Transport.Protocol
 
                         return new { Completed = result.EndOfMessage, Successful = true };
                     },
-                    onCancellationAction: async () => { await Task.CompletedTask; },
+                    onCancellationAction: null,
+                    onActionTaskExceptionAction: null,
                     getExceptionOnTimeout: () =>
                     {
                         var socketException = new SocketException(10060);
@@ -154,18 +155,15 @@ namespace Halibut.Transport.Protocol
         }
 
         public override bool CanRead => context.State == WebSocketState.Open;
-        public override bool CanSeek { get; } = false;
+        public override bool CanSeek => false;
         public override bool CanWrite => context.State == WebSocketState.Open;
 
-        public override long Length
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public override long Length => throw new NotImplementedException();
 
         public override long Position
         {
-            get { throw new NotImplementedException(); }
-            set { throw new NotImplementedException(); }
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
         void SendCloseMessage()
@@ -180,7 +178,7 @@ namespace Halibut.Transport.Protocol
 
         public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            byte[] buffer = new byte[bufferSize];
+            var buffer = new byte[bufferSize];
             var readLength = await ReadAsync(buffer, 0, bufferSize, cancellationToken);
             await destination.WriteAsync(buffer, 0, readLength, cancellationToken);
         }

--- a/source/Halibut/Transport/Streams/CancellationAndTimeoutTaskWrapper.cs
+++ b/source/Halibut/Transport/Streams/CancellationAndTimeoutTaskWrapper.cs
@@ -10,7 +10,7 @@ namespace Halibut.Transport.Streams
     {
         public static async Task<T> WrapWithCancellationAndTimeout<T>(
             Func<CancellationToken, Task<T>> action,
-            Action onCancellationAction,
+            Func<Task> onCancellationAction,
             Func<Exception> getExceptionOnTimeout,
             TimeSpan timeout,
             string methodName,
@@ -31,7 +31,7 @@ namespace Halibut.Transport.Streams
                 {
                     actionTask.IgnoreUnobservedExceptions();
 
-                    onCancellationAction();
+                    await onCancellationAction();
 
                     ThrowMeaningfulException();
                 }

--- a/source/Halibut/Transport/Streams/SupportsTimeoutsStream.cs
+++ b/source/Halibut/Transport/Streams/SupportsTimeoutsStream.cs
@@ -1,0 +1,100 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if NETFRAMEWORK
+using System.Runtime.Remoting;
+#endif
+
+namespace Halibut.Transport.Streams
+{
+    class SupportsTimeoutsStream : AsyncDisposableStream
+    {
+        readonly Stream inner;
+        int readTimeout;
+        int writeTimeout;
+
+        public SupportsTimeoutsStream(Stream inner, TimeSpan readTimeout, TimeSpan writeTimeout)
+        {
+            this.inner = inner;
+            this.readTimeout = readTimeout.Milliseconds;
+            this.writeTimeout = writeTimeout.Milliseconds;
+        }
+
+        public override async ValueTask DisposeAsync() => await inner.DisposeAsync();
+
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await inner.FlushAsync(cancellationToken);
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => await inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => await inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+#if !NETFRAMEWORK
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => await inner.ReadAsync(buffer, cancellationToken);
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => await inner.WriteAsync(buffer, cancellationToken);
+#endif
+
+        public override void Close() => inner.Close();
+        
+        public override int ReadByte() => inner.ReadByte();
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) => inner.BeginRead(buffer, offset, count, callback, state);
+
+        public override int EndRead(IAsyncResult asyncResult) => inner.EndRead(asyncResult);
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) => inner.BeginWrite(buffer, offset, count, callback, state);
+
+        public override void EndWrite(IAsyncResult asyncResult) => inner.EndWrite(asyncResult);
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        public override void WriteByte(byte value) => inner.WriteByte(value);
+
+#if !NETFRAMEWORK
+        public override int Read(Span<byte> buffer) => inner.Read(buffer);
+
+        public override void Write(ReadOnlySpan<byte> buffer) => inner.Write(buffer);
+#endif
+
+#if NETFRAMEWORK
+        public override ObjRef CreateObjRef(Type requestedType) => inner.CreateObjRef(requestedType);
+
+        public override object? InitializeLifetimeService() => inner.InitializeLifetimeService();
+#endif
+
+        public override int ReadTimeout
+        {
+            get => readTimeout;
+            set => readTimeout = value;
+        }
+
+        public override int WriteTimeout
+        {
+            get => writeTimeout;
+            set => writeTimeout = value;
+        }
+
+        public override bool CanTimeout => true;
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+    }
+}


### PR DESCRIPTION
# Background

Make the NetworkTimeoutStream behave the same for sync calls as it does for async calls by closing the stream on timeout.
- Due to the way some of the streams work e.g. the `DeflateStream` `Dispose` will cause it to `PurgeBuffers`, it has been necessary to make the `NetworkTimeoutStream` handle the case where it is used after it has been closed due to a timeout. Without this logic Halibut will throw an Already Disposed Exception which will look like there is a bug.
![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/9d09c9c2-b088-47e2-9056-c23c2f686eb0)
- The `NetworkTimeoutStream` now tracks when it has timed out along with recording the exception that was throw. If it is used after timeout it will throw the original exception to the caller.

NetworkTimeoutStream should DisposeAsync of the inner stream instead of Close when an async operation is being called.

## Under net48

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/0239ad82-0a20-4553-b68c-430ae75f95fe)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/d36d1900-3ad1-4264-b4d9-2f5ac0c621c5)

## Under net6.0

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/7ad19901-55b2-488e-b040-3e27a1e01703)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/fb22b434-e648-4480-afff-c89c3fb16aff)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
