### PR TITLE
Wrap streams with NetworkTimeoutStream

### DIFF
--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -60,9 +60,8 @@ namespace Halibut.Transport
                 var log = logs.ForEndpoint(serviceEndpoint.BaseUri);
                 using (var client = await TcpConnectionFactory.CreateConnectedTcpClientAsync(serviceEndpoint, halibutTimeoutsAndLimits, log, cancellationToken))
                 {
-                    using (var networkStream = client.GetStream())
+                    await using (var networkTimeoutStream = client.GetNetworkTimeoutStream())
                     {
-                        var networkTimeoutStream = new NetworkTimeoutStream(networkStream);
                         using (var ssl = new SslStream(networkTimeoutStream, false, ValidateCertificate))
                         {
 #if NETFRAMEWORK

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -34,7 +34,7 @@ namespace Halibut.Transport.Protocol
         public MessageExchangeStream(Stream stream, IMessageSerializer serializer, AsyncHalibutFeature asyncHalibutFeature, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, ILog log)
         {
             this.stream = asyncHalibutFeature.IsEnabled() ? 
-                new RewindableBufferStream(new NetworkTimeoutStream(stream), halibutTimeoutsAndLimits.RewindableBufferStreamSize) : 
+                new RewindableBufferStream(stream, halibutTimeoutsAndLimits.RewindableBufferStreamSize) : 
 #pragma warning disable CS0612
                 new RewindableBufferStream(stream, HalibutLimits.RewindableBufferStreamSize);
 #pragma warning restore CS0612

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -340,7 +340,7 @@ namespace Halibut.Transport.Proxy
         
         async Task SendConnectionCommandAsync(string host, int port, CancellationToken cancellationToken)
         {
-            var stream = new NetworkTimeoutStream(TcpClient.GetStream());
+            var stream = TcpClient.GetNetworkTimeoutStream();
             var connectCmd = GetConnectCmd(host, port);
             var request = Encoding.ASCII.GetBytes(connectCmd);
 

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -207,7 +207,13 @@ namespace Halibut.Transport
         async Task ExecuteRequest(TcpClient client)
         {
             var clientName = client.Client.RemoteEndPoint;
-            var stream = client.GetStream();
+            
+            Stream stream = client.GetStream();
+            if (asyncHalibutFeature.IsEnabled())
+            {
+                stream = stream.AsNetworkTimeoutStream();
+            }
+            
             using (var ssl = new SslStream(stream, true, AcceptAnySslCertificate))
             {
                 try
@@ -295,7 +301,7 @@ namespace Halibut.Transport
             }
         }
 
-        void SafelyCloseStream(NetworkStream stream, EndPoint clientName)
+        void SafelyCloseStream(Stream stream, EndPoint clientName)
         {
             try
             {

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStreamExtensionMethods.cs
@@ -1,0 +1,18 @@
+﻿using System.IO;
+using System.Net.Sockets;
+
+namespace Halibut.Transport.Streams
+{
+    public static class NetworkTimeoutStreamExtensionMethods
+    {
+        internal static NetworkTimeoutStream AsNetworkTimeoutStream(this Stream stream)
+        {
+            return new NetworkTimeoutStream(stream);
+        }
+
+        internal static NetworkTimeoutStream GetNetworkTimeoutStream(this TcpClient client)
+        {
+            return new NetworkTimeoutStream(client.GetStream());
+        }
+    }
+}

--- a/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -60,8 +60,7 @@ namespace Halibut.Transport
             var client = await CreateConnectedTcpClientAsync(serviceEndpoint, halibutTimeoutsAndLimits, log, cancellationToken);
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
             
-            var networkStream = client.GetStream();
-            var networkTimeoutStream = new NetworkTimeoutStream(networkStream);
+            var networkTimeoutStream = client.GetNetworkTimeoutStream();
             var ssl = new SslStream(networkTimeoutStream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
 
             log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");


### PR DESCRIPTION
`NetworkTimeoutStream` allows us to add timeout and cancellation support to otherwise unsupported streams. This PR wraps the TCP streams at the lowest level we can (i.e. just after calling `TcpClient.GetStream` to ensure we don't have any streams which don't timeout and wait forever.

Fixes [sc-56419]