### PR TITLE
Make the CompatBinary exit when the test times out if it is still running

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -18,7 +18,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
     /// </summary>
     public class ProxyServiceForwardingRequestToClient
     {
-        public static async Task Run()
+        public static async Task Run(CancellationToken cancellationToken)
         {
             var serviceConnectionType = SettingsHelper.GetServiceConnectionType();
             var serviceCert = SettingsHelper.GetServiceCertificate();
@@ -59,9 +59,9 @@ namespace Halibut.TestUtils.SampleProgram.Base
                         realServiceEndpoint = new ServiceEndPoint(new Uri("poll://SQ-TENTAPOLL"), serviceCert.Thumbprint, proxyDetails);
                         break;
                     case ServiceConnectionType.PollingOverWebSocket:
-                        using (await TcpPortHelper.WaitForLock(CancellationToken.None))
+                        using (await TcpPortHelper.WaitForLock(cancellationToken))
                         {
-                            var webSocketListeningPort = WebSocketListeningPort(client, out var webSocketListeningUrl);
+                            var webSocketListeningPort = WebSocketListeningPort(client, out var webSocketListeningUrl, cancellationToken);
                             Console.WriteLine($"WebSocket Polling listener is listening on: {webSocketListeningUrl}");
                             // Do not change the log message as it is used by the HalibutTestBinaryRunners
                             Console.WriteLine("Polling listener is listening on port: " + webSocketListeningPort);
@@ -74,6 +74,8 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
+
+                cancellationToken.ThrowIfCancellationRequested();
 
                 // A Halibut Runtime which will be the Service that proxies requests to the real Service (Tentacle) in the Test CLR
                 // using an old version of Halibut as the Client which is the thing we are trying to test
@@ -106,16 +108,18 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     await Console.Out.FlushAsync();
 
                     // Run until the Program is terminated
-                    await StayAliveUntilHelper.WaitUntilSignaledToDie();
+                    await StayAliveUntilHelper.WaitUntilSignaledToDie(cancellationToken);
                 }
             }
         }
 
-        public static int WebSocketListeningPort(HalibutRuntime client, out string webSocketListeningUrl)
+        public static int WebSocketListeningPort(HalibutRuntime client, out string webSocketListeningUrl, CancellationToken cancellationToken)
         {
             webSocketListeningUrl = null;
             for (int i = 0; i < 9; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 try
                 {
                     return WebSocketListeningPortAttemptOnce(client, out webSocketListeningUrl);
@@ -125,6 +129,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     Console.WriteLine($"Failed to listen for websocket, trying again. {e}");
                 }
             }
+
             return WebSocketListeningPortAttemptOnce(client, out webSocketListeningUrl);
         }
         

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -108,7 +108,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                     await Console.Out.FlushAsync();
 
                     // Run until the Program is terminated
-                    await StayAliveUntilHelper.WaitUntilSignaledToDie(cancellationToken);
+                    await StayAliveUntilHelper.WaitUntilSignaledToDie();
                 }
             }
         }

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
@@ -7,10 +7,10 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
 {
     public class StayAliveUntilHelper
     {
-        public static async Task WaitUntilSignaledToDie(CancellationToken cancellationToken)
+        public static async Task WaitUntilSignaledToDie()
         {
             var stayAliveFile = SettingsHelper.CompatBinaryStayAliveLockFile();
-            while (!cancellationToken.IsCancellationRequested)
+            while (true)
             {
                 try
                 {
@@ -42,9 +42,8 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
                     Environment.Exit(0);
                 }
 
-                await Task.Delay(2000, cancellationToken);
+                await Task.Delay(2000);
             }
-            
         }
     }
 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,10 +7,10 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
 {
     public class StayAliveUntilHelper
     {
-        public static async Task WaitUntilSignaledToDie()
+        public static async Task WaitUntilSignaledToDie(CancellationToken cancellationToken)
         {
             var stayAliveFile = SettingsHelper.CompatBinaryStayAliveLockFile();
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
@@ -42,8 +41,8 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
                 {
                     Environment.Exit(0);
                 }
-                
-                Thread.Sleep(2000);
+
+                await Task.Delay(2000, cancellationToken);
             }
             
         }

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -136,5 +136,18 @@ namespace Halibut.TestUtils.SampleProgram.Base
         {
             return GetMandatoryBool("WithTentacleServices");
         }
+
+        public static TimeSpan GetTestTimeout()
+        {
+            var timeoutString = GetSetting("TestTimeout");
+
+            if (string.IsNullOrWhiteSpace(timeoutString))
+            {
+                // If a test doesn't have a timeout lets assume we should not run forever.
+                return TimeSpan.FromMinutes(15);
+            }
+
+            return TimeSpan.Parse(timeoutString);
+        }
     }
 }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -5,7 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using CliWrap;
 using Halibut.Logging;
+using Halibut.Tests.Support.ExtensionMethods;
 using Nito.AsyncEx;
+using NUnit.Framework;
 using Serilog;
 
 namespace Halibut.Tests.Support.BackwardsCompatibility
@@ -58,7 +60,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 { CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.LockFile },
                 { "WithStandardServices", availableServices.HasStandardServices.ToString() },
                 { "WithCachingService", availableServices.HasCachingService.ToString() },
-                { "WithTentacleServices", availableServices.HasTentacleServices.ToString() }
+                { "WithTentacleServices", availableServices.HasTentacleServices.ToString() },
+                { "TestTimeout", TestContext.CurrentContext.GetTestTimeout()?.ToString() ?? string.Empty }
             };
 
             if (proxyDetails != null)

--- a/source/Halibut.Tests/Support/ExtensionMethods/TestContextExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/ExtensionMethods/TestContextExtensionMethods.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Halibut.Tests.Support.ExtensionMethods
+{
+    static class TestContextExtensionMethods
+    {
+        public static TestExecutionContext GetTestExecutionContext(this TestContext testContext)
+        {
+            var testExecutionContextField = testContext.GetType().GetField("_testExecutionContext", BindingFlags.NonPublic | BindingFlags.Instance);
+            var testExecutionContext = (TestExecutionContext)testExecutionContextField!.GetValue(testContext);
+
+            return testExecutionContext;
+        }
+
+        public static TimeSpan? GetTestTimeout(this TestContext testContext)
+        {
+            var timeout = TestContext.CurrentContext.GetTestExecutionContext().TestCaseTimeout;
+
+            if (timeout > 0)
+            {
+                return TimeSpan.FromMilliseconds(timeout);
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# Background

Ensure the CompatBinary does not stay running for longer than the test timeout

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
