### PR TITLE
Making tests do async disposal

### DIFF
--- a/source/Halibut.Tests/AsyncServicesFixture.cs
+++ b/source/Halibut.Tests/AsyncServicesFixture.cs
@@ -42,7 +42,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService: false, testNetworkConditions: false)]
         public async Task AsyncServiceWithNoReturnType_CanBeRegisteredAndResolved(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder()
                 .WithAsyncService<ILockService, IAsyncLockService>(() => new AsyncLockService())
                 .Build(CancellationToken);
@@ -62,7 +62,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testAsyncServicesAsWell: true, testSyncService: false, testNetworkConditions: false)]
         public async Task AsyncServiceWithNoParams_CanBeRegisteredAndResolve(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder()
                 .WithAsyncService<ICountingService, IAsyncCountingService>(() => new AsyncCountingService())
                 .Build(CancellationToken);

--- a/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests.BackwardsCompatibility
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task OldInvocationExceptionMessages_AreMappedTo_ServiceInvocationHalibutClientException(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests
             var clientTrustProvider = new DefaultTrustProvider();
             var unauthorizedThumbprint = "";
 
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithCountingService(countingService)
                        .WithClientTrustingTheWrongCertificate()
@@ -64,7 +64,7 @@ namespace Halibut.Tests
             var trustProvider = new DefaultTrustProvider();
             var unauthorizedThumbprint = "";
 
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithCountingService(countingService)
                        .RecordingClientLogs(out var serviceLoggers)
@@ -118,7 +118,7 @@ namespace Halibut.Tests
         public async Task FailWhenPollingServiceHasThumbprintRemovedViaTrustOnly(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             // Arrange
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -156,7 +156,7 @@ namespace Halibut.Tests
         public async Task FailWhenClientPresentsWrongCertificateToListeningService(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var countingService = new CountingService();
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithServiceTrustingTheWrongCertificate()
                        .WithCountingService(countingService)
@@ -180,7 +180,7 @@ namespace Halibut.Tests
         public async Task FailWhenClientPresentsWrongCertificateToPollingService(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var countingService = new CountingService();
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithServiceTrustingTheWrongCertificate()
                        .WithCountingService(countingService)
@@ -219,7 +219,7 @@ namespace Halibut.Tests
         public async Task FailWhenListeningServicePresentsWrongCertificate(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var countingService = new CountingService();
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithClientTrustingTheWrongCertificate()
                        .WithCountingService(countingService)
@@ -239,7 +239,7 @@ namespace Halibut.Tests
         public async Task FailWhenPollingServicePresentsWrongCertificate(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var countingService = new CountingService();
-            using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithClientTrustingTheWrongCertificate()
                        .WithCountingService(countingService)

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -43,7 +43,7 @@ namespace Halibut.Tests
 
         async Task CanCancel_ConnectingOrQueuedRequests(ClientAndServiceTestCase clientAndServiceTestCase, CancellationTokenSource tokenSourceToCancel, HalibutProxyRequestOptions halibutRequestOption)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port).Build())
                        .WithStandardServices()
                        .Build(CancellationToken))
@@ -74,7 +74,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task HalibutProxyRequestOptions_ConnectingCancellationToken_CanNotCancel_InFlightRequests(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithHalibutLoggingLevel(LogLevel.Trace)
                        .WithStandardServices()
                        .Build(CancellationToken))
@@ -126,7 +126,7 @@ namespace Halibut.Tests
 #endif
         public async Task HalibutProxyRequestOptions_InProgressCancellationToken_CanCancel_InFlightRequests(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -167,7 +167,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling:false)]
         public async Task CannotHaveServiceWithHalibutProxyRequestOptions(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .NoService()
                        .WithService<IAmNotAllowed>(() => new AmNotAllowed())
@@ -192,7 +192,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task HalibutProxyRequestOptionsCanBeSentToLatestAndOldServicesThatPreDateHalibutProxyRequestOptions(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -209,7 +209,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false, testAsyncClients: false)]
         public async Task HalibutProxyRequestOptions_CanNotCancel_InFlightRequests_ForSyncServiceCalls(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {

--- a/source/Halibut.Tests/DataStreamFixture.cs
+++ b/source/Halibut.Tests/DataStreamFixture.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests
         [Obsolete]
         public async Task SyncDataStreamWriterCanStillBeUsed(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -43,7 +43,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncClients: false)]
         public async Task AsyncDataStreamsAreUsedWhenInAsync(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithForcingClientProxyType(ForceClientProxyType.AsyncClient)
@@ -70,7 +70,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         public async Task AsyncDataStreamsCanBeUsedInSyncAndAsync(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -11,10 +11,7 @@ using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.TestServices.Async;
 using Halibut.TestUtils.Contracts;
-using Halibut.Transport.Proxy;
-using NSubstitute;
 using NUnit.Framework;
-using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests.Diagnostics
 {
@@ -52,7 +49,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestClientAndLatestServiceTestCases(testNetworkConditions:false)]
             public async Task WhenTheConnectionTerminatesWaitingForAResponse(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithPortForwarding(out var portForwarder)
                            .WithDoSomeActionService(() => portForwarder.Value.EnterKillNewAndExistingConnectionsMode())
@@ -82,7 +79,7 @@ namespace Halibut.Tests.Diagnostics
                 )]
             public async Task WhenTheConnectionPausesWaitingForAResponse(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithPortForwarding(out var portForwarder)
                            .WithDoSomeActionService(() => portForwarder.Value.PauseExistingConnections())
@@ -110,7 +107,7 @@ namespace Halibut.Tests.Diagnostics
                 var services = new DelegateServiceFactory();
                 services.Register<IEchoService>(() => new EchoService());
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .NoService()
                            .Build(CancellationToken))
                 {
@@ -127,7 +124,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
             public async Task BecauseTheListeningTentacleIsNotResponding(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .NoService()
                            .Build(CancellationToken))
                 {
@@ -144,7 +141,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
             public async Task BecauseTheProxyIsNotResponding_TheExceptionShouldBeANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithStandardServices()
                            .WithProxy()
                            .Build(CancellationToken))
@@ -167,7 +164,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
             public async Task BecauseOfAInvalidCertificateException_WhenConnectingToListening_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithClientTrustingTheWrongCertificate()
                            .WithEchoService()
@@ -187,7 +184,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
             public async Task BecauseTheDataStreamHadAnErrorOpeningTheFileWithFileStream_WhenSending_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithStandardServices()
                            .Build(CancellationToken))
                 {
@@ -214,7 +211,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
             public async Task BecauseTheDataStreamThrowAFileNotFoundException_WhenSending_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithStandardServices()
                            .Build(CancellationToken))
                 {
@@ -240,7 +237,7 @@ namespace Halibut.Tests.Diagnostics
             [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
             public async Task BecauseTheServiceThrowAnException_ItIsNotANetworkError(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithStandardServices()
                            .Build(CancellationToken))
                 {

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -31,7 +31,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false, testListening: false)]
         public async Task FailsWhenSendingToPollingMachineButNothingPicksItUp(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .NoService()
                        .Build(CancellationToken))
@@ -53,7 +53,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task FailWhenServerThrowsAnException(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -108,7 +108,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         public async Task FailWhenServerThrowsDuringADataStream(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithHalibutLoggingLevel(LogLevel.Fatal)
                        .As<LatestClientAndLatestServiceBuilder>()

--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests
         public async Task ListeningRetriesAttemptsUpToTheConfiguredValue(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
                        {
@@ -54,7 +54,7 @@ namespace Halibut.Tests
         public async Task ListeningRetriesAttemptsUpToTheConfiguredTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
                        {
@@ -91,7 +91,7 @@ namespace Halibut.Tests
         public async Task ListeningRetryListeningSleepIntervalWorks(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
                        {
@@ -128,7 +128,7 @@ namespace Halibut.Tests
         public async Task ListeningRetriesAttemptsCanEventuallyWork(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
                        {

--- a/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
+++ b/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests
         public async Task TestOnlyHealthConnectionsAreKeptInThePool(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                            .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
                            .Build())

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests
                 {
                     builder = builder.WithForcingClientProxyType(ForceClientProxyType.AsyncClient);
                 }
-                using var clientAndService = await builder.Build(CancellationToken);
+                await using var clientAndService = await builder.Build(CancellationToken);
 
                 var lockService = clientAndService.CreateAsyncClient<ILockService, IAsyncClientLockService>();
 
@@ -83,7 +83,7 @@ namespace Halibut.Tests
                     builder = builder.WithForcingClientProxyType(ForceClientProxyType.AsyncClient);
                 }
                 
-                using var clientAndService = await builder
+                await using var clientAndService = await builder
                     .WithStandardServices()
                     .Build(CancellationToken);
 
@@ -126,7 +126,7 @@ namespace Halibut.Tests
             [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false, testAsyncAndSyncClients: false)]
             public async Task MultipleRequestsCanBeInFlightInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                     .WithStandardServices()
                     .Build(CancellationToken);
 
@@ -185,7 +185,7 @@ namespace Halibut.Tests
             [LatestAndPreviousClientAndServiceVersionsTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false, testAsyncAndSyncClients: false)]
             public async Task SendMessagesToTentacleInParallel(ClientAndServiceTestCase clientAndServiceTestCase)
             {
-                using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                     .WithStandardServices()
                     .Build(CancellationToken);
 

--- a/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
+++ b/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests
                 calls.Add(DateTime.UtcNow);
             });
 
-            using (clientAndService)
+            await using (clientAndService)
             {
                 await doSomeActionService.ActionAsync();
             }
@@ -50,7 +50,7 @@ namespace Halibut.Tests
                 calls.Add(DateTime.UtcNow);
             });
 
-            using (clientAndService)
+            await using (clientAndService)
             {
                 await doSomeActionService.ActionAsync();
 

--- a/source/Halibut.Tests/PollingTentacleDequeuesRequestsInOrderFixture.cs
+++ b/source/Halibut.Tests/PollingTentacleDequeuesRequestsInOrderFixture.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests
         public async Task QueuedUpRequestsShouldBeDequeuedInOrder(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             IPendingRequestQueue pendingRequestQueue = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .AsLatestClientAndLatestServiceBuilder()
                        .WithInstantReconnectPollingRetryPolicy()

--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests
         // PollingOverWebSockets does not support (or use) ProxyDetails if provided.
         public async Task ClientCanSendMessagesToService_WhenUsingAProxy(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithProxy()
                        .Build(CancellationToken))
@@ -37,7 +37,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task ClientTimesOutConnectingToAProxy_WhenTheProxyIsUnavailable(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithHalibutLoggingLevel(LogLevel.Trace)
                        .WithStandardServices()
                        .WithProxy()
@@ -64,7 +64,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task ClientTimesOutConnectingToAProxy_WhenTheProxyHangsDuringConnect(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithHalibutLoggingLevel(LogLevel.Trace)
                        .WithStandardServices()
                        .WithProxy()

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatDoesNotSupportCaching_ResponsesShouldNotBeCached(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -39,7 +39,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatDoesNotSupportCaching_WithClientInterface_ResponsesShouldNotBeCached(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -57,7 +57,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ResponseShouldBeCached(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -75,7 +75,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_WithClientInterface_ResponseShouldBeCached(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -93,7 +93,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ResponseForServiceWithInputParametersShouldBeCached(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -112,7 +112,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_CachedItemShouldBeInvalidatedAfterTheCacheDurationExpires(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -136,7 +136,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentServices(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -154,13 +154,13 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentEndpoints(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndServiceOne = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndServiceOne = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
                 var clientOne = clientAndServiceOne.CreateClient<ICachingService, IAsyncClientCachingService>();
 
-                using var clientAndServiceTwo = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using var clientAndServiceTwo = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .WithCachingService()
                            .Build(CancellationToken);
 
@@ -178,7 +178,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ResponseShouldBeDifferentForDifferentInputParameters(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -196,7 +196,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ClientShouldBeAbleToForceSpecificErrorResponsesToBeCached(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {
@@ -220,7 +220,7 @@ namespace Halibut.Tests
         [LatestClientAndPreviousServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ForAServiceThatSupportsCaching_ErrorResponsesShouldNotBeCachedByDefault(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithCachingService()
                        .Build(CancellationToken))
             {

--- a/source/Halibut.Tests/SerializerFixture.cs
+++ b/source/Halibut.Tests/SerializerFixture.cs
@@ -15,7 +15,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         public async Task HalibutSerializerIsKeptUpToDateWithPollingTentacle(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithHalibutLoggingLevel(LogLevel.Info)
                        .Build(CancellationToken))

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -375,7 +375,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             readonly DisposableCollection disposableCollection;
             readonly CancellationTokenSource cancellationTokenSource;
 
-            public ClientAndService(HalibutRuntime proxyClient,
+            public ClientAndService(
+                HalibutRuntime proxyClient,
                 ProxyHalibutTestBinaryRunner.RoundTripRunningOldHalibutBinary runningOldHalibutBinary,
                 Uri serviceUri,
                 CertAndThumbprint serviceCertAndThumbprint,
@@ -479,7 +480,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
             }
 
-            public void Dispose()
+            public async ValueTask DisposeAsync()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();
                 
@@ -490,10 +491,10 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
                 void LogError(Exception e) => logger.Warning(e, "Ignoring error in dispose");
 
-                Try.CatchingError(() => cancellationTokenSource?.Cancel(), LogError);
+                Try.CatchingError(() => cancellationTokenSource.Cancel(), LogError);
                 if (Client.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
                 {
-                    Try.DisposingAsync(Client, LogError).GetAwaiter().GetResult();
+                    await Try.DisposingAsync(Client, LogError);
                 }
                 else
                 {
@@ -502,7 +503,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 Try.CatchingError(runningOldHalibutBinary.Dispose, LogError);
                 if (service.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
                 {
-                    Try.DisposingAsync(service, LogError).GetAwaiter().GetResult();
+                    await Try.DisposingAsync(service, LogError);
                 }
                 else
                 {
@@ -511,7 +512,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 Try.CatchingError(() => HttpProxy?.Dispose(), LogError);
                 Try.CatchingError(() => PortForwarder?.Dispose(), LogError);
                 Try.CatchingError(disposableCollection.Dispose, LogError); ;
-                Try.CatchingError(() => cancellationTokenSource?.Dispose(), LogError);
+                Try.CatchingError(() => cancellationTokenSource.Dispose(), LogError);
             }
         }
     }

--- a/source/Halibut.Tests/Support/IClientAndService.cs
+++ b/source/Halibut.Tests/Support/IClientAndService.cs
@@ -6,7 +6,7 @@ using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests.Support
 {
-    public interface IClientAndService : IDisposable
+    public interface IClientAndService : IAsyncDisposable
     {
         HalibutRuntime Client { get; }
         ServiceEndPoint ServiceEndPoint { get; }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -525,7 +525,8 @@ namespace Halibut.Tests.Support
             readonly CancellationTokenSource cancellationTokenSource;
             readonly ForceClientProxyType? forceClientProxyType;
 
-            public ClientAndService(HalibutRuntime client,
+            public ClientAndService(
+                HalibutRuntime client,
                 HalibutRuntime service,
                 Uri serviceUri,
                 string thumbprint,
@@ -607,7 +608,7 @@ namespace Halibut.Tests.Support
                 return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
             }
 
-            public void Dispose()
+            public async ValueTask DisposeAsync()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();
 
@@ -618,11 +619,11 @@ namespace Halibut.Tests.Support
 
                 void LogError(Exception e) => logger.Warning(e, "Ignoring error in dispose");
 
-                Try.CatchingError(() => cancellationTokenSource?.Cancel(), LogError);
+                Try.CatchingError(() => cancellationTokenSource.Cancel(), LogError);
 
                 if (Client.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
                 {
-                    Try.DisposingAsync(Client, LogError).GetAwaiter().GetResult();
+                    await Try.DisposingAsync(Client, LogError);
                 }
                 else
                 {
@@ -633,7 +634,7 @@ namespace Halibut.Tests.Support
                 {
                     if (Service.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
                     {
-                        Try.DisposingAsync(Service, LogError).GetAwaiter().GetResult();
+                        await Try.DisposingAsync(Service, LogError);
                     }
                     else
                     {
@@ -644,7 +645,7 @@ namespace Halibut.Tests.Support
                 Try.CatchingError(() => HttpProxy?.Dispose(), LogError);
                 Try.CatchingError(() => PortForwarder?.Dispose(), LogError);
                 Try.CatchingError(disposableCollection.Dispose, LogError);
-                Try.CatchingError(() => cancellationTokenSource?.Dispose(), LogError);
+                Try.CatchingError(() => cancellationTokenSource.Dispose(), LogError);
             }
         }
     }

--- a/source/Halibut.Tests/Tentacle/WhenCallingServicesSimilarToTheOnesInTentacle.cs
+++ b/source/Halibut.Tests/Tentacle/WhenCallingServicesSimilarToTheOnesInTentacle.cs
@@ -25,7 +25,7 @@ namespace Halibut.Tests.Tentacle
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task FilesCanBeDownloaded(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
                        .Build(CancellationToken))
             {
@@ -60,7 +60,7 @@ namespace Halibut.Tests.Tentacle
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task FilesCanBeUploaded(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
                        .Build(CancellationToken))
             {
@@ -110,7 +110,7 @@ namespace Halibut.Tests.Tentacle
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ScriptCanBeExecutedWithScriptServiceV1(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
                        .Build(CancellationToken))
             {
@@ -151,7 +151,7 @@ namespace Halibut.Tests.Tentacle
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ScriptCanBeExecutedWithScriptServiceV2(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithTentacleServices()
                        .Build(CancellationToken))
             {

--- a/source/Halibut.Tests/TestPortForwarderFixture.cs
+++ b/source/Halibut.Tests/TestPortForwarderFixture.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ClientCanSendMessagesToTentacle_WithEchoService_AndPortForwrding(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
                        .Build(CancellationToken))
@@ -36,7 +36,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task ClientCanNotSendMessagesToTentacle_WithEchoService_AndBrokenPortForwarding(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
                        .Build(CancellationToken))
@@ -59,7 +59,7 @@ namespace Halibut.Tests
         // PollingOverWebSockets does not support (or use) ProxyDetails if provided.
         public async Task ClientCanSendMessagesToTentacle_WithEchoService_AndPortForwarding_AndProxy(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .WithPortForwarding(i => PortForwarderUtil.ForwardingToLocalPort(i).Build())
                        .WithProxy()

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -25,7 +25,7 @@ namespace Halibut.Tests.Timeouts
         {
             var dataSentSizes = new List<long>();
             long? pauseStreamWhenServiceSendsMessageOfSize = null;
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                            .WithPortForwarderDataLogging(clientAndServiceTestCase.ServiceConnectionType)
                            .WithPortForwarderServiceSentDataObserver(clientAndServiceTestCase.ServiceConnectionType, (tcpPump, stream) =>

--- a/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
+++ b/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests.Timeouts
         public async Task WhenNoMessagesAreSentToAPollingTentacle_ThePollingRequestQueueCausesNullMessagesToBeSent_KeepingTheConnectionAlive(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var timeSpansBetweenDataFlowing = new ConcurrentBag<TimeSpan>();
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                            .WithDataObserver(() =>
                            {

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -24,7 +24,7 @@ namespace Halibut.Tests.Timeouts
         public async Task HalibutTimeoutsAndLimits_AppliesToTcpClientReceiveTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var expectedTimeout = clientAndServiceTestCase.SyncOrAsync == SyncOrAsync.Sync ? HalibutLimits.TcpClientReceiveTimeout : TimeSpan.FromSeconds(10);
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port).WithPortForwarderDataLogging(clientAndServiceTestCase.ServiceConnectionType).Build())
                        .WithPortForwarding(out var portForwarderRef)
@@ -66,7 +66,7 @@ namespace Halibut.Tests.Timeouts
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task WhenThenNetworkIsPaused_WhileReadingAResponseMessage_ATcpReadTimeoutOccurs_and_FurtherRequestsCanBeMade(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(out var portForwarderRef)
                        .WithEchoService()
@@ -95,7 +95,7 @@ namespace Halibut.Tests.Timeouts
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task WhenThenNetworkIsPaused_WhileReadingAResponseMessageDataStream_ATcpReadTimeoutOccurs_and_FurtherRequestsCanBeMade(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(out var portForwarderRef)
                        .WithEchoService()
@@ -129,7 +129,7 @@ namespace Halibut.Tests.Timeouts
         {
             var numberOfBytesBeforePausingAStream = 1024 * 1024; // 1MB
 
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                            .PauseSingleStreamAfterANumberOfBytesHaveBeenSet(numberOfBytesBeforePausingAStream)
@@ -187,7 +187,7 @@ namespace Halibut.Tests.Timeouts
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task WhenThenNetworkIsPaused_WhileSendingADataStreamAsPartOfARequestMessage_ATcpWriteTimeoutOccurs_and_FurtherRequestsCanBeMade(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(out var portForwarderRef)
                        .WithEchoService()

--- a/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
+++ b/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
@@ -37,7 +37,7 @@ namespace Halibut.Tests.Timeouts
                 .Build();
             var dataTransferObserverDoNothing = new DataTransferObserverBuilder().Build();
             
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                            .WithDataObserver(() =>

--- a/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests.Transport
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
         public async Task DiscoverMethodReturnsEndpointDetails(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder()
                 .Build(CancellationToken);
 
@@ -52,7 +52,7 @@ namespace Halibut.Tests.Transport
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling:false)]
         public async Task OctopusCanDiscoverTentacle(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .AsLatestClientAndLatestServiceBuilder()
                        .Build(CancellationToken))
             {
@@ -73,7 +73,7 @@ namespace Halibut.Tests.Transport
                 .Build();
             var dataTransferObserverDoNothing = new DataTransferObserverBuilder().Build();
 
-            using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder()
                 .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                     .WithDataObserver(() => new BiDirectionalDataTransferObserver(dataTransferObserverDoNothing, dataTransferObserverPauser))

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases()]
         public async Task OctopusCanSendMessagesToTentacle_WithEchoService(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -38,7 +38,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task LargeMessages(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -60,7 +60,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases()]
         public async Task OctopusCanSendMessagesToTentacle_WithSupportedServices(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -79,7 +79,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases()]
         public async Task StreamsCanBeSent(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -101,7 +101,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task SupportsDifferentServiceContractMethods(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -139,7 +139,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
         public async Task StreamsCanBeSentWithProgressReporting(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
@@ -171,7 +171,7 @@ namespace Halibut.Tests
         [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task OctopusCanSendAndReceiveComplexObjects_WithMultipleDataStreams(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase
+            await using (var clientAndService = await clientAndServiceTestCase
                        .CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))
@@ -222,7 +222,7 @@ namespace Halibut.Tests
                 new(ComplexEnum.RequestValue3, "ComplexSet #3"),
             };
 
-            using (var clientAndService = await clientAndServiceTestCase
+            await using (var clientAndService = await clientAndServiceTestCase
                        .CreateTestCaseBuilder()
                        .WithStandardServices()
                        .Build(CancellationToken))

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests
         {
             var services = new SingleServiceFactory(new object(), typeof(EchoService));
 
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithServiceFactory(services)
                        .Build(CancellationToken))

--- a/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAServiceThatDoesNotExist.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testAsyncServicesAsWell: true)]
         public async Task AServiceNotFoundHalibutClientExceptionShouldBeRaisedByTheClient(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -27,7 +27,7 @@ namespace Halibut.Tests
             {
                 var cancellationTokenSource = new CancellationTokenSource();
                 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .NoService()
                            .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, cancellationTokenSource)))
@@ -47,7 +47,7 @@ namespace Halibut.Tests
                 var tokenSourceToCancel = new CancellationTokenSource();
                 var halibutProxyRequestOptions = new HalibutProxyRequestOptions(tokenSourceToCancel.Token, null);
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .NoService()
                            .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, tokenSourceToCancel)))
@@ -70,7 +70,7 @@ namespace Halibut.Tests
             {
                 var (tokenSourcesToCancel, halibutProxyRequestOptions) = CreateTokenSourceAndHalibutProxyRequestOptions(connectingCancellationTokenCancelled, inProgressCancellationTokenCancelled);
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .NoService()
                            .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, tokenSourcesToCancel)))
@@ -92,7 +92,7 @@ namespace Halibut.Tests
                 var calls = new List<DateTime>();
                 var tokenSourceToCancel = new CancellationTokenSource();
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithDoSomeActionService(() =>
                            {
@@ -124,7 +124,7 @@ namespace Halibut.Tests
                 var tokenSourceToCancel = new CancellationTokenSource();
                 var halibutProxyRequestOptions = new HalibutProxyRequestOptions(tokenSourceToCancel.Token, null);
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithDoSomeActionService(() =>
                            {
@@ -157,7 +157,7 @@ namespace Halibut.Tests
                     connectingCancellationTokenCancelled: true, 
                     inProgressCancellationTokenCancelled: false);
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithDoSomeActionService(() =>
                            {
@@ -192,7 +192,7 @@ namespace Halibut.Tests
                 var calls = new List<DateTime>();
                 var (tokenSourcesToCancel, halibutProxyRequestOptions) = CreateTokenSourceAndHalibutProxyRequestOptions(connectingCancellationTokenCancelled, inProgressCancellationTokenCancelled);
 
-                using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                            .AsLatestClientAndLatestServiceBuilder()
                            .WithHalibutLoggingLevel(LogLevel.Trace)
                            .WithDoSomeActionService(() =>

--- a/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionIsKilledWhileWaitingForTheResponse.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         public async Task AResponseShouldBeQuicklyReturned(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(out var portForwarder)
                        .WithDoSomeActionService(() => portForwarder.Value.Dispose())

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket:false, testPolling:false)]
         public async Task HalibutCanRecoverFromIdleTcpDisconnect(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithEchoService()
                        .WithPortForwarding()


### PR DESCRIPTION
[sc-57004]

# Background

We want to make all our tests dispose asynchronously if they are an async test, and synchronously if they are a sync test.

# Results

Related to https://github.com/OctopusDeploy/Issues/issues/8266

## Before

We currently already do what we want to achieve. But we do it via the 'synchronous' way of disposing.

## After

We have changed `IClientAndService` from being `IDisposable` to `IAsyncDisposable`, made the dispose method async friendly, and made all tests that use builders use `await using` instead of `using`

# How to review this PR
All changes are going from `await using` instead of `using`.

To help make reviewing easier, I have commented the changes that are more than just this.

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
