### PR TITLE
Ensure the NetworkTimeoutStream always closes the inner Stream on timeout for async operations

### DIFF
--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -14,7 +14,7 @@ namespace Halibut.Transport.Protocol
     {
         readonly WebSocket context;
         bool isDisposed;
-        readonly CancellationTokenSource cancel = new CancellationTokenSource();
+        readonly CancellationTokenSource cancel = new();
 
         static readonly TimeSpan SendCancelTimeout = TimeSpan.FromSeconds(1);
 
@@ -114,7 +114,8 @@ namespace Halibut.Transport.Protocol
 
                         return new { Completed = result.EndOfMessage, Successful = true };
                     },
-                    onCancellationAction: async () => { await Task.CompletedTask; },
+                    onCancellationAction: null,
+                    onActionTaskExceptionAction: null,
                     getExceptionOnTimeout: () =>
                     {
                         var socketException = new SocketException(10060);
@@ -154,18 +155,15 @@ namespace Halibut.Transport.Protocol
         }
 
         public override bool CanRead => context.State == WebSocketState.Open;
-        public override bool CanSeek { get; } = false;
+        public override bool CanSeek => false;
         public override bool CanWrite => context.State == WebSocketState.Open;
 
-        public override long Length
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public override long Length => throw new NotImplementedException();
 
         public override long Position
         {
-            get { throw new NotImplementedException(); }
-            set { throw new NotImplementedException(); }
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
         }
 
         void SendCloseMessage()
@@ -180,7 +178,7 @@ namespace Halibut.Transport.Protocol
 
         public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            byte[] buffer = new byte[bufferSize];
+            var buffer = new byte[bufferSize];
             var readLength = await ReadAsync(buffer, 0, bufferSize, cancellationToken);
             await destination.WriteAsync(buffer, 0, readLength, cancellationToken);
         }


### PR DESCRIPTION
# Background

Under net6.0, when performing async operations on a NetworkStream, a cancellation token can be used to stop the async IO operation. Under net48 this cancellation token is not fully respected and will only cancel the operation if the cancellation token is cancelled before the method is called. The NetworkTimeoutStream was added to address this inconsistent behaviour as well as enforcing timeouts for async IO operations which do not respect the stream timeouts. A decision was made to always close the stream if cancellation or timeout occurred to ensure consistent behaviour and stop the stream from being used after a request timed out or was cancelled.

This PR fixes a possible race condition in the `NetworkTimeoutStream` that would introduce inconsistent behaviour between net48 and net6.0. In a timeout or cancellation scenario, if the IO operation task completed before the timeout task it is possible that the stream would not be closed (disposed). This differs from the behaviour if the timeout task completes, where the stream will be closed.

As this is a race condition in the implementation it is difficult to add a test for this scenario. It was manually verified to work by changing the implementation to ensure the race condition occurred and verify all the tests under net6.0 pass and some tests under net48 fail (as the NetworkStream doesn't respect cancellation so the race condition can't occur).

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/e0e78eb0-3aad-4d87-a70a-e20ebf81d1fa)


This PR caters for the race condition. An alternative to this would be to change the implementation so that the net6.0 implementation is different to the net4.8 implementation, and so remove the race condition.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
