### PR TITLE
Remove underscores from required methods in AsyncStream

### DIFF
--- a/source/Halibut.Tests/Transport/Streams/AsyncStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/AsyncStreamFixture.cs
@@ -64,22 +64,22 @@ namespace Halibut.Tests.Transport.Streams
             set => stream.Position = value;
         }
 
-        protected override Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return stream.ReadAsync(buffer, offset, count, cancellationToken);
         }
 
-        protected override Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return stream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
-        protected override Task _FlushAsync(CancellationToken cancellationToken)
+        public override Task FlushAsync(CancellationToken cancellationToken)
         {
             return stream.FlushAsync(cancellationToken);
         }
 
-        protected override ValueTask _DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
             return stream.DisposeAsync();
         }

--- a/source/Halibut/Transport/Streams/AsyncStream.cs
+++ b/source/Halibut/Transport/Streams/AsyncStream.cs
@@ -16,36 +16,17 @@ namespace Halibut.Transport.Streams
     /// </summary>
     public abstract class AsyncStream : AsyncDisposableStream
     {
-        public sealed override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return await _ReadAsync(buffer, offset, count, cancellationToken);
-        }
+        
+        public abstract override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
-        protected abstract Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
-        public sealed override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            await _WriteAsync(buffer, offset, count, cancellationToken);
-        }
+        public abstract override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
 
-        protected abstract Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken);
+        public abstract override Task FlushAsync(CancellationToken cancellationToken);
 
-        public sealed override async Task FlushAsync(CancellationToken cancellationToken)
-        {
-            await _FlushAsync(cancellationToken);
-        }
-
-        protected abstract Task _FlushAsync(CancellationToken cancellationToken);
-
-#if NETFRAMEWORK
-        public sealed override ValueTask DisposeAsync()
-        {
-            return _DisposeAsync();
-        }
-#else
-        public sealed override ValueTask DisposeAsync() => _DisposeAsync();
+#if !NETFRAMEWORK
+        public abstract override ValueTask DisposeAsync();
 #endif
-        protected abstract ValueTask _DisposeAsync();
 
         /**
          * Ensures that calls to old APM-style async methods are redirected
@@ -55,7 +36,7 @@ namespace Halibut.Transport.Streams
         {
             // BeginRead does not respect timeouts. So force it to use ReadAsync, which does.
             // Redirect to ReadAsync to ensure code execution stays async.
-            return _ReadAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
+            return ReadAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
         }
 
         public sealed override int EndRead(IAsyncResult asyncResult)
@@ -74,7 +55,7 @@ namespace Halibut.Transport.Streams
         {
             // BeginWrite does not respect timeouts. So force it to use ReadAsync, which does.
             // Redirect to BeginWrite to ensure code execution stays async.
-            return _WriteAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
+            return WriteAsync(buffer, offset, count, CancellationToken.None).AsAsynchronousProgrammingModel(callback, state);
         }
 
         public sealed override void EndWrite(IAsyncResult asyncResult)

--- a/source/Halibut/Transport/Streams/ByteCountingStream.cs
+++ b/source/Halibut/Transport/Streams/ByteCountingStream.cs
@@ -45,7 +45,7 @@ namespace Halibut.Transport.Streams
             }
         }
 
-        protected override async ValueTask _DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             if (onDispose == OnDispose.DisposeInputStream)
             {
@@ -75,9 +75,9 @@ namespace Halibut.Transport.Streams
 
         public override void Flush() => countBytesFromStream.Flush();
 
-        protected override Task _FlushAsync(CancellationToken cancellationToken) => countBytesFromStream.FlushAsync(cancellationToken);
+        public override Task FlushAsync(CancellationToken cancellationToken) => countBytesFromStream.FlushAsync(cancellationToken);
 
-        protected override async Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             var bytesRead = await countBytesFromStream.ReadAsync(buffer, offset, count, cancellationToken);
 
@@ -86,7 +86,7 @@ namespace Halibut.Transport.Streams
             return bytesRead;
         }
 
-        protected override async Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             await countBytesFromStream.WriteAsync(buffer, offset, count, cancellationToken);
             BytesWritten += count;

--- a/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
+++ b/source/Halibut/Transport/Streams/ErrorRecordingStream.cs
@@ -43,7 +43,7 @@ namespace Halibut.Transport.Streams
             
         }
 
-        protected override async Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {
@@ -82,7 +82,7 @@ namespace Halibut.Transport.Streams
             }
         }
         
-        protected override async Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             try
             {
@@ -95,7 +95,7 @@ namespace Halibut.Transport.Streams
             }
         }
 
-        protected override async Task _FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -130,7 +130,7 @@ namespace Halibut.Transport.Streams
             }
         }
 
-        protected override async ValueTask _DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             if (closeInner)
             {

--- a/source/Halibut/Transport/Streams/ReadIntoMemoryBufferStream.cs
+++ b/source/Halibut/Transport/Streams/ReadIntoMemoryBufferStream.cs
@@ -35,7 +35,7 @@ namespace Halibut.Transport.Streams
             }
         }
 
-        protected override async ValueTask _DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             await memoryBuffer.DisposeAsync();
 
@@ -84,7 +84,7 @@ namespace Halibut.Transport.Streams
 
         public override void Flush() => throw new NotSupportedException();
         
-        protected override Task _FlushAsync(CancellationToken cancellationToken)
+        public override Task FlushAsync(CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }
@@ -99,7 +99,7 @@ namespace Halibut.Transport.Streams
             return sourceStream.Read(buffer, offset, count);
         }
 
-        protected override async Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (ShouldReadFromMemoryStream)
             {
@@ -116,7 +116,7 @@ namespace Halibut.Transport.Streams
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
         
-        protected override Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }

--- a/source/Halibut/Transport/Streams/RewindableBufferStream.cs
+++ b/source/Halibut/Transport/Streams/RewindableBufferStream.cs
@@ -107,7 +107,7 @@ namespace Halibut.Transport.Streams
         /// <param name="count"><inheritdoc/></param>
         /// <param name="cancellationToken"><inheritdoc/></param>
         /// <returns><inheritdoc/></returns>
-        protected override async Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             count = ReduceReadCountToBufferSize(count);
             var rewoundCount = ReadFromRewindBuffer(buffer, offset, count);
@@ -136,17 +136,17 @@ namespace Halibut.Transport.Streams
             baseStream.Write(buffer, offset, count);
         }
 
-        protected override async Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             await baseStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
         
-        protected override Task _FlushAsync(CancellationToken cancellationToken)
+        public override Task FlushAsync(CancellationToken cancellationToken)
         {
             return baseStream.FlushAsync(cancellationToken);
         }
 
-        protected override ValueTask _DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
             return baseStream.DisposeAsync();
         }

--- a/source/Halibut/Transport/Streams/WriteIntoMemoryBufferStream.cs
+++ b/source/Halibut/Transport/Streams/WriteIntoMemoryBufferStream.cs
@@ -54,12 +54,12 @@ namespace Halibut.Transport.Streams
             }
         }
 
-        protected override Task _FlushAsync(CancellationToken cancellationToken)
+        public override Task FlushAsync(CancellationToken cancellationToken)
         {
             return innerStream.FlushAsync(cancellationToken);
         }
 
-        protected override async ValueTask _DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
             if (usingMemoryBuffer)
             {
@@ -98,12 +98,12 @@ namespace Halibut.Transport.Streams
         public override void SetLength(long value) => throw new NotSupportedException();
         public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-        protected override Task<int> _ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }
 
-        protected override async Task _WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (usingMemoryBuffer)
             {


### PR DESCRIPTION
# Background

Updates the sub classes of AsyncStream such that they do not need underscore yet are required to implement the min set of async methods.

This makes use of a language feature which allows overriding a implementation method as being once again abstract thus forcing sub classes to implement those methods.

# Results

## Before

Hate of the underscore:
![image](https://github.com/OctopusDeploy/Halibut/assets/7076477/b3456f8f-9063-4186-a896-71428aacf8e8)

![image](https://github.com/OctopusDeploy/Halibut/assets/7076477/875258ac-108e-4081-a447-e63c3871f938)

## After

![image](https://github.com/OctopusDeploy/Halibut/assets/7076477/90d10fb7-c390-436e-aaa4-5738a2620b20)

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
