### PR TITLE
WriteIntoMemoryBufferStream should not try to write bytes twice

### DIFF
--- a/source/Halibut.Tests/Support/Streams/ActionBeforeWriteStream.cs
+++ b/source/Halibut.Tests/Support/Streams/ActionBeforeWriteStream.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Transport.Streams;
+
+namespace Halibut.Tests.Support.Streams
+{
+    public class ActionBeforeWriteStream : AsyncStream
+    {
+        readonly Stream stream;
+        public Action BeforeWrite = () => {};
+
+        public ActionBeforeWriteStream(Stream stream)
+        {
+            this.stream = stream;
+        }
+
+        public override void Flush()
+        {
+            stream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return stream.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return stream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            BeforeWrite();
+            return stream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return stream.FlushAsync(cancellationToken);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            return stream.DisposeAsync();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return stream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            stream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            BeforeWrite();
+            stream.Write(buffer, offset, count);
+        }
+
+        public override bool CanRead => stream.CanRead;
+
+        public override bool CanSeek => stream.CanSeek;
+
+        public override bool CanWrite => stream.CanWrite;
+
+        public override long Length => stream.Length;
+
+        public override long Position
+        {
+            get => stream.Position;
+            set => stream.Position = value;
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/WriteIntoMemoryBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/WriteIntoMemoryBufferStreamFixture.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.Streams;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Util;
 using Halibut.Transport.Streams;
@@ -160,6 +162,24 @@ namespace Halibut.Tests.Transport.Streams
             // Assert
             memoryStream.Length.Should().Be(bytesToWrite.Length);
             sut.BytesWrittenIntoMemory.Should().Be(writeIntoMemoryLimitBytes);
+        }
+        
+        [Test]
+        public async Task AfterAFailedWriteDisposeShouldNotAttemptToWriteThoseBytesAgain()
+        {
+            using var memoryStream = new MemoryStream();
+            using var actionBeforeWriteStream = new ActionBeforeWriteStream(memoryStream);
+            actionBeforeWriteStream.BeforeWrite = () => throw new Exception("Oh no");
+            var sut = new WriteIntoMemoryBufferStream(actionBeforeWriteStream, 8192, OnDispose.LeaveInputStreamOpen);
+
+            sut.WriteString("Some");
+
+            await AssertAsync.Throws<Exception>(async () => await sut.WriteBufferToUnderlyingStream(CancellationToken));
+            
+            memoryStream.Length.Should().Be(0);
+
+            // This should not throw since it should not attempt to write the same bytes to the stream. 
+            await sut.DisposeAsync();
         }
     }
 }

--- a/source/Halibut/Transport/Streams/WriteIntoMemoryBufferStream.cs
+++ b/source/Halibut/Transport/Streams/WriteIntoMemoryBufferStream.cs
@@ -117,8 +117,8 @@ namespace Halibut.Transport.Streams
 
                 // We tried our best, but will no longer fit in memory. Transition over to use the sinkStream.
                 memoryBuffer.Position = 0;
-                await memoryBuffer.CopyToAsync(innerStream, 8192, cancellationToken);
                 usingMemoryBuffer = false;
+                await memoryBuffer.CopyToAsync(innerStream, 8192, cancellationToken);
             }
 
             await innerStream.WriteAsync(buffer, offset, count, cancellationToken);
@@ -138,8 +138,8 @@ namespace Halibut.Transport.Streams
 
                 // We tried our best, but will no longer fit in memory. Transition over to use the sinkStream.
                 memoryBuffer.Position = 0;
-                memoryBuffer.CopyTo(innerStream);
                 usingMemoryBuffer = false;
+                memoryBuffer.CopyTo(innerStream);
             }
 
             innerStream.Write(buffer, offset, count);

--- a/source/Halibut/Transport/Streams/WriteIntoMemoryBufferStream.cs
+++ b/source/Halibut/Transport/Streams/WriteIntoMemoryBufferStream.cs
@@ -150,9 +150,10 @@ namespace Halibut.Transport.Streams
             if (usingMemoryBuffer)
             {
                 memoryBuffer.Position = 0;
-                await memoryBuffer.CopyToAsync(innerStream, 8192, cancellationToken);
-
+                // Mark we are not using the memory buffer here, since if the write below fails
+                // on dispose we will attempt to write the data again!
                 usingMemoryBuffer = false;
+                await memoryBuffer.CopyToAsync(innerStream, 8192, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
# Background

I am seeing exceptions in the dispose method of the `WriteIntoMemoryBufferStream`. This is likely to be because `WriteBufferToUnderlyingStream` fails and then it tries to do the same write again in `dispose`.

We should never attempt to re-write the same bytes on a stream after a stream has thrown an exception.

[SC-57434]
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
