### PR TITLE
Clean up SecureClient async calls

### DIFF
--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -182,8 +182,11 @@ namespace Halibut.Transport
                     }
                     catch
                     {
-                        // TODO - ASYNC ME UP!
-                        connection?.Dispose();
+                        if (connection != null)
+                        {
+                            await connection.DisposeAsync();
+                        }
+                        
                         if (connectionManager.IsDisposed)
                             return;
                         throw;


### PR DESCRIPTION
This PR ensures that `SecureClient` calls AsyncDispose on the connection if an exception is thrown, as per [sc-57239]