### PR TITLE
Set the Test Filter and if dot memory tests should be run via command line arguments when running tests via nuke

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -74,6 +74,10 @@
           "type": "string",
           "description": "Root directory during build execution"
         },
+        "RunDotMemoryTests": {
+          "type": "boolean",
+          "description": "True if dot memory tests should be run, otherwise false. Default to True for Windows and False for Linux"
+        },
         "Skip": {
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
@@ -121,6 +125,10 @@
               "TestWindowsNet60"
             ]
           }
+        },
+        "TestFilter": {
+          "type": "string",
+          "description": "The test Filter passed to dotnet test e.g. TestCategory=Async"
         },
         "Verbosity": {
           "type": "string",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -37,6 +37,12 @@ class Build : NukeBuild
     [OctoVersion(UpdateBuildNumber = true, BranchMember = nameof(BranchName), AutoDetectBranchMember = nameof(AutoDetectBranch), Framework = "net6.0")]
     readonly OctoVersionInfo OctoVersionInfo;
 
+    [Parameter("The test Filter passed to dotnet test e.g. TestCategory=Async")]
+    readonly string TestFilter;
+
+    [Parameter("True if dot memory tests should be run, otherwise false. Default to True for Windows and False for Linux")]
+    readonly bool? RunDotMemoryTests;
+
     static AbsolutePath SourceDirectory => RootDirectory / "source";
     static AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
     static AbsolutePath LocalPackagesDirectory => RootDirectory / ".." / "LocalPackages";
@@ -81,7 +87,7 @@ class Build : NukeBuild
     }
 
     [PublicAPI]
-    Target TestWindows => _ => TestDefinition(_, Compile, null, runDotMemoryTests:true);
+    Target TestWindows => _ => TestDefinition(_, Compile, null, runDotMemoryTests: true);
 
     [PublicAPI]
     Target TestLinux => _ => TestDefinition(_, Compile, null, runDotMemoryTests: false);
@@ -98,7 +104,7 @@ class Build : NukeBuild
             .DependsOn(dependsOn)
             .Executes(() =>
             {
-                if (runDotMemoryTests)
+                if (RunDotMemoryTests ?? runDotMemoryTests)
                 {
                     var frameworkOption = framework != null ? $"--framework={framework}" : "";
 
@@ -109,6 +115,7 @@ class Build : NukeBuild
                     .SetProjectFile(Solution.Halibut_Tests)
                     .SetConfiguration(Configuration)
                     .SetFramework(framework)
+                    .SetFilter(TestFilter)
                     .EnableNoBuild()
                     .EnableNoRestore()
                     .EnableBlameCrash()


### PR DESCRIPTION
# Background

This PR allows the test [Filter](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test#filter-option-details) and if the dot memory tests should be run to be set via command line arguments when running tests via nuke

It will allow tests to be split across TeamCity build configurations e.g.

`.\build.cmd -target TestWindowsNet48 -TestFilter TestCategory!=PollingOverWebSocket -RunDotMemoryTests true`
`.\build.cmd -target TestWindowsNet48 -TestFilter TestCategory=PollingOverWebSocket -RunDotMemoryTests false`

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
