### PR TITLE
HTTPProxy client no longer requires all headers to arrive together (async only)

### DIFF
--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -79,10 +79,13 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
                 });
 
-                (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello")))
-                    .And.Message.Should().ContainAny(
+                var exception = (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello"))).And;
+                Logger.Information(exception, "Got exception, we were expecting one.");    
+                exception.Message.Should().ContainAny(
                         "No connection could be made because the target machine actively refused it",
                         "the polling endpoint did not collect the request within the allowed time",
+                        "Unable to read data from the transport connection: Connection timed out.",
+                        "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.",
                         "A timeout while waiting for the proxy server at");
                 ;
             }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -20,7 +20,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
         Version? version = null;
         Func<int, PortForwarder>? portForwarderFactory;
-        Func<HttpProxyService>? proxyFactory;
+        ProxyFactory proxyFactory;
         LogLevel halibutLogLevel = LogLevel.Info;
         OldServiceAvailableServices availableServices = new(false, false);
         bool hasService = true;
@@ -121,13 +121,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
         public LatestClientAndPreviousServiceVersionBuilder WithProxy()
         {
-            this.proxyFactory = () =>
-            {
-                var options = new HttpProxyOptions();
-                var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
-
-                return new HttpProxyService(options, loggerFactory);
-            };
+            this.proxyFactory = new ProxyFactory().WithDelaySendingSectionsOfHttpHeaders(false);
 
             return this;
         }
@@ -203,7 +197,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             var disposableCollection = new DisposableCollection();
             PortForwarder? portForwarder = null;
 
-            var proxy = proxyFactory?.Invoke();
+            var proxy = proxyFactory?.Build();
             ProxyDetails? proxyDetails = null;
 
             if (proxy != null)

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -32,7 +32,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly CertAndThumbprint serviceCertAndThumbprint;
         readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
         Version? version = null;
-        Func<HttpProxyService>? proxyFactory;
+        ProxyFactory? proxyFactory;
         IEchoService echoService = new EchoService();
         ICachingService cachingService = new CachingService();
         IMultipleParametersTestService multipleParametersTestService = new MultipleParametersTestService();
@@ -178,13 +178,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
         public PreviousClientVersionAndLatestServiceBuilder WithProxy()
         {
-            this.proxyFactory = () =>
-            {
-                var options = new HttpProxyOptions();
-                var loggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
-
-                return new HttpProxyService(options, loggerFactory);
-            };
+            this.proxyFactory = new ProxyFactory().WithDelaySendingSectionsOfHttpHeaders(false);
 
             return this;
         }
@@ -274,7 +268,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             var disposableCollection = new DisposableCollection();
             ProxyHalibutTestBinaryRunner.RoundTripRunningOldHalibutBinary runningOldHalibutBinary;
             Uri serviceUri;
-            var httpProxy = proxyFactory?.Invoke();
+            var httpProxy = proxyFactory?.Build();
             ProxyDetails? httpProxyDetails = null;
 
             if (httpProxy != null)

--- a/source/Halibut.Tests/Support/ProxyFactory.cs
+++ b/source/Halibut.Tests/Support/ProxyFactory.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests.Support
 
         public HttpProxyService Build()
         {
-            return new HttpProxyService(options, false, serilogLoggerFactory);
+            return new HttpProxyService(options, delaySendingSectionsOfHttpHeaders, serilogLoggerFactory);
         }
     }
 }

--- a/source/Halibut.Tests/Support/ProxyFactory.cs
+++ b/source/Halibut.Tests/Support/ProxyFactory.cs
@@ -1,0 +1,24 @@
+using Halibut.TestProxy;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Serilog.Extensions.Logging;
+
+namespace Halibut.Tests.Support
+{
+    public class ProxyFactory
+    {
+        HttpProxyOptions options = new HttpProxyOptions();
+        SerilogLoggerFactory serilogLoggerFactory = new SerilogLoggerFactory(new SerilogLoggerBuilder().Build());
+        bool delaySendingSectionsOfHttpHeaders = true;
+
+        public ProxyFactory WithDelaySendingSectionsOfHttpHeaders(bool delaySendingSectionsOfHttpHeaders)
+        {
+            this.delaySendingSectionsOfHttpHeaders = delaySendingSectionsOfHttpHeaders;
+            return this;
+        }
+
+        public HttpProxyService Build()
+        {
+            return new HttpProxyService(options, false, serilogLoggerFactory);
+        }
+    }
+}

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -505,8 +505,6 @@ namespace Halibut.Tests.Transport.Streams
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.WriteTimeout).Throw<Exception>().And);
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.WriteTimeout = 1).Throw<Exception>().And);
 
-                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.DataAvailable).Throw<Exception>().And);
-
                 var memoryStream = new MemoryStream();
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.ReadByte()).Throw<Exception>().And);
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Flush()).Throw<Exception>().And);

--- a/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -102,6 +103,19 @@ namespace Halibut.Tests.Transport.Streams
             memoryStream.Position = 0;
             
             await AssertAsync.Throws<EndOfStreamException>(async () => await memoryStream.ReadBytesAsync(1000, CancellationToken));
+        }
+
+        [Test]
+        public async Task WithTemporaryReadTimeoutSetsAndRestoresReadTimeout()
+        {
+            var currentTimeOut = TimeSpan.FromMilliseconds(42);
+            using var stream = new SupportsTimeoutsStream(new MemoryStream(), currentTimeOut, TimeSpan.FromMilliseconds(13));
+            using (var _ = stream.WithTemporaryReadTimeout(34))
+            {
+                stream.ReadTimeout.Should().Be(34);
+            }
+
+            stream.ReadTimeout.Should().Be(42);
         }
 
         byte[] BytesFromBinaryWriter(long l)

--- a/source/Halibut.Tests/Util/ActionDisposableFixture.cs
+++ b/source/Halibut.Tests/Util/ActionDisposableFixture.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Halibut.Util;
+using NUnit.Framework;
+
+namespace Halibut.Tests.Util
+{
+    public class ActionDisposableFixture
+    {
+        [Test]
+        public void DisposeIsCalledOnce()
+        {
+            var list = new List<string>();
+            using (var actionDisposable = new ActionDisposable(() => list.Add("just dispose once")))
+            {
+                actionDisposable.Dispose();
+            }
+
+            list.Count.Should().Be(1);
+        }
+    }
+}

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -347,25 +347,31 @@ namespace Halibut.Transport.Proxy
             // send the connect request
             await stream.WriteAsync(request, 0, request.Length, cancellationToken);
 
-            // wait for the proxy server to respond
-            await WaitForDataAsync(stream, cancellationToken);
-
             // PROXY SERVER RESPONSE
             // =======================================================================
             //HTTP/1.0 200 Connection Established<CR><LF>
             //[.... other HTTP header lines ending with <CR><LF>..
             //ignore all of them]
             //<CR><LF>    // Last Empty Line
-
-            // create an byte response array  
-            var response = new byte[TcpClient.ReceiveBufferSize];
+  
+            
             var sbuilder = new StringBuilder();
 
-            do
+            var existingTimeout = stream.ReadTimeout;
+            stream.ReadTimeout = WAIT_FOR_DATA_TIMEOUT;
+            try
             {
-                var bytes = await stream.ReadAsync(response, 0, TcpClient.ReceiveBufferSize, cancellationToken);
-                sbuilder.Append(Encoding.UTF8.GetString(response, 0, bytes));
-            } while (stream.DataAvailable);
+                var response = new byte[1]; // Read 1 byte at a time to prevent over read. (This is not efficient but this is only done once per stream)
+                while (!sbuilder.ToString().EndsWith("\r\n\r\n"))
+                {
+                    var bytes = await stream.ReadAsync(response, 0, response.Length, cancellationToken);
+                    sbuilder.Append(Encoding.UTF8.GetString(response, 0, bytes));
+                }
+            }
+            finally
+            {
+                stream.ReadTimeout = existingTimeout;
+            }
 
             ParseResponse(sbuilder.ToString());
             
@@ -426,18 +432,6 @@ namespace Halibut.Transport.Proxy
             while (!stream.DataAvailable)
             {
                 Thread.Sleep(WAIT_FOR_DATA_INTERVAL);
-                sleepTime += WAIT_FOR_DATA_INTERVAL;
-                if (sleepTime > WAIT_FOR_DATA_TIMEOUT)
-                    throw new ProxyException(string.Format("A timeout while waiting for the proxy server at {0} on port {1} to respond.", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient)), true);
-            }
-        }
-        
-        async Task WaitForDataAsync(NetworkTimeoutStream stream, CancellationToken cancellationToken)
-        {
-            var sleepTime = 0;
-            while (!stream.DataAvailable)
-            {
-                await Task.Delay(WAIT_FOR_DATA_INTERVAL, cancellationToken);
                 sleepTime += WAIT_FOR_DATA_INTERVAL;
                 if (sleepTime > WAIT_FOR_DATA_TIMEOUT)
                     throw new ProxyException(string.Format("A timeout while waiting for the proxy server at {0} on port {1} to respond.", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient)), true);

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -353,8 +353,7 @@ namespace Halibut.Transport.Proxy
             //[.... other HTTP header lines ending with <CR><LF>..
             //ignore all of them]
             //<CR><LF>    // Last Empty Line
-  
-            
+
             var sbuilder = new StringBuilder();
 
             var existingTimeout = stream.ReadTimeout;

--- a/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
+++ b/source/Halibut/Transport/Streams/NetworkTimeoutStream.cs
@@ -295,21 +295,6 @@ namespace Halibut.Transport.Streams
             }
         }
 
-        public bool DataAvailable
-        {
-            get
-            {
-                ThrowIfAlreadyTimedOut();
-
-                if (inner is NetworkStream networkStream)
-                {
-                    return networkStream.DataAvailable;
-                }
-
-                throw new NotSupportedException($"{nameof(DataAvailable)} is only available when wrapping a {nameof(NetworkStream)}");
-            }
-        }
-
         async Task<T> WrapWithCancellationAndTimeout<T>(
             Func<CancellationToken, Task<T>> action,
             int timeout,

--- a/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
+++ b/source/Halibut/Transport/Streams/StreamExtensionMethods.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Util;
 
 namespace Halibut.Transport.Streams
 {
@@ -125,5 +126,11 @@ namespace Halibut.Transport.Streams
             }
         }
 #endif
+        public static IDisposable WithTemporaryReadTimeout(this Stream stream, int temporaryReadTimeout)
+        {
+            var currentTimeout = stream.ReadTimeout;
+            stream.ReadTimeout = temporaryReadTimeout;
+            return new ActionDisposable(() => stream.ReadTimeout = currentTimeout);
+        }
     }
 }

--- a/source/Halibut/Util/ActionDisposable.cs
+++ b/source/Halibut/Util/ActionDisposable.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Halibut.Util
+{
+    public class ActionDisposable : IDisposable
+    {
+        Action action;
+
+        public ActionDisposable(Action action)
+        {
+            this.action = action;
+        }
+
+        public void Dispose()
+        {
+            if (action != null)
+            {
+                var localAction = action;
+                this.action = null;
+                localAction();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

Fixes a bug in HTTPProxyClient in which it would leave parts of the HTTP header in the stream, which would then be passed to the SSL stream which would throw.

The problem is the existing implementation would assume that it is done getting bytes when the network stream happened to have no bytes available at the time it checked. This doesn't make any sense since bytes of the HTTP header can arrive with any timing. When a delay occurs, the HTTPProxyClient would assume it has no more bytes and proceed to checking what it has and passing the stream to the SslStream.

The fix is to simply keep reading until the end of the HTTP headers is signalled which per the spec (citation needed) is when an empty line is received ie when the last 4 bytes are `\r\n\r\n`.

# Results

The Halibut http proxy test library is updated to have the ability to trigger the exact issue. When proxy tests are run with that enabled, they fail. With the fix they pass. Note that only latest client and latest service both in async has the fix and so this new feature of the HTTP proxy is only used in that case.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
