### PR TITLE
Fix an issue with tests hanging when waiting for the external binary to exit

### DIFF
--- a/source/Halibut.Tests/Support/BackwardsCompatibility/CompatBinaryStayAlive.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/CompatBinaryStayAlive.cs
@@ -1,28 +1,30 @@
 using System;
 using System.IO;
+using Serilog;
 
 namespace Halibut.Tests.Support.BackwardsCompatibility
 {
     public class CompatBinaryStayAlive : IDisposable
     {
-
+        readonly ILogger logger;
         public static string StayAliveFilePathEnvVarKey = "CompatBinaryStayAliveFilePath";
         
         readonly TmpDirectory tmpDirectory;
         public string LockFile { get; }
         readonly FileStream fileStreamLock;
-        public CompatBinaryStayAlive()
+        public CompatBinaryStayAlive(ILogger logger)
         {
+            logger = logger.ForContext<CompatBinaryStayAlive>();
+
+            this.logger = logger;
             tmpDirectory = new TmpDirectory();
             LockFile = Path.Combine(tmpDirectory.FullPath, "compat-bin-lock");
             
             fileStreamLock = new FileStream(LockFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
-
         }
 
         public void Dispose()
         {
-            var logger = new SerilogLoggerBuilder().Build().ForContext<CompatBinaryStayAlive>();
             try
             {
                 fileStreamLock.Dispose();

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -176,9 +176,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             public void Dispose()
             {
-                compatBinaryStayAlive.Dispose();
                 cts.Cancel();
-                runningOldHalibutTask.GetAwaiter().GetResult();
+                compatBinaryStayAlive.Dispose();
                 tmpDirectory.Dispose();
             }
         }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -22,11 +22,19 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly string version;
         readonly ProxyDetails? proxyDetails;
         readonly LogLevel halibutLogLevel;
-        readonly ILogger logger = new SerilogLoggerBuilder().Build().ForContext<HalibutRuntimeBuilder>();
+        readonly ILogger logger;
         readonly Uri webSocketServiceEndpointUri;
         readonly OldServiceAvailableServices availableServices;
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string? version, ProxyDetails? proxyDetails, LogLevel halibutLogLevel, OldServiceAvailableServices availableServices)
+        public HalibutTestBinaryRunner(
+            ServiceConnectionType serviceConnectionType, 
+            CertAndThumbprint clientCertAndThumbprint, 
+            CertAndThumbprint serviceCertAndThumbprint, 
+            string? version, 
+            ProxyDetails? proxyDetails, 
+            LogLevel halibutLogLevel, 
+            OldServiceAvailableServices availableServices,
+            ILogger logger)
         {
             this.serviceConnectionType = serviceConnectionType;
             this.clientCertAndThumbprint = clientCertAndThumbprint;
@@ -35,22 +43,41 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.proxyDetails = proxyDetails;
             this.halibutLogLevel = halibutLogLevel;
             this.availableServices = availableServices;
+            this.logger = logger.ForContext<HalibutRuntimeBuilder>();
         }
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, int? clientServicePort, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string? version, ProxyDetails proxyDetails, LogLevel halibutLoggingLevel, OldServiceAvailableServices availableServices) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel, availableServices)
+        public HalibutTestBinaryRunner(
+            ServiceConnectionType serviceConnectionType, 
+            int? clientServicePort, 
+            CertAndThumbprint clientCertAndThumbprint, 
+            CertAndThumbprint serviceCertAndThumbprint, 
+            string? version, 
+            ProxyDetails proxyDetails, 
+            LogLevel halibutLoggingLevel, 
+            OldServiceAvailableServices availableServices,
+            ILogger logger) :
+            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel, availableServices, logger)
         {
             this.clientServicePort = clientServicePort;
         }
 
-        public HalibutTestBinaryRunner(ServiceConnectionType serviceConnectionType, Uri webSocketServiceEndpointUri, CertAndThumbprint clientCertAndThumbprint, CertAndThumbprint serviceCertAndThumbprint, string? version, ProxyDetails? proxyDetails, LogLevel halibutLoggingLevel, OldServiceAvailableServices availableServices) :
-            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel, availableServices)
+        public HalibutTestBinaryRunner(
+            ServiceConnectionType serviceConnectionType,
+            Uri webSocketServiceEndpointUri, 
+            CertAndThumbprint clientCertAndThumbprint, 
+            CertAndThumbprint serviceCertAndThumbprint, 
+            string? version, 
+            ProxyDetails? proxyDetails,
+            LogLevel halibutLoggingLevel, 
+            OldServiceAvailableServices availableServices,
+            ILogger logger) :
+            this(serviceConnectionType, clientCertAndThumbprint, serviceCertAndThumbprint, version, proxyDetails, halibutLoggingLevel, availableServices, logger)
         {
             this.webSocketServiceEndpointUri = webSocketServiceEndpointUri;
         }
 
         public async Task<RunningOldHalibutBinary> Run()
         {
-            var compatBinaryStayAlive = new CompatBinaryStayAlive(); 
+            var compatBinaryStayAlive = new CompatBinaryStayAlive(logger); 
             var settings = new Dictionary<string, string>
             {
                 { "mode", "serviceonly" },

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -98,6 +98,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             catch (Exception)
             {
                 cts.Cancel();
+                cts.Dispose();
                 throw;
             }
         }
@@ -143,10 +144,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 }
             }, cancellationToken);
 
-            await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(cancellationToken), Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
+            var completedTask = await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(), Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
 
             // Will throw.
-            if (runningTentacle.IsCompleted) await runningTentacle;
+            if (completedTask == runningTentacle)
+            {
+                await runningTentacle;
+            }
 
             if (!hasTentacleStarted.IsSet)
             {
@@ -177,6 +181,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public void Dispose()
             {
                 cts.Cancel();
+                cts.Dispose();
                 compatBinaryStayAlive.Dispose();
                 tmpDirectory.Dispose();
             }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -229,7 +229,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         version?.ToString(),
                         proxyDetails,
                         halibutLogLevel,
-                        availableServices).Run();
+                        availableServices,
+                        logger).Run();
                 }
             }
             else if (serviceConnectionType == ServiceConnectionType.PollingOverWebSocket)
@@ -260,7 +261,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         version?.ToString(),
                         proxyDetails,
                         halibutLogLevel,
-                        availableServices).Run();
+                        availableServices,
+                        logger).Run();
                 }
             }
             else if (serviceConnectionType == ServiceConnectionType.Listening)
@@ -276,7 +278,8 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         version?.ToString(),
                         proxyDetails,
                         halibutLogLevel,
-                        availableServices).Run();
+                        availableServices,
+                        logger).Run();
 
                     listenPort = (int)runningOldHalibutBinary.ServiceListenPort!;
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -91,6 +91,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             catch (Exception)
             {
                 cts.Cancel();
+                cts.Dispose();
                 throw;
             }
         }
@@ -143,10 +144,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 }
             }, cancellationToken);
 
-            await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(cancellationToken), Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
+            var completedTask = await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(), Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
 
             // Will throw.
-            if (runningTentacle.IsCompleted) await runningTentacle;
+            if (completedTask == runningTentacle)
+            {
+                await runningTentacle;
+            }
 
             if (!hasTentacleStarted.IsSet)
             {
@@ -184,9 +188,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             public void Dispose()
             {
-                compatBinaryStayAlive.Dispose();
                 cts.Cancel();
-                runningOldHalibutTask.GetAwaiter().GetResult();
+                cts.Dispose();
+                compatBinaryStayAlive.Dispose();
                 tmpDirectory.Dispose();
             }
         }


### PR DESCRIPTION
# Background

Fix an issue with tests hanging when waiting for the external binary to exit

When running all the PollingOverWebSocket tests locally, I was able to replicate hanging tests every run/couple of runs. Killing some of the CompatBinaries would normally make the tests continue with a handful of failures. 

With the fixes in this PR, I am able to run the full suite of PollingOverWebSocket tests over and over. It's still not perfect and often fails after 6+ runs (run until failure) but it is a lot more stable.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
