### PR TITLE
PollingOverWebSocket Test Stability changes

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -64,14 +64,15 @@ namespace Halibut.Tests.Diagnostics
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
                     
-                        exception.Message.Should().ContainAny(new String[]
+                        exception.Message.Should().ContainAny(new []
                             {
                                 "Attempted to read past the end of the stream.",
                                 "Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host.",
-                                "The I/O operation has been aborted because of either a thread exit or an application request"
+                                "The I/O operation has been aborted because of either a thread exit or an application request",
+                                "The remote party closed the WebSocket connection without completing the close handshake"
                             },
                             because: "This isn't the best message, really the connection was closed before we got the data we were expecting resulting in us reading past the end of the stream");
-                    }
+                }
             }
             
             [LatestClientAndLatestServiceTestCases(testNetworkConditions:false, 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -78,7 +78,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         public async Task<RunningOldHalibutBinary> Run()
         {
             var compatBinaryStayAlive = new CompatBinaryStayAlive(logger); 
-            var settings = new Dictionary<string, string>
+            var settings = new Dictionary<string, string?>
             {
                 { "mode", "serviceonly" },
                 { "tentaclecertpath", serviceCertAndThumbprint.CertificatePfxPath },
@@ -111,80 +111,87 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             }
 
             settings.Add("ServiceConnectionType", serviceConnectionType.ToString());
+            
+            var tmpDirectory = new TmpDirectory();
 
-            var cts = new CancellationTokenSource();
+            var (task, serviceListenPort, runningTentacleCancellationTokenSource) = await StartHalibutTestBinary(version, settings, tmpDirectory);
 
-            try
-            {
-                var tmp = new TmpDirectory();
-
-                var (task, serviceListenPort) = await StartHalibutTestBinary(version, settings, tmp, cts.Token);
-
-                return new RunningOldHalibutBinary(cts, task, tmp, serviceListenPort, compatBinaryStayAlive);
-            }
-            catch (Exception)
-            {
-                cts.Cancel();
-                cts.Dispose();
-                throw;
-            }
+            return new RunningOldHalibutBinary(runningTentacleCancellationTokenSource, task, tmpDirectory, serviceListenPort, compatBinaryStayAlive);
         }
 
-        async Task<(Task, int?)> StartHalibutTestBinary(string version, Dictionary<string, string> settings, TmpDirectory tmp, CancellationToken cancellationToken)
+        async Task<(Task RunningTentacleTask, int? ServiceListenPort, CancellationTokenSource RunningTentacleCancellationTokenSource)> StartHalibutTestBinary(
+            string version, 
+            Dictionary<string, string?> settings, 
+            TmpDirectory tmp)
         {
             var hasTentacleStarted = new AsyncManualResetEvent();
             hasTentacleStarted.Reset();
 
             int? serviceListenPort = null;
-            var runningTentacle = Task.Run(async () =>
+
+            var runningTentacleCancellationTokenSource = new CancellationTokenSource();
+
+            try
             {
-                try
+
+                var runningTentacle = Task.Run(async () =>
                 {
-                    async Task ProcessLogs(string s, CancellationToken ct)
+                    try
                     {
-                        await Task.CompletedTask;
-                        logger.Information(s);
-                        if (s.StartsWith("Listening on port: "))
+                        async Task ProcessLogs(string s, CancellationToken ct)
                         {
-                            serviceListenPort = int.Parse(Regex.Match(s, @"\d+").Value);
+                            await Task.CompletedTask;
+                            logger.Information(s);
+                            if (s.StartsWith("Listening on port: "))
+                            {
+                                serviceListenPort = int.Parse(Regex.Match(s, @"\d+").Value);
+                            }
+
+                            if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
                         }
 
-                        if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
+                        await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version))
+                            .WithArguments(new string[0])
+                            .WithWorkingDirectory(tmp.FullPath)
+                            .WithStandardOutputPipe(PipeTarget.ToDelegate(ProcessLogs))
+                            .WithStandardErrorPipe(PipeTarget.ToDelegate(ProcessLogs))
+                            .WithEnvironmentVariables(settings)
+                            .ExecuteAsync(runningTentacleCancellationTokenSource.Token);
                     }
+                    catch (OperationCanceledException)
+                    {
+                        // Don't throw when we cancel the running of the binary, this is an expected way of killing it.
+                    }
+                    catch (Exception e)
+                    {
+                        logger.Information(e, "Error running Halibut Test Binary");
+                        throw;
+                    }
+                }, runningTentacleCancellationTokenSource.Token);
 
-                    await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version))
-                        .WithArguments(new string[0])
-                        .WithWorkingDirectory(tmp.FullPath)
-                        .WithStandardOutputPipe(PipeTarget.ToDelegate(ProcessLogs))
-                        .WithStandardErrorPipe(PipeTarget.ToDelegate(ProcessLogs))
-                        .WithEnvironmentVariables(settings)
-                        .ExecuteAsync(cancellationToken);
-                }
-                catch (OperationCanceledException)
+                var completedTask = await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(), Task.Delay(TimeSpan.FromSeconds(30), runningTentacleCancellationTokenSource.Token));
+                
+                if (completedTask == runningTentacle)
                 {
-                    // Don't throw when we cancel the running of the binary, this is an expected way of killing it.
+                    runningTentacleCancellationTokenSource.Cancel();
+                    // Will throw the startup exception.
+                    await runningTentacle;
                 }
-                catch (Exception e)
+
+                if (!hasTentacleStarted.IsSet)
                 {
-                    logger.Information(e, "Error running Halibut Test Binary");
-                    throw;
+                    runningTentacleCancellationTokenSource.Cancel();
+                    throw new Exception("Halibut test binary did not appear to start correctly");
                 }
-            }, cancellationToken);
 
-            var completedTask = await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(), Task.Delay(TimeSpan.FromMinutes(1), cancellationToken));
-
-            // Will throw.
-            if (completedTask == runningTentacle)
-            {
-                await runningTentacle;
+                return (runningTentacle, serviceListenPort, runningTentacleCancellationTokenSource);
             }
-
-            if (!hasTentacleStarted.IsSet)
+            catch (Exception)
             {
-                throw new Exception("Halibut test binary did not appear to start correctly");
+                runningTentacleCancellationTokenSource.Cancel();
+                runningTentacleCancellationTokenSource.Dispose();
+                throw;
             }
-
-            return (runningTentacle, serviceListenPort);
         }
 
         public class RunningOldHalibutBinary : IDisposable

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -146,10 +146,14 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                     }
                 }, runningTentacleCancellationTokenSource.Token);
 
-                var completedTask = await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(), Task.Delay(TimeSpan.FromSeconds(30), runningTentacleCancellationTokenSource.Token));
+                using var whenAnyCleanupCancellationTokenSource = new CancellationTokenSource();
+                using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(runningTentacleCancellationTokenSource.Token, whenAnyCleanupCancellationTokenSource.Token);
+
+                var completedTask = await Task.WhenAny(runningTentacle, hasTentacleStarted.WaitAsync(), Task.Delay(TimeSpan.FromSeconds(30), linkedCancellationTokenSource.Token));
 
                 if (completedTask == runningTentacle)
                 {
+                    whenAnyCleanupCancellationTokenSource.Cancel();
                     runningTentacleCancellationTokenSource.Cancel();
                     // Will throw the startup exception.
                     await runningTentacle;
@@ -157,9 +161,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
                 if (!hasTentacleStarted.IsSet)
                 {
+                    whenAnyCleanupCancellationTokenSource.Cancel();
                     runningTentacleCancellationTokenSource.Cancel();
                     throw new Exception("Halibut test binary did not appear to start correctly");
                 }
+
+                whenAnyCleanupCancellationTokenSource.Cancel();
 
                 logger.Information("External halibut binary started.");
                 return (runningTentacle, serviceListenPort, proxyClientListenPort, runningTentacleCancellationTokenSource);

--- a/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestAndPreviousClientAndServiceVersionsTestCasesAttribute.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections;
 using System.Linq;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Util;
-using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
 {
@@ -28,7 +27,7 @@ namespace Halibut.Tests.Support.TestAttributes
         
         static class LatestAndPreviousClientAndServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, bool testAsyncServicesAsWell)
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncAndSyncClients, bool testAsyncServicesAsWell)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -47,7 +46,7 @@ namespace Halibut.Tests.Support.TestAttributes
                     serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
                 }
 
-                ForceClientProxyType[] clientProxyTypesToTest = new ForceClientProxyType[0];
+                var clientProxyTypesToTest = Array.Empty<ForceClientProxyType>();
                 if (testAsyncAndSyncClients)
                 {
                     clientProxyTypesToTest = ForceClientProxyTypeValues.All;
@@ -72,7 +71,7 @@ namespace Halibut.Tests.Support.TestAttributes
                     serviceAsyncHalibutFeatureTestCases
                     );
 
-                return builder.Build().GetEnumerator();
+                return builder.Build();
             }
         }
     }

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndLatestServiceTestCasesAttribute.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Util;
-using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
 {

--- a/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/LatestClientAndPreviousServiceVersionsTestCasesAttribute.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Halibut.Tests.Support.BackwardsCompatibility;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Util;
-using NUnit.Framework;
 
 namespace Halibut.Tests.Support.TestAttributes
 {
@@ -28,7 +28,7 @@ namespace Halibut.Tests.Support.TestAttributes
         
         static class LatestClientAndPreviousServiceVersionsTestCases
         {
-            public static IEnumerator<ClientAndServiceTestCase> GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncClients, bool testSyncClients, bool testAsyncServicesAsWell)
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncClients, bool testSyncClients, bool testAsyncServicesAsWell)
             {
                 var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
 
@@ -77,7 +77,7 @@ namespace Halibut.Tests.Support.TestAttributes
                     serviceAsyncHalibutFeatureTestCases
                 );
 
-                return builder.Build().GetEnumerator();
+                return builder.Build();
             }
         }
     }

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCase.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Util;
 
@@ -66,30 +67,52 @@ namespace Halibut.Tests.Support.TestCases
         public override string ToString()
         {
             // This is used as the test parameter name, so make this something someone can understand in teamcity or their IDE.
-            var testParameter = new List<string>();
+            var builder = new StringBuilder();
             
             // These names can be longer than what rider will handle, setting UseShortTestNames=true will help with that.
             bool useShortString = EnvironmentVariableReaderHelper.EnvironmentVariableAsBool("UseShortTestNames", false);
             
-            testParameter.Add(ServiceConnectionType.ToString());
-            testParameter.Add(useShortString ? ClientAndServiceTestVersion.ToShortString(ServiceConnectionType): ClientAndServiceTestVersion.ToString(ServiceConnectionType));
-            testParameter.Add(useShortString ? NetworkConditionTestCase.ToShortString() : NetworkConditionTestCase.ToString());
-            testParameter.Add(useShortString ? $"RecIters:{RecommendedIterations}" : $"RecommendedIters: {RecommendedIterations}");
+            builder.Append(ServiceConnectionType.ToString());
+            builder.Append(", ");
+            builder.Append(useShortString ? ClientAndServiceTestVersion.ToShortString(ServiceConnectionType): ClientAndServiceTestVersion.ToString(ServiceConnectionType));
+            builder.Append(", ");
+            builder.Append(useShortString ? NetworkConditionTestCase.ToShortString() : NetworkConditionTestCase.ToString());
+            builder.Append(", ");
+            builder.Append(useShortString ? $"RecIters:{RecommendedIterations}" : $"RecommendedIters: {RecommendedIterations}");
+            builder.Append(", ");
             if (ForceClientProxyType != null)
             {
-                testParameter.Add(ForceClientProxyType.ToString());
+                builder.Append(ForceClientProxyType.ToString());
+                builder.Append(", ");
             }
 
             if (ServiceAsyncHalibutFeature == AsyncHalibutFeature.Enabled)
             {
-                testParameter.Add("AsyncService");
+                builder.Append("AsyncService");
             }
             else
             {
-                testParameter.Add("SyncService");
+                builder.Append("SyncService");
             }
             
-            return string.Join(", ", testParameter);
+            return builder.ToString();
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as ClientAndServiceTestCase);
+        }
+
+        public bool Equals(ClientAndServiceTestCase? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return this.ToString().Equals(other.ToString());
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
         }
     }
 }

--- a/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCasesBuilder.cs
+++ b/source/Halibut.Tests/Support/TestCases/ClientAndServiceTestCasesBuilder.cs
@@ -29,6 +29,13 @@ namespace Halibut.Tests.Support.TestCases
 
         public IEnumerable<ClientAndServiceTestCase> Build()
         {
+            return BuildDistinct();
+        }
+
+        List<ClientAndServiceTestCase> BuildDistinct()
+        {
+            var cases = new List<ClientAndServiceTestCase>();
+
             foreach (var clientServiceTestVersion in clientServiceTestVersions)
             {
                 foreach (var serviceConnectionType in serviceConnectionTypes)
@@ -52,19 +59,19 @@ namespace Halibut.Tests.Support.TestCases
                             
                             if (!forceClientProxyTypes.Any())
                             {
-                                yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, null, serviceAsyncHalibutFeatureTestCase);
+                                cases.Add(new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, null, serviceAsyncHalibutFeatureTestCase));
                             }
                             else
                             {
                                 if (clientServiceTestVersion.IsPreviousClient())
                                 {
-                                    yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, null, serviceAsyncHalibutFeatureTestCase);
+                                    cases.Add(new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, null, serviceAsyncHalibutFeatureTestCase));
                                 }
                                 else
                                 {
                                     foreach (var forceClientProxyType in forceClientProxyTypes)
                                     {
-                                        yield return new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, forceClientProxyType, serviceAsyncHalibutFeatureTestCase);
+                                        cases.Add(new ClientAndServiceTestCase(serviceConnectionType, networkConditionTestCase, recommendedIterations, clientServiceTestVersion, forceClientProxyType, serviceAsyncHalibutFeatureTestCase));
                                     }
                                 }
                             }
@@ -72,6 +79,10 @@ namespace Halibut.Tests.Support.TestCases
                     }
                 }
             }
+
+            var distinct = cases.Distinct().ToList();
+
+            return distinct;
         }
     }
 }

--- a/source/Halibut.Tests/Support/WebSocketSslCertificateHelper.cs
+++ b/source/Halibut.Tests/Support/WebSocketSslCertificateHelper.cs
@@ -23,7 +23,7 @@ namespace Halibut.Tests.Support
                 throw new Exception("Only the SSL certificate can be used in websockets see AddSslCertToLocalStore()");
             }
             
-            var proc = new Process
+            using var proc = new Process
             {
                 StartInfo = new ProcessStartInfo("netsh", $"http add sslcert ipport={address} certhash={certAndThumbprint.Thumbprint} appid={{2e282bfb-fce9-40fc-a594-2136043e1c8f}}")
                 {
@@ -46,7 +46,7 @@ namespace Halibut.Tests.Support
 
         internal static void RemoveSslCertBindingFor(string address)
         {
-            var proc = new Process
+            using var proc = new Process
             {
                 StartInfo = new ProcessStartInfo("netsh", $"http delete sslcert ipport={address}")
                 {

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -65,6 +65,8 @@ namespace Halibut.Diagnostics
                 if (exception.Message.Contains("An existing connection was forcibly closed by the remote host.")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("The I/O operation has been aborted because of either a thread exit or an application request")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.")) return HalibutNetworkExceptionType.IsNetworkError;
+                if (exception.Message.Contains("The remote party closed the WebSocket connection without completing the close handshake.")) return HalibutNetworkExceptionType.IsNetworkError;
+                
             }
 
             return HalibutNetworkExceptionType.UnknownError;


### PR DESCRIPTION
# Background

Changes to the way the compact binary is started mainly around cancellation and more aggressive cancellation during the startup of tasks.

Fixed a flakey bug where a network error was not classified as a network error

Fixed an issue where we were running the same test multiple times due to the TestCases generating a non-distinct set of tests to run - the issue occurs when versions are redirected for stability which occurs for WebSockets.

Locally I have reached 15 tests runs without a failure!! I haven't been able to get past 6 previously!! May be luck, something locally just works but it's a step towards more stability!!

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/e5cd46d6-2e4f-4377-94d8-282bb42c46d5)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
