### PR TITLE
Making WebSocketStream support async disposal

### DIFF
--- a/source/Halibut.Tests/AsyncClientAndServiceMustNotUseSyncNetworkIO.cs
+++ b/source/Halibut.Tests/AsyncClientAndServiceMustNotUseSyncNetworkIO.cs
@@ -96,22 +96,7 @@ namespace Halibut.Tests
                 // TODO: ASYNC ME UP!
                 // All we see in this stack trace is the single call to this method, we see no parent.
                 .Where(s => !s.Contains("SyncIoRecordingWebSocketStream.Flush()"))
-
-                // TODO: ASYNC ME UP!
-                // We are missing an async dispose on web sockets, and ExecuteRequest in SecureWebSocketListener needs to call the async close.
-                .Where(s => !(s.Contains("SynIoRecording.SyncIoRecordingWebSocketStream.Dispose")
-                              && s.Contains("ExecuteRequest")))
                 
-                // TODO: ASYNC ME UP!
-                // SecureConnection should dispose websockets async
-                .Where(s => !(s.Contains("SynIoRecording.SyncIoRecordingWebSocketStream.Dispose")
-                              && s.Contains("Halibut.Transport.SecureConnection.DisposeAsync()")))
-
-                // TODO: ASYNC ME UP!
-                // We seem to be using a sync dispose on DisposableNotifierConnection which results in a sync write or close
-                .Where(s => !(s.Contains("Halibut.Transport.ConnectionManagerAsync.DisposableNotifierConnection.Dispose()")
-                              && s.Contains("SynIoRecording.SyncIoRecordingWebSocketStream")))
-
                 // The follow can not be fixed up
                 // SslStream in net48 does not have async dispose, 
                 .Where(s => !s.Contains("System.Net.Security.SslStream.Dispose("))

--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -166,7 +166,17 @@ namespace Halibut.Transport.Protocol
             set => throw new NotImplementedException();
         }
 
-        async Task SendCloseMessage()
+        void SendCloseMessage()
+        {
+            if (context.State != WebSocketState.Open)
+                return;
+
+            using (var sendCancel = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
+                context.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Closing", sendCancel.Token)
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        async Task SendCloseMessageAsync()
         {
             if (context.State != WebSocketState.Open)
                 return;
@@ -190,7 +200,7 @@ namespace Halibut.Transport.Protocol
             {
                 try
                 {
-                    SendCloseMessage().GetAwaiter().GetResult();
+                    SendCloseMessage();
                 }
                 finally
                 {
@@ -208,7 +218,7 @@ namespace Halibut.Transport.Protocol
         {
             try
             {
-                await SendCloseMessage();
+                await SendCloseMessageAsync();
             }
             finally
             {

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -180,7 +180,7 @@ namespace Halibut.Transport
                     }
                     catch
                     {
-                        if (connection != null)
+                        if (connection is not null)
                         {
                             await connection.DisposeAsync();
                         }

--- a/source/Halibut/Transport/SecureConnection.cs
+++ b/source/Halibut/Transport/SecureConnection.cs
@@ -19,7 +19,8 @@ namespace Halibut.Transport
         readonly MessageExchangeProtocol protocol;
         DateTimeOffset lastUsed;
 
-        public SecureConnection(IDisposable client, 
+        public SecureConnection(
+            IDisposable client, 
             Stream stream,
             ExchangeProtocolBuilder exchangeProtocolBuilder,
             AsyncHalibutFeature asyncHalibutFeature,

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -185,7 +185,11 @@ namespace Halibut.Transport
                     }
                     catch
                     {
-                        connection?.Dispose();
+                        if (connection is not null)
+                        {
+                            await connection.DisposeAsync();
+                        }
+                        
                         throw;
                     }
 

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -183,7 +183,7 @@ namespace Halibut.Transport
             finally
             {
                 // Closing an already closed stream or client is safe, better not to leak
-                webSocketStream?.Dispose();
+                if (webSocketStream is not null) await webSocketStream.DisposeAsync();
                 listenerContext.Response.Close();
             }
         }


### PR DESCRIPTION
[sc-57814]

# Background

While making Halibut async, we found that a `WebSocketStream` does not support asynchronous disposal.

# Results

Related to OctopusDeploy/Issues#8266

## Before

`WebSocketStream` disposed synchronously, resulting in a call to the asynchronous `context.CloseOutputAsync` with a blocking `.GetAwaiter().GetResult()` at the end...

## After

`WebSocketStream` now supports async disposal, and therefore calls `context.CloseOutputAsync` asynchronously.

As a result, when `SecureConnection` wraps a `WebSocketStream`, it can dispose of it asynchronously (which it already did, but would result in sync disposal before).

Using `SecureConnection`, the `SecureWebSocketClient` can now dispose of of the connection asynchronously (on async paths).

Also, `SecureWebSocketListener` can now dispose of the `WebSocketStream` asynchronously also.

# How to review this PR

`SecureWebSocketListener` doesn't have a "sync vs async" path. So making it dispose `WebSocketStream` async is a different behaviour to the synchronous version.

I think it will be fine, but thought it worth raising in case we wish to split that out into a separate story.

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
