### PR TITLE
Create TcpClient.CloseImmediately extension method

### DIFF
--- a/source/Halibut.TestProxy/TcpClientExtensionMethods.cs
+++ b/source/Halibut.TestProxy/TcpClientExtensionMethods.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Net.Sockets;
+
+namespace Halibut.TestProxy
+{
+    public static class TcpClientExtensionMethods
+    {
+        public static void CloseImmediately(this TcpClient client)
+        {
+            client.CloseImmediately(_ => { });
+        }
+
+        public static void CloseImmediately(this TcpClient client, Action<Exception> onError)
+        {
+            Try.CatchingError(() => client.Client.Close(0), onError);
+            Try.CatchingError(client.Close, onError);
+        }
+    }
+}

--- a/source/Halibut.TestProxy/TcpTunnel.cs
+++ b/source/Halibut.TestProxy/TcpTunnel.cs
@@ -50,11 +50,21 @@ namespace Halibut.TestProxy
                 await Task.WhenAll(
                     fromWriter.CompleteAsync().AsTask(),
                     toWriter.CompleteAsync().AsTask());
-                
+
                 Try.CatchingError(() => fromStream.Close(), e => { _logger.LogWarning("Error closing fromStream"); });
                 Try.CatchingError(() => toStream.Close(), e => { _logger.LogWarning("Error closing toStream"); });
-                Try.CatchingError(() => fromClient.Close(), e => { _logger.LogWarning("Error closing fromClient"); });
-                Try.CatchingError(() => toClient.Close(), e => { _logger.LogWarning("Error closing toClient");});
+                Try.CatchingError(() =>
+                {
+                    // Close the socket, with no waiting
+                    fromClient.Client.Close(0);
+                    fromClient.Close();
+                }, e => { _logger.LogWarning("Error closing fromClient"); });
+                Try.CatchingError(() =>
+                {
+                    // Close the socket, with no waiting
+                    toClient.Client.Close(0);
+                    toClient.Close();
+                }, e => { _logger.LogWarning("Error closing toClient"); });
             }
         }
 

--- a/source/Halibut.TestProxy/TcpTunnel.cs
+++ b/source/Halibut.TestProxy/TcpTunnel.cs
@@ -53,18 +53,8 @@ namespace Halibut.TestProxy
 
                 Try.CatchingError(() => fromStream.Close(), e => { _logger.LogWarning("Error closing fromStream"); });
                 Try.CatchingError(() => toStream.Close(), e => { _logger.LogWarning("Error closing toStream"); });
-                Try.CatchingError(() =>
-                {
-                    // Close the socket, with no waiting
-                    fromClient.Client.Close(0);
-                    fromClient.Close();
-                }, e => { _logger.LogWarning("Error closing fromClient"); });
-                Try.CatchingError(() =>
-                {
-                    // Close the socket, with no waiting
-                    toClient.Client.Close(0);
-                    toClient.Close();
-                }, e => { _logger.LogWarning("Error closing toClient"); });
+                fromClient.CloseImmediately(_ => { _logger.LogWarning("Error closing fromClient"); });
+                toClient.CloseImmediately(_ => { _logger.LogWarning("Error closing toClient"); });
             }
         }
 

--- a/source/Halibut.Tests/TcpClientCloseImmediatelyFixture.cs
+++ b/source/Halibut.Tests/TcpClientCloseImmediatelyFixture.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Tests.Support;
 using Halibut.Tests.Transport.Streams;
 using Halibut.Tests.Util;
 using Halibut.Transport;
@@ -20,126 +19,82 @@ namespace Halibut.Tests
         [Test]
         public async Task DoesNotWait()
         {
-            using var writeTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
-            var (disposables, sut, client) = await BuildTcpClientAndTcpListener(
-                CancellationToken,
-                onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
+            var client = await GetTcpClientInWritingBlockedState();
 
-            using (disposables)
-            {
-                // Ensure the timeouts are not used
-                sut.WriteTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
-                sut.ReadTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+            Logger.Information("Writer has blocked, closing...");
+            var stopWatch = Stopwatch.StartNew();
+            client.CloseImmediately();
+            stopWatch.Stop();
+            Logger.Information($"Close completed, duration: {stopWatch.Elapsed.TotalMilliseconds}ms");
 
-                var data = new byte[655360];
-                var r = new Random();
-                r.NextBytes(data);
-
-                var semaphore = new SemaphoreSlim(1, 1);
-
-                // Brute force attempt to get the Write to be slow
-                Logger.Information("Start writing");
-                _ = Task.Run(async () =>
-                {
-                    await Try.RunTillExceptionOrCancellation(
-                        async () =>
-                        {
-                            semaphore.Release();
-                            await semaphore.WaitAsync(writeTokenSource.Token);
-                            Logger.Information("WRITER: Start");
-                            await sut.WriteToStream(StreamWriteMethod.WriteAsync, data, 0, data.Length, writeTokenSource.Token);
-                            Logger.Information("WRITER: Finished");
-                        },
-                        CancellationToken);
-                });
-
-                Logger.Information("Wait for writer to block...");
-                // Wait for some brute force writing...
-                while (semaphore.Wait(1000))
-                {
-                    // Do nothing, just wait for the semaphore to time out,
-                    // as that means writing is blocked
-                    Logger.Information("Keep waiting...");
-                    await Task.Delay(10);
-                }
-
-                Logger.Information("Writer has blocked, closing...");
-                var stopWatch = Stopwatch.StartNew();
-                client.CloseImmediately();
-                stopWatch.Stop();
-                Logger.Information($"Close completed, duration: {stopWatch.Elapsed.TotalMilliseconds}ms");
-
-                stopWatch.ElapsedMilliseconds.Should().BeLessThan(10);
-            }
+            stopWatch.ElapsedMilliseconds.Should().BeLessThan(10);
         }
-        
-        
+
         [Test]
         public async Task CanBeCalledMultipleTimes()
         {
+            var client = await GetTcpClientInWritingBlockedState();
+
+            Logger.Information("Writer has blocked, closing...");
+            client.CloseImmediately();
+            Logger.Information($"Close completed");
+
+            // Wait a little, to ensure any behind-the-scenes clean up has completed
+            await Task.Delay(1000);
+
+            // Try closing again
+            Logger.Information("Closing again...");
+            client.CloseImmediately();
+            Logger.Information("Close completed");
+        }
+
+        async Task<TcpClient> GetTcpClientInWritingBlockedState()
+        {
             using var writeTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
-            var (disposables, sut, client) = await BuildTcpClientAndTcpListener(
+            var (sut, client) = await BuildTcpClientAndTcpListener(
                 CancellationToken,
                 onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
 
-            using (disposables)
+            // Ensure the timeouts are not used
+            sut.WriteTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+            sut.ReadTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+
+            var data = new byte[655360];
+            var r = new Random();
+            r.NextBytes(data);
+
+            var writerTimedOut = new ManualResetEventSlim(false);
+
+            // Brute force attempt to get the Write to be slow
+            Logger.Information("Start writing");
+            _ = Task.Run(() =>
             {
-                // Ensure the timeouts are not used
-                sut.WriteTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
-                sut.ReadTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
-
-                var data = new byte[655360];
-                var r = new Random();
-                r.NextBytes(data);
-
-                var semaphore = new SemaphoreSlim(1, 1);
-
-                // Brute force attempt to get the Write to be slow
-                Logger.Information("Start writing");
-                _ = Task.Run(async () =>
+                while (true)
                 {
-                    await Try.RunTillExceptionOrCancellation(
-                        async () =>
-                        {
-                            semaphore.Release();
-                            await semaphore.WaitAsync(writeTokenSource.Token);
-                            Logger.Information("WRITER: Start");
-                            await sut.WriteToStream(StreamWriteMethod.WriteAsync, data, 0, data.Length, writeTokenSource.Token);
-                            Logger.Information("WRITER: Finished");
-                        },
-                        CancellationToken);
-                });
+                    Logger.Information("WRITER: Start");
+                    var writeCompleted = sut.WriteToStream(StreamWriteMethod.WriteAsync, data, 0, data.Length, writeTokenSource.Token).Wait(TimeSpan.FromSeconds(1));
+                    if (!writeCompleted)
+                    {
+                        Logger.Information("WRITER: Timed out");
+                        writerTimedOut.Set();
+                        return Task.CompletedTask;
+                    }
 
-                Logger.Information("Wait for writer to block...");
-                // Wait for some brute force writing...
-                while (semaphore.Wait(1000))
-                {
-                    // Do nothing, just wait for the semaphore to time out,
-                    // as that means writing is blocked
-                    Logger.Information("Keep waiting...");
-                    await Task.Delay(10);
+                    Logger.Information("WRITER: Finished");
                 }
+            }, writeTokenSource.Token);
 
-                Logger.Information("Writer has blocked, closing...");
-                client.CloseImmediately();
-                Logger.Information($"Close completed");
-                    
-                // Wait a little, to ensure any behind-the-scenes clean up has completed
-                await Task.Delay(1000);
-                    
-                // Try closing again
-                Logger.Information("Closing again...");
-                client.CloseImmediately();
-                Logger.Information("Close completed");
-            }
+            Logger.Information("Wait for writer to block...");
+            writerTimedOut.Wait(CancellationToken);
+
+            return client;
         }
 
-        async Task<(IDisposable Disposables, Stream SystemUnderTest, TcpClient Client)> BuildTcpClientAndTcpListener(
+        async Task<(Stream SystemUnderTest, TcpClient Client)> BuildTcpClientAndTcpListener(
             CancellationToken cancellationToken,
             Func<string, Task>? onListenerRead = null)
         {
             Func<string, Task>? performServiceWriteFunc = null;
-            var disposableCollection = new DisposableCollection();
 
             var service = new TcpListener(IPAddress.Loopback, 0);
             service.Start();
@@ -178,7 +133,7 @@ namespace Halibut.Tests
                 await Task.Delay(10, cancellationToken);
             }
 
-            return (disposableCollection, clientStream, client);
+            return (clientStream, client);
         }
 
         static async Task DelayForeverToTryAndDelayWriting(CancellationToken cancellationToken)

--- a/source/Halibut.Tests/TcpClientCloseImmediatelyFixture.cs
+++ b/source/Halibut.Tests/TcpClientCloseImmediatelyFixture.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Transport.Streams;
+using Halibut.Tests.Util;
+using Halibut.Transport;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class TcpClientCloseImmediatelyFixture : BaseTest
+    {
+        [Test]
+        public async Task DoesNotWait()
+        {
+            using var writeTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+            var (disposables, sut, client) = await BuildTcpClientAndTcpListener(
+                CancellationToken,
+                onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
+
+            using (disposables)
+            {
+                // Ensure the timeouts are not used
+                sut.WriteTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+                sut.ReadTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+
+                var data = new byte[655360];
+                var r = new Random();
+                r.NextBytes(data);
+
+                var semaphore = new SemaphoreSlim(1, 1);
+
+                // Brute force attempt to get the Write to be slow
+                Logger.Information("Start writing");
+                _ = Task.Run(async () =>
+                {
+                    await Try.RunTillExceptionOrCancellation(
+                        async () =>
+                        {
+                            semaphore.Release();
+                            await semaphore.WaitAsync(writeTokenSource.Token);
+                            Logger.Information("WRITER: Start");
+                            await sut.WriteToStream(StreamWriteMethod.WriteAsync, data, 0, data.Length, writeTokenSource.Token);
+                            Logger.Information("WRITER: Finished");
+                        },
+                        CancellationToken);
+                });
+
+                Logger.Information("Wait for writer to block...");
+                // Wait for some brute force writing...
+                while (semaphore.Wait(1000))
+                {
+                    // Do nothing, just wait for the semaphore to time out,
+                    // as that means writing is blocked
+                    Logger.Information("Keep waiting...");
+                    await Task.Delay(10);
+                }
+
+                Logger.Information("Writer has blocked, closing...");
+                var stopWatch = Stopwatch.StartNew();
+                client.CloseImmediately();
+                stopWatch.Stop();
+                Logger.Information($"Close completed, duration: {stopWatch.Elapsed.TotalMilliseconds}ms");
+
+                stopWatch.ElapsedMilliseconds.Should().BeLessThan(10);
+            }
+        }
+        
+        
+        [Test]
+        public async Task CanBeCalledMultipleTimes()
+        {
+            using var writeTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+            var (disposables, sut, client) = await BuildTcpClientAndTcpListener(
+                CancellationToken,
+                onListenerRead: async _ => await DelayForeverToTryAndDelayWriting(CancellationToken));
+
+            using (disposables)
+            {
+                // Ensure the timeouts are not used
+                sut.WriteTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+                sut.ReadTimeout = (int)TimeSpan.FromSeconds(240).TotalMilliseconds;
+
+                var data = new byte[655360];
+                var r = new Random();
+                r.NextBytes(data);
+
+                var semaphore = new SemaphoreSlim(1, 1);
+
+                // Brute force attempt to get the Write to be slow
+                Logger.Information("Start writing");
+                _ = Task.Run(async () =>
+                {
+                    await Try.RunTillExceptionOrCancellation(
+                        async () =>
+                        {
+                            semaphore.Release();
+                            await semaphore.WaitAsync(writeTokenSource.Token);
+                            Logger.Information("WRITER: Start");
+                            await sut.WriteToStream(StreamWriteMethod.WriteAsync, data, 0, data.Length, writeTokenSource.Token);
+                            Logger.Information("WRITER: Finished");
+                        },
+                        CancellationToken);
+                });
+
+                Logger.Information("Wait for writer to block...");
+                // Wait for some brute force writing...
+                while (semaphore.Wait(1000))
+                {
+                    // Do nothing, just wait for the semaphore to time out,
+                    // as that means writing is blocked
+                    Logger.Information("Keep waiting...");
+                    await Task.Delay(10);
+                }
+
+                Logger.Information("Writer has blocked, closing...");
+                client.CloseImmediately();
+                Logger.Information($"Close completed");
+                    
+                // Wait a little, to ensure any behind-the-scenes clean up has completed
+                await Task.Delay(1000);
+                    
+                // Try closing again
+                Logger.Information("Closing again...");
+                client.CloseImmediately();
+                Logger.Information("Close completed");
+            }
+        }
+
+        async Task<(IDisposable Disposables, Stream SystemUnderTest, TcpClient Client)> BuildTcpClientAndTcpListener(
+            CancellationToken cancellationToken,
+            Func<string, Task>? onListenerRead = null)
+        {
+            Func<string, Task>? performServiceWriteFunc = null;
+            var disposableCollection = new DisposableCollection();
+
+            var service = new TcpListener(IPAddress.Loopback, 0);
+            service.Start();
+
+            var _ = Task.Run(async () =>
+            {
+                using var serviceTcpClient = await service.AcceptTcpClientAsync();
+                serviceTcpClient.ReceiveBufferSize = 10;
+                serviceTcpClient.SendBufferSize = 10;
+
+                using var serviceStream = serviceTcpClient.GetStream();
+                performServiceWriteFunc = async data => await serviceStream.WriteAsync(Encoding.UTF8.GetBytes(data), 0, data.Length, cancellationToken);
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var buffer = new byte[19];
+                    var readBytes = await serviceStream.ReadAsync(buffer, 0, 19, cancellationToken);
+
+                    var readData = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                    if (onListenerRead != null)
+                    {
+                        await onListenerRead(readData);
+                    }
+                }
+            }, cancellationToken);
+
+            var client = new TcpClient();
+            client.ReceiveBufferSize = 10;
+            client.SendBufferSize = 10;
+
+            await client.ConnectAsync("localhost", ((IPEndPoint)service.LocalEndpoint).Port);
+
+            var clientStream = client.GetStream();
+            while (performServiceWriteFunc == null)
+            {
+                await Task.Delay(10, cancellationToken);
+            }
+
+            return (disposableCollection, clientStream, client);
+        }
+
+        static async Task DelayForeverToTryAndDelayWriting(CancellationToken cancellationToken)
+        {
+            await Task.Delay(-1, cancellationToken);
+        }
+    }
+}

--- a/source/Halibut.Tests/TrustFixture.cs
+++ b/source/Halibut.Tests/TrustFixture.cs
@@ -13,8 +13,8 @@ namespace Halibut.Tests
     public class TrustFixture : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testListening: true, testPolling: false, testWebSocket: false)]
-        public async Task TrustOnlyClosesConnectionsToUntrustedClients(ClientAndServiceTestCase clientAndServiceTestCase)
+        [LatestClientAndLatestServiceTestCases(testListening: true, testPolling: false, testWebSocket: false, testNetworkConditions: false)]
+        public async Task NewRequestsCannotBeMadeByUntrustedClients(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                 .AsLatestClientAndLatestServiceBuilder()

--- a/source/Halibut.Tests/TrustFixture.cs
+++ b/source/Halibut.Tests/TrustFixture.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class TrustFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testListening: true, testPolling: false, testWebSocket: false)]
+        public async Task TrustOnlyClosesConnectionsToUntrustedClients(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithStandardServices()
+                .Build(CancellationToken);
+
+            var echoService = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+            var result = await echoService.SayHelloAsync("Hello");
+            result.Should().Be("Hello...");
+
+            // Trust no one
+            clientAndService.Service!.TrustOnly(Array.Empty<string>());
+
+            await AssertAsync.Throws<Exception>(async () => await echoService.SayHelloAsync("Hello again"));
+        }
+    }
+}

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -287,20 +287,8 @@ namespace Halibut.Transport
                 {
                     SafelyRemoveClientFromTcpClientManager(client, clientName);
                     await SafelyCloseStreamAsync(stream, clientName);
-                    SafelyCloseClient(client, clientName);
+                    client.CloseImmediately(ex => log.Write(EventType.Error, "Failed to close TcpClient for {0}. This may result in a memory leak. {1}", clientName, ex.Message));
                 }
-            }
-        }
-
-        void SafelyCloseClient(TcpClient client, EndPoint clientName)
-        {
-            try
-            {
-                client.Close();
-            }
-            catch (Exception ex)
-            {
-                log.Write(EventType.Error, "Failed to close TcpClient for {0}. This may result in a memory leak. {1}", clientName, ex.Message);
             }
         }
 

--- a/source/Halibut/Transport/TcpClientExtensions.cs
+++ b/source/Halibut/Transport/TcpClientExtensions.cs
@@ -3,6 +3,7 @@ using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Util;
 using Halibut.Util.AsyncEx;
 
 namespace Halibut.Transport
@@ -80,6 +81,12 @@ namespace Halibut.Transport
                 {
                 }
             }
+        }
+
+        public static void CloseImmediately(this TcpClient client)
+        {
+            Try.CatchingError(() => client.Client.Close(0), _ => { });
+            Try.CatchingError(client.Close, _ => { });
         }
     }
 }

--- a/source/Halibut/Transport/TcpClientExtensions.cs
+++ b/source/Halibut/Transport/TcpClientExtensions.cs
@@ -85,8 +85,13 @@ namespace Halibut.Transport
 
         public static void CloseImmediately(this TcpClient client)
         {
-            Try.CatchingError(() => client.Client.Close(0), _ => { });
-            Try.CatchingError(client.Close, _ => { });
+            client.CloseImmediately(_ => { });
+        }
+
+        public static void CloseImmediately(this TcpClient client, Action<Exception> onError)
+        {
+            Try.CatchingError(() => client.Client.Close(0), onError);
+            Try.CatchingError(client.Close, onError);
         }
     }
 }

--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -35,7 +35,7 @@ namespace Halibut.Transport
                 {
                     foreach (var client in tcpClients)
                     {
-                        client.Close();
+                        client.CloseImmediately();
                     }
                 }
                 activeClients.Remove(thumbprint);


### PR DESCRIPTION
# Background
This PR introduces a `CloseImmediately` extension method for `TcpClient`, which ensures that no blocking I/O is performed upon trying to close the client.

After some investigation, we were able to clearly show via WireShark that while `TcpClient.Close()` returns almost immediately, the OS has not actually closed the socket and is still trying to send data. This can cause stability issues on the build server when running tests, as sockets are being held open at the OS level longer than expected.

The new `CloseImmediately` extension method first closes the internal Socket manually, explicitly passing a `0` timeout, _then_ calls the regular `TcpClient.Close()` method. This ensures that the client _immediately_ kills the connection, regardless of pending operations, freeing up the socket as expected. This behaviour was verified via WireShark, as well as by a new automated test which has been added.

A new integration fixture `TrustFixture` has also been added, which exercises the only non-obsolete code path which will make use of this change.

# Results
Fixes [sc-57237]

## Before
```
TcpClient client = ...

// Setup code

Logger.Information("Writer has blocked, closing...");
var stopWatch = Stopwatch.StartNew();
client.Close();
stopWatch.Stop();
Logger.Information($"Close completed, duration: {stopWatch.Elapsed.TotalMilliseconds}ms");

```
![20230825-152618_rider64_0BgbNgwFCJ](https://github.com/OctopusDeploy/Halibut/assets/277700/3f17e1b4-6b09-4b16-a25c-c1c88de0cea5)

![20230825-151934_Wireshark_HH3NRZBxP6](https://github.com/OctopusDeploy/Halibut/assets/277700/4b515e44-0dc0-4ecb-8291-67dabeb703b8)

## After

```
TcpClient client = ...

// Setup code

Logger.Information("Writer has blocked, closing...");
var stopWatch = Stopwatch.StartNew();
client.CloseImmediately();
stopWatch.Stop();
Logger.Information($"Close completed, duration: {stopWatch.Elapsed.TotalMilliseconds}ms");

```
![20230825-163036_rider64_yOp1paJHsW](https://github.com/OctopusDeploy/Halibut/assets/277700/be5d12c5-85a9-4d86-a4fe-48c3a0a8fc67)

![20230825-162414_Wireshark_bYOYUA2bBd](https://github.com/OctopusDeploy/Halibut/assets/277700/6cbd5592-8d39-4b5c-803d-af97b24673b6)
