### PR TITLE
Remove the usage of AsyncLocal for DataStream capture in Async Halibut

### DIFF
--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -307,7 +307,7 @@ namespace Halibut.Tests.Transport.Protocol
         {
             if (testCase.SyncOrAsync == SyncOrAsync.Async)
             {
-                return await messageSerializer.ReadMessageAsync<T>(rewindableBufferStream, CancellationToken);
+                return (await messageSerializer.ReadMessageAsync<T>(rewindableBufferStream, CancellationToken)).Message;
             }
 
             return messageSerializer.ReadMessage<T>(rewindableBufferStream);

--- a/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
+++ b/source/Halibut/Transport/Protocol/HalibutContractResolver.cs
@@ -38,19 +38,38 @@ namespace Halibut.Transport.Protocol
 
         static void CaptureOnSerialize(object o, StreamingContext context)
         {
-            var capture = StreamCapture.Current;
-            if (capture != null)
+            if (context.Context is StreamCapturingJsonSerializer.StreamCaptureContext contextCapture)
             {
-                capture.SerializedStreams.Add((DataStream)o);
+                contextCapture.AddCapturedStream((DataStream)o);
+            }
+            else
+            {
+#pragma warning disable CS0612
+                var capture = StreamCapture.Current;
+#pragma warning restore CS0612
+
+                if (capture != null)
+                {
+                    capture.SerializedStreams.Add((DataStream)o);
+                }
             }
         }
 
         static void CaptureOnDeserialize(object o, StreamingContext context)
         {
-            var capture = StreamCapture.Current;
-            if (capture != null)
+            if (context.Context is StreamCapturingJsonSerializer.StreamCaptureContext contextCapture)
             {
-                capture.DeserializedStreams.Add((DataStream)o);
+                contextCapture.AddCapturedStream((DataStream)o);
+            }
+            else
+            {
+#pragma warning disable CS0612
+                var capture = StreamCapture.Current;
+#pragma warning restore CS0612
+                if (capture != null)
+                {
+                    capture.DeserializedStreams.Add((DataStream)o);
+                }
             }
         }
     }

--- a/source/Halibut/Transport/Protocol/IMessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/IMessageSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,10 +11,10 @@ namespace Halibut.Transport.Protocol
     {
         [Obsolete]
         void WriteMessage<T>(Stream stream, T message);
-        Task WriteMessageAsync<T>(Stream stream, T message, CancellationToken cancellationToken);
+        Task<IReadOnlyList<DataStream>> WriteMessageAsync<T>(Stream stream, T message, CancellationToken cancellationToken);
 
         [Obsolete]
         T ReadMessage<T>(RewindableBufferStream stream);
-        Task<T> ReadMessageAsync<T>(RewindableBufferStream stream, CancellationToken cancellationToken);
+        Task<(T Message, IReadOnlyList<DataStream> DataStreams)> ReadMessageAsync<T>(RewindableBufferStream stream, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -51,6 +51,7 @@ namespace Halibut.Transport.Protocol
         {
             var typeRegistry = this.typeRegistry ?? new TypeRegistry();
 
+            [Obsolete]
             JsonSerializer Serializer()
             {
                 var settings = CreateSerializer();
@@ -60,11 +61,23 @@ namespace Halibut.Transport.Protocol
                 return JsonSerializer.Create(settings);
             }
 
+            StreamCapturingJsonSerializer StreamCapturingSerializer()
+            {
+                var settings = CreateSerializer();
+                var binder = new RegisteredSerializationBinder(typeRegistry);
+                settings.SerializationBinder = binder;
+                configureSerializer?.Invoke(settings);
+                return new StreamCapturingJsonSerializer(settings);
+            }
+
             var messageSerializerObserver = this.messageSerializerObserver ?? new NoMessageSerializerObserver();
 
             var messageSerializer = new MessageSerializer(
                 typeRegistry, 
+#pragma warning disable CS0612
                 Serializer, 
+#pragma warning restore CS0612
+                StreamCapturingSerializer, 
                 messageSerializerObserver,
                 readIntoMemoryLimitBytes,
                 writeIntoMemoryLimitBytes,

--- a/source/Halibut/Transport/Protocol/StreamCapture.cs
+++ b/source/Halibut/Transport/Protocol/StreamCapture.cs
@@ -4,6 +4,7 @@ using System.Threading;
 
 namespace Halibut.Transport.Protocol
 {
+    [Obsolete]
     public class StreamCapture : IDisposable
     {
         readonly HashSet<DataStream> serializedStreams = new();
@@ -20,7 +21,7 @@ namespace Halibut.Transport.Protocol
         public ICollection<DataStream> SerializedStreams => serializedStreams;
 
         public ICollection<DataStream> DeserializedStreams => deserializedStreams;
-
+        
         public static StreamCapture New()
         {
             var capture = new StreamCapture();

--- a/source/Halibut/Transport/Protocol/StreamCapturingJsonSerializer.cs
+++ b/source/Halibut/Transport/Protocol/StreamCapturingJsonSerializer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace Halibut.Transport.Protocol
+{
+    public class StreamCapturingJsonSerializer
+    {
+        readonly StreamCaptureContext streamCaptureContext;
+        public JsonSerializer Serializer { get; }
+        public IReadOnlyList<DataStream> DataStreams => streamCaptureContext.CapturedStreams;
+
+        public StreamCapturingJsonSerializer(JsonSerializerSettings settings)
+        {
+            Serializer = JsonSerializer.Create(settings);
+            streamCaptureContext = new StreamCaptureContext();
+            Serializer.Context = new StreamingContext(default, streamCaptureContext);
+        }
+
+        public class StreamCaptureContext
+        {
+            readonly List<DataStream> streams = new();
+            public IReadOnlyList<DataStream> CapturedStreams => streams;
+
+            public void AddCapturedStream(DataStream stream)
+            {
+                streams.Add(stream);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

This PR removes the usage of AsyncLocal for DataStream capture in Async Halibut.

while performance testing Server with Async Halibut DataStreams were being retained unexpectedly, although not confirmed, it seems like it may be from the usage of AsyncLocal. Either way, the usage of AsyncLocal for DataStream capture is not required and can be removed and simplified.

## Before

AsyncLocal was used as a store by the JsonSerializer to capture the serialized and deserialized data streams. These would then be referenced in code via the AsyncLocal later on in the ReadMessageAsync and WriteMessageAsync call.

## After

AsyncLocal is not used by Async Halibut to capture the streams. Instead, the `StreamingContext` on the `HalibutContractResolver` is used as an extension point which gets the DataStreams added to it.

This is then used later to access the streams. 

While it is still a bit of an obscure code flow to follow as it has to hook into the serialization and deserialisation logic, it removes the usage of AsyncLocal.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
