### PR TITLE
Response cache no longer NPE when response is null

### DIFF
--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -252,7 +252,7 @@ namespace Halibut.Tests
             cache.CacheResponse(serviceEndpoint, request, methodInfo, null, action);
             cache.GetCachedResponse(serviceEndpoint, request, methodInfo).Should().BeNull();
             
-            // Anc check we are using the cache correctly.
+            // This just checks we are using the cache correctly, ensuring the above is valid.
             cache.CacheResponse(serviceEndpoint, request, methodInfo, response, action);
             cache.GetCachedResponse(serviceEndpoint, request, methodInfo).Should().NotBeNull();
         }

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -1,14 +1,17 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
 using Halibut.ServiceModel;
+using Halibut.Tests.Builders;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
 using Halibut.Tests.TestServices.SyncClientWithOptions;
+using Halibut.Transport.Caching;
 using NUnit.Framework;
 using ICachingService = Halibut.Tests.TestServices.ICachingService;
 
@@ -233,6 +236,25 @@ namespace Halibut.Tests
                 exception2!.Message.Should().StartWith("Exception");
                 exception1!.Message.Should().NotBe(exception2.Message);
             }
+        }
+
+        [Test]
+        public void NullRequestsAreNotCached()
+        {
+            var cache = new ResponseCache();
+            var serviceEndpoint = new ServiceEndPointBuilder().Build();
+            var request = new RequestMessageBuilder(serviceEndpoint.BaseUri.ToString()).Build();
+            var methodInfo = typeof(IAsyncClientCachingService).GetMethods().First(m => m.Name.Equals("CachableCallAsync"));
+            var response = new ResponseMessageBuilder(serviceEndpoint.BaseUri.ToString()).Build();
+            OverrideErrorResponseMessageCachingAction action = message => false;
+            
+            // Actual test, testing a null response.
+            cache.CacheResponse(serviceEndpoint, request, methodInfo, null, action);
+            cache.GetCachedResponse(serviceEndpoint, request, methodInfo).Should().BeNull();
+            
+            // Anc check we are using the cache correctly.
+            cache.CacheResponse(serviceEndpoint, request, methodInfo, response, action);
+            cache.GetCachedResponse(serviceEndpoint, request, methodInfo).Should().NotBeNull();
         }
     }
 }

--- a/source/Halibut/Transport/Caching/ResponseCache.cs
+++ b/source/Halibut/Transport/Caching/ResponseCache.cs
@@ -53,6 +53,11 @@ namespace Halibut.Transport.Caching
 
         bool CanBeCached(MethodInfo methodInfo, ResponseMessage response, OverrideErrorResponseMessageCachingAction overrideErrorResponseMessageCachingAction)
         {
+            if (response == null)
+            {
+                return false;
+            }
+            
             if (!CanBeCached(methodInfo))
             {
                 return false;


### PR DESCRIPTION
# Background

The ResponseCache would throw when given a null response. This can happen so instead just don't cache null responses messages.

Note that the entire Halibut `ResponseMessage` is null, this has nothing to do with that the RPC call itself returned.

[SC-58477]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
