### PR TITLE
Remove the Message property from the LogEvent to reduce the size of the LogEvent object

### DIFF
--- a/source/Halibut/Diagnostics/LogEvent.cs
+++ b/source/Halibut/Diagnostics/LogEvent.cs
@@ -7,18 +7,15 @@ namespace Halibut.Diagnostics
         public LogEvent(EventType type, string message, Exception error, object[] formatArguments)
         {
             Type = type;
-            Message = message;
             Error = error;
             Time = DateTimeOffset.UtcNow;
             FormattedMessage = formatArguments == null || formatArguments.Length == 0
-                ? Message
-                : string.Format(Message, formatArguments);
+                ? message
+                : string.Format(message, formatArguments);
         }
 
         public EventType Type { get; }
-
-        public string Message { get; }
-
+        
         public string FormattedMessage { get; }
 
         public Exception Error { get; }
@@ -27,7 +24,7 @@ namespace Halibut.Diagnostics
 
         public override string ToString()
         {
-            return Type + " " + Message;
+            return Type + " " + FormattedMessage;
         }
     }
 }


### PR DESCRIPTION
# Background

Currently Server retains up to 100 LogEvents per ExecutionTarget which quickly grows to 100's MB when scaling Server.

The LogMesage object contains a redundant field `Message` that is not referenced by Server. Remove this redundant field to reduce some Memory usage.

## Example Memory Usage

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/1ee09d2e-96ff-4139-868d-5aa9756772ba)

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/8fde1fdc-8e33-4cf3-99a8-233c690ba818)

## Example Server Usage of LogEvent

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/5a7c569f-8d76-4af9-bd09-9f3630cf6705)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
