### PR TITLE
Log exceptions before the queue is reached in a way that makes it easy to determine this is before message exchange.

### DIFF
--- a/source/Halibut.Tests/Diagnostics/FailuresWhenPollingTentaclesConnectAreLoggedFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/FailuresWhenPollingTentaclesConnectAreLoggedFixture.cs
@@ -32,17 +32,17 @@ namespace Halibut.Tests.Diagnostics
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
                 // If this task completes and then we likely didn't kill the connect as we intended to.  
-                var checkPollingTentacleDidntConnect = Task.Run(async () => await echo.SayHelloAsync("Deploy package A"));
+                var checkPollingTentacleDidNotConnect = Task.Run(async () => await echo.SayHelloAsync("Deploy package A"));
 
                 await Wait.For(async () =>
                 {
                     await Task.CompletedTask;
                     var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
                     if (logs.Any(l => l.Type == EventType.ErrorInInitialisation)) return true;
-                    return checkPollingTentacleDidntConnect.IsCompleted;
+                    return checkPollingTentacleDidNotConnect.IsCompleted;
                 }, CancellationToken);
 
-                checkPollingTentacleDidntConnect.IsCompleted.Should().BeFalse("We should have killed the connection before the request");
+                checkPollingTentacleDidNotConnect.IsCompleted.Should().BeFalse("We should have killed the connection before the request");
 
                 var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
                 logs.Should().Match(logs => logs.Any(l => l.Type == EventType.ErrorInInitialisation));
@@ -74,17 +74,17 @@ namespace Halibut.Tests.Diagnostics
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
                 // If this task completes and then we likely didn't kill the connect as we intended to.  
-                var checkPollingTentacleDidntConnect = Task.Run(async () => await echo.SayHelloAsync("Deploy package A"));
+                var checkPollingTentacleDidNotConnect = Task.Run(async () => await echo.SayHelloAsync("Deploy package A"));
 
                 await Wait.For(async () =>
                 {
                     await Task.CompletedTask;
                     var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
                     if (logs.Any(l => l.Type == EventType.ErrorInInitialisation)) return true;
-                    return checkPollingTentacleDidntConnect.IsCompleted;
+                    return checkPollingTentacleDidNotConnect.IsCompleted;
                 }, CancellationToken);
 
-                checkPollingTentacleDidntConnect.IsCompleted.Should().BeFalse("We should have killed the connection before the request");
+                checkPollingTentacleDidNotConnect.IsCompleted.Should().BeFalse("We should have killed the connection before the request");
 
                 var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
                 logs.Should().Match(logs => logs.Any(l => l.Type == EventType.ErrorInInitialisation));

--- a/source/Halibut.Tests/Diagnostics/FailuresWhenPollingTentaclesConnectAreLoggedFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/FailuresWhenPollingTentaclesConnectAreLoggedFixture.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.Streams;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
+using Halibut.TestUtils.Contracts;
+using Halibut.Transport.Streams;
+using NUnit.Framework;
+using Octopus.TestPortForwarder;
+
+namespace Halibut.Tests.Diagnostics
+{
+    public class FailuresWhenPollingTentaclesConnectAreLoggedFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testListening: false, testNetworkConditions: false)]
+        public async Task VeryEarlyOnFailuresAreRecordedAsInitialisationErrors(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .WithStandardServices()
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .RecordingClientLogs(out var clientLogs)
+                             .WithPortForwarding(out var portForwarder)
+                             .WithClientStreamFactory(new ActionBeforeCreateStreamFactory(new StreamFactory(clientAndServiceTestCase.ServiceAsyncHalibutFeature),
+                                 () => { portForwarder.Value.CloseExistingConnections(); }))
+                             .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                // If this task completes and then we likely didn't kill the connect as we intended to.  
+                var checkPollingTentacleDidntConnect = Task.Run(async () => await echo.SayHelloAsync("Deploy package A"));
+
+                await Wait.For(async () =>
+                {
+                    await Task.CompletedTask;
+                    var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
+                    if (logs.Any(l => l.Type == EventType.ErrorInInitialisation)) return true;
+                    return checkPollingTentacleDidntConnect.IsCompleted;
+                }, CancellationToken);
+
+                checkPollingTentacleDidntConnect.IsCompleted.Should().BeFalse("We should have killed the connection before the request");
+
+                var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
+                logs.Should().Match(logs => logs.Any(l => l.Type == EventType.ErrorInInitialisation));
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testListening: false,
+            testWebSocket: false, // Web Sockets do init work to go from TCP to ssl to http finally to web socket before we
+            // get to it so killing the connection via the port forwarder does not result in a connection
+            // error we can see.
+            testNetworkConditions: false)]
+        public async Task VeryEarlyOnFailuresAreRecordedAsInitialisationErrors_KilledAfterFirstWrite(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .WithStandardServices()
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .RecordingClientLogs(out var clientLogs)
+                             .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
+                                 .WithDataObserver(() =>
+                                 {
+                                     var connectionKiller = new DataTransferObserverBuilder()
+                                         .WithKillConnectionAfterANumberOfWrites(Logger, 2)
+                                         .Build();
+                                     return new BiDirectionalDataTransferObserver(connectionKiller, connectionKiller);
+                                 })
+                                 .Build())
+                             .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                // If this task completes and then we likely didn't kill the connect as we intended to.  
+                var checkPollingTentacleDidntConnect = Task.Run(async () => await echo.SayHelloAsync("Deploy package A"));
+
+                await Wait.For(async () =>
+                {
+                    await Task.CompletedTask;
+                    var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
+                    if (logs.Any(l => l.Type == EventType.ErrorInInitialisation)) return true;
+                    return checkPollingTentacleDidntConnect.IsCompleted;
+                }, CancellationToken);
+
+                checkPollingTentacleDidntConnect.IsCompleted.Should().BeFalse("We should have killed the connection before the request");
+
+                var logs = clientLogs.Values.SelectMany(log => log.GetLogs()).ToList();
+                logs.Should().Match(logs => logs.Any(l => l.Type == EventType.ErrorInInitialisation));
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -57,7 +57,8 @@ namespace Halibut.Tests.Support
         Func<string, string, UnauthorizedClientConnectResponse> clientOnUnauthorizedClientConnect;
         HalibutTimeoutsAndLimits? halibutTimeoutsAndLimits;
 
-        IStreamFactory? streamFactory;
+        IStreamFactory? clientStreamFactory;
+        IStreamFactory? serviceStreamFactory;
 
 
         public LatestClientAndLatestServiceBuilder(ServiceConnectionType serviceConnectionType,
@@ -120,7 +121,20 @@ namespace Halibut.Tests.Support
 
         public LatestClientAndLatestServiceBuilder WithStreamFactory(IStreamFactory streamFactory)
         {
-            this.streamFactory = streamFactory;
+            this.serviceStreamFactory = streamFactory;
+            this.clientStreamFactory = streamFactory;
+            return this;
+        }
+        
+        public LatestClientAndLatestServiceBuilder WithClientStreamFactory(IStreamFactory clientStreamFactory)
+        {
+            this.clientStreamFactory = clientStreamFactory;
+            return this;
+        }
+        
+        public LatestClientAndLatestServiceBuilder WithServiceStreamFactory(IStreamFactory serviceStreamFactory)
+        {
+            this.serviceStreamFactory = serviceStreamFactory;
             return this;
         }
 
@@ -377,7 +391,7 @@ namespace Halibut.Tests.Support
                 .WithPendingRequestQueueFactory(factory)
                 .WithTrustProvider(clientTrustProvider)
                 .WithAsyncHalibutFeatureEnabledIfForcingAsync(forceClientProxyType)
-                .WithStreamFactoryIfNotNull(streamFactory)
+                .WithStreamFactoryIfNotNull(clientStreamFactory)
                 .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                 .WithOnUnauthorizedClientConnect(clientOnUnauthorizedClientConnect);
 
@@ -397,7 +411,7 @@ namespace Halibut.Tests.Support
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                     .WithAsyncHalibutFeature(serviceAsyncHalibutFeature)
                     .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
-                    .WithStreamFactoryIfNotNull(streamFactory)
+                    .WithStreamFactoryIfNotNull(serviceStreamFactory)
                     .WithLogFactory(BuildServiceLogger());
 
                 if(pollingReconnectRetryPolicy != null) serviceBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);

--- a/source/Halibut.Tests/Support/Streams/ActionBeforeCreateStreamFactory.cs
+++ b/source/Halibut.Tests/Support/Streams/ActionBeforeCreateStreamFactory.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using Halibut.Transport.Protocol;
+using Halibut.Transport.Streams;
+
+namespace Halibut.Tests.Support.Streams
+{
+    public class ActionBeforeCreateStreamFactory : IStreamFactory
+    {
+        IStreamFactory streamFactory;
+        Action beforeCreateStream;
+
+        public ActionBeforeCreateStreamFactory(IStreamFactory streamFactory, Action beforeCreateStream)
+        {
+            this.streamFactory = streamFactory;
+            this.beforeCreateStream = beforeCreateStream;
+        }
+
+        public Stream CreateStream(TcpClient stream)
+        {
+            beforeCreateStream();
+            return streamFactory.CreateStream(stream);
+        }
+
+        public WebSocketStream CreateStream(WebSocket webSocket)
+        {
+            beforeCreateStream();
+            return streamFactory.CreateStream(webSocket);
+        }
+    }
+}

--- a/source/Halibut/Diagnostics/EventType.cs
+++ b/source/Halibut/Diagnostics/EventType.cs
@@ -9,12 +9,33 @@ namespace Halibut.Diagnostics
         Security,
         MessageExchange,
         Diagnostic,
+        
+        /// <summary>
+        /// Used when the listening server (which may or may not be a service)
+        /// is not presented with a certificate from the client OR
+        /// the certificate presented by the client is not authorized.
+        /// 
+        /// This happens before messages are exchanged.
+        /// </summary>
         ClientDenied,
+        
         Error,
+        
+        /// <summary>
+        /// An error that has occured before message exchange
+        /// </summary>
+        ErrorInInitialisation,
+        
         ListenerStarted,
         ListenerAcceptedClient,
         ListenerStopped,
         SecurityNegotiation,
-        FileTransfer
+        FileTransfer,
+        
+        /// <summary>
+        /// Used when an error occurs identifying the remote or identify
+        /// This happens before messages are exchanged.
+        /// </summary>
+        ErrorInIdentify
     }
 }

--- a/source/Halibut/Diagnostics/EventType.cs
+++ b/source/Halibut/Diagnostics/EventType.cs
@@ -5,6 +5,7 @@ namespace Halibut.Diagnostics
     public enum EventType
     {
         OpeningNewConnection,
+        [Obsolete]
         UsingExistingConnectionFromPool,
         Security,
         MessageExchange,
@@ -30,6 +31,7 @@ namespace Halibut.Diagnostics
         ListenerAcceptedClient,
         ListenerStopped,
         SecurityNegotiation,
+        [Obsolete]
         FileTransfer,
         
         /// <summary>

--- a/source/Halibut/Diagnostics/ILog.cs
+++ b/source/Halibut/Diagnostics/ILog.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
+using Halibut.Diagnostics.LogWriters;
 
 namespace Halibut.Diagnostics
 {
-    public interface ILog
+    public interface ILog : ILogWriter
     {
-        void Write(EventType type, string message, params object[] args);
-        void WriteException(EventType type, string message, Exception ex, params object[] args);
         IList<LogEvent> GetLogs();
     }
 }

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -54,6 +54,7 @@ namespace Halibut.Diagnostics
             switch (logEvent.Type)
             {
                 case EventType.Error:
+                case EventType.ErrorInInitialisation:
                     return LogLevel.Error;
                 case EventType.Diagnostic:
                 case EventType.SecurityNegotiation:

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -55,6 +55,7 @@ namespace Halibut.Diagnostics
             {
                 case EventType.Error:
                 case EventType.ErrorInInitialisation:
+                case EventType.ErrorInIdentify:
                     return LogLevel.Error;
                 case EventType.Diagnostic:
                 case EventType.SecurityNegotiation:

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -212,6 +212,20 @@ namespace Halibut.Transport.Protocol
             }
         }
 
+        async Task<RemoteIdentity> GetRemoteIdentityAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var identity = await stream.ReadRemoteIdentityAsync(cancellationToken);
+                return identity;
+            }
+            catch (Exception e)
+            {
+                log.WriteException(EventType.ErrorInIdentify, "Remote failed to identify itself.", e);
+                throw;
+            }
+        }
+
         async Task IdentifyAsServerAsync(RemoteIdentity identityOfRemote, CancellationToken cancellationToken)
         {
             try
@@ -223,22 +237,6 @@ namespace Halibut.Transport.Protocol
                 log.WriteException(EventType.ErrorInIdentify, $"Failed to identify as server to the previously identified remote {identityOfRemote.SubscriptionId} of type {identityOfRemote.IdentityType}", e);
                 throw;
             }
-        }
-
-        async Task<RemoteIdentity> GetRemoteIdentityAsync(CancellationToken cancellationToken)
-        {
-            RemoteIdentity identity;
-            try
-            {
-                identity = await stream.ReadRemoteIdentityAsync(cancellationToken);
-            }
-            catch (Exception e)
-            {
-                log.WriteException(EventType.ErrorInIdentify, "Remote failed to identify itself.", e);
-                throw;
-            }
-
-            return identity;
         }
 
         [Obsolete]

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -195,8 +195,8 @@ namespace Halibut.Transport.Protocol
 
         public async Task ExchangeAsServerAsync(Func<RequestMessage, Task<ResponseMessage>> incomingRequestProcessor, Func<RemoteIdentity, IPendingRequestQueue> pendingRequests, CancellationToken cancellationToken)
         {
-            var identity = await stream.ReadRemoteIdentityAsync(cancellationToken);
-            await stream.IdentifyAsServerAsync(cancellationToken);
+            var identity = await GetRemoteIdentityAsync(cancellationToken);
+            await IdentifyAsServerAsync(identity, cancellationToken);
 
             switch (identity.IdentityType)
             {
@@ -207,8 +207,38 @@ namespace Halibut.Transport.Protocol
                     await ProcessSubscriberAsync(pendingRequests(identity), cancellationToken);
                     break;
                 default:
+                    log.Write(EventType.ErrorInIdentify, $"Remote with identify {identity.SubscriptionId} identified itself with an unknown identity type {identity.IdentityType}");
                     throw new ProtocolException("Unexpected remote identity: " + identity.IdentityType);
             }
+        }
+
+        async Task IdentifyAsServerAsync(RemoteIdentity identityOfRemote, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await stream.IdentifyAsServerAsync(cancellationToken);
+            }
+            catch (Exception e)
+            {
+                log.WriteException(EventType.ErrorInIdentify, $"Failed to identify as server to the previously identified remote {identityOfRemote.SubscriptionId} of type {identityOfRemote.IdentityType}", e);
+                throw;
+            }
+        }
+
+        async Task<RemoteIdentity> GetRemoteIdentityAsync(CancellationToken cancellationToken)
+        {
+            RemoteIdentity identity;
+            try
+            {
+                identity = await stream.ReadRemoteIdentityAsync(cancellationToken);
+            }
+            catch (Exception e)
+            {
+                log.WriteException(EventType.ErrorInIdentify, "Remote failed to identify itself.", e);
+                throw;
+            }
+
+            return identity;
         }
 
         [Obsolete]

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -159,13 +159,13 @@ namespace Halibut.Transport
                     catch (Exception ex)
                     {
                         numberOfFailedAttemptsInRow++;
-                        log.WriteException(EventType.Error, "Error accepting TCP client", ex);
+                        log.WriteException(EventType.ErrorInInitialisation, "Error accepting TCP client", ex);
                         // Slow down the logs in case an exception is immediately encountered after X failed AcceptTcpClient calls
                         if (numberOfFailedAttemptsInRow >= errorThreshold)
                         {
                             var millisecondsTimeout = Math.Max(0, Math.Min(numberOfFailedAttemptsInRow - errorThreshold, 100)) * 10;
                             log.Write(
-                                EventType.Error,
+                                EventType.ErrorInInitialisation,
                                 $"Accepting a connection has failed {numberOfFailedAttemptsInRow} times in a row. Waiting {millisecondsTimeout}ms before attempting to accept another connection. For a detailed troubleshooting guide go to https://g.octopushq.com/TentacleTroubleshooting"
                             );
                             Thread.Sleep(millisecondsTimeout);
@@ -206,7 +206,7 @@ namespace Halibut.Transport
             }
             catch (Exception ex)
             {
-                log.WriteException(EventType.Error, "Error initializing TCP client", ex);
+                log.WriteException(EventType.ErrorInInitialisation, "Error initializing TCP client", ex);
             }
         }
 
@@ -220,6 +220,7 @@ namespace Halibut.Transport
 #endif            
             using (var ssl = new SslStream(stream, true, AcceptAnySslCertificate))
             {
+                bool hasReachedExchangeMessages = false;
                 try
                 {
                     log.Write(EventType.SecurityNegotiation, "Performing TLS server handshake");
@@ -265,6 +266,7 @@ namespace Halibut.Transport
                                    }))
                             {
                                 tcpClientManager.AddActiveClient(thumbprint, client);
+                                hasReachedExchangeMessages = true;
                                 await ExchangeMessages(ssl).ConfigureAwait(false);
                             }
                         }
@@ -273,6 +275,7 @@ namespace Halibut.Transport
                             // The stream is wrapped in a NetworkTimeoutStream which handles closing the inner stream on timeout
                             // so the weakSsl workaround is not required to ensure the stream is Disposed
                             tcpClientManager.AddActiveClient(thumbprint, client);
+                            hasReachedExchangeMessages = true;
                             await ExchangeMessages(ssl).ConfigureAwait(false);
                         }
                     }
@@ -283,7 +286,8 @@ namespace Halibut.Transport
                 }
                 catch (IOException ex) when (ex.InnerException is SocketException)
                 {
-                    log.WriteException(EventType.Error, "Socket IO exception: {0}", ex.InnerException, clientName);
+                    var errorEventType = hasReachedExchangeMessages ? EventType.Error : EventType.ErrorInInitialisation;
+                    log.WriteException(errorEventType, "Socket IO exception: {0}", ex.InnerException, clientName);
                 }
                 catch (IOException ex) when (ex.InnerException is ObjectDisposedException)
                 {
@@ -291,17 +295,20 @@ namespace Halibut.Transport
                 }
                 catch (SocketException ex)
                 {
-                    log.WriteException(EventType.Error, "Socket exception: {0}", ex, clientName);
+                    var errorEventType = hasReachedExchangeMessages ? EventType.Error : EventType.ErrorInInitialisation;
+                    log.WriteException(errorEventType, "Socket exception: {0}", ex, clientName);
                 }
                 catch (Exception ex)
                 {
-                    log.WriteException(EventType.Error, "Unhandled error when handling request from client: {0}", ex, clientName);
+                    var errorEventType = hasReachedExchangeMessages ? EventType.Error : EventType.ErrorInInitialisation;
+                    log.WriteException(errorEventType, "Unhandled error when handling request from client: {0}", ex, clientName);
                 }
                 finally
                 {
                     SafelyRemoveClientFromTcpClientManager(client, clientName);
                     await SafelyCloseStreamAsync(stream, clientName);
-                    client.CloseImmediately(ex => log.Write(EventType.Error, "Failed to close TcpClient for {0}. This may result in a memory leak. {1}", clientName, ex.Message));
+                    var errorEventType = hasReachedExchangeMessages ? EventType.Error : EventType.ErrorInInitialisation;
+                    client.CloseImmediately(ex => log.Write(errorEventType, "Failed to close TcpClient for {0}. This may result in a memory leak. {1}", clientName, ex.Message));
                 }
             }
         }

--- a/source/Octopus.TestPortForwarder/DataTransferObserverBuilder.cs
+++ b/source/Octopus.TestPortForwarder/DataTransferObserverBuilder.cs
@@ -32,6 +32,23 @@ namespace Octopus.TestPortForwarder
                 }
             });
         }
+        
+        public DataTransferObserverBuilder WithKillConnectionAfterANumberOfWrites(ILogger logger, int writeNumberToKillOn)
+        {
+            var hasKilledConnection = false;
+            var numberOfWritesSeen = 0;
+
+            return WithWritingDataObserver((tcpPump, _) =>
+            {
+                Interlocked.Increment(ref numberOfWritesSeen);
+                if (!hasKilledConnection && (numberOfWritesSeen - 1) == writeNumberToKillOn)
+                {
+                    hasKilledConnection = true;
+                    logger.Information("Killing pump");
+                    tcpPump.Dispose();
+                }
+            });
+        }
 
         public IDataTransferObserver Build()
         {


### PR DESCRIPTION
# Background

We log errors from a connection from the time theconnection is created to close to when the queue (so no more IO is being done).

These log messages now come out with events types that make it possible to determine they are during the connecting phase. These events are:
* ErrorInInitialisation,
* ErrorInIdentify
* ClientDenied

Some existing log event types are now commented to make it easy for us to identify which ones to log.

[SC-55402]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
