### PR TITLE
Distinguishing between a connection that was authorized or unauthorized.

### DIFF
--- a/source/Halibut.Tests/Support/TestConnectionsObserver.cs
+++ b/source/Halibut.Tests/Support/TestConnectionsObserver.cs
@@ -1,25 +1,30 @@
 using System;
-using System.Threading;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using Halibut.Transport.Observability;
 
 namespace Halibut.Tests.Support
 {
     public class TestConnectionsObserver : IConnectionsObserver
     {
-        long connectionAcceptedCount;
-        long connectionClosedCount;
+        readonly ConcurrentBag<bool> connectionAcceptedAuthorized = new();
+        readonly ConcurrentBag<bool> connectionClosedAuthorized = new();
+        
+        public long ConnectionAcceptedCount => connectionAcceptedAuthorized.Count;
+        public long ConnectionClosedCount => connectionClosedAuthorized.Count;
 
-        public long ConnectionAcceptedCount => Interlocked.Read(ref connectionAcceptedCount);
-        public long ConnectionClosedCount => Interlocked.Read(ref connectionClosedCount);
+        public IReadOnlyList<bool> ConnectionAcceptedAuthorized => connectionAcceptedAuthorized.ToList();
+        public IReadOnlyList<bool> ConnectionClosedAuthorized => connectionClosedAuthorized.ToList();
 
-        public void ConnectionAccepted()
+        public void ConnectionAccepted(bool authorized)
         {
-            Interlocked.Increment(ref connectionAcceptedCount);
+            connectionAcceptedAuthorized.Add(authorized);
         }
 
-        public void ConnectionClosed()
+        public void ConnectionClosed(bool authorized)
         {
-            Interlocked.Increment(ref connectionClosedCount);
+            connectionClosedAuthorized.Add(authorized);
         }
     }
 }

--- a/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
+++ b/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.ServiceModel;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
+using Halibut.Tests.TestServices.SyncClientWithOptions;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 
@@ -14,7 +18,7 @@ namespace Halibut.Tests.Transport.Observability
     {
         [Test]
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
-        public async Task ObserveConnections(ClientAndServiceTestCase clientAndServiceTestCase)
+        public async Task ObserveAuthorizedConnections(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var connectionsObserver = new TestConnectionsObserver();
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
@@ -22,7 +26,6 @@ namespace Halibut.Tests.Transport.Observability
                              .AsLatestClientAndLatestServiceBuilder()
                              .WithConnectionObserverOnTcpServer(connectionsObserver)
                              .WithPortForwarding()
-                             .WithInstantReconnectPollingRetryPolicy()
                              .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
@@ -44,7 +47,99 @@ namespace Halibut.Tests.Transport.Observability
                 connectionsObserver.ConnectionAcceptedCount.Should().Be(2);
                 connectionsObserver.ConnectionClosedCount.Should().Be(2);
             }, TimeSpan.FromSeconds(30), Logger, CancellationToken);
-            
+
+            connectionsObserver.ConnectionAcceptedAuthorized.Should().AllSatisfy(a => a.Should().BeTrue());
+            connectionsObserver.ConnectionClosedAuthorized.Should().AllSatisfy(a => a.Should().BeTrue());
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
+        public async Task ObserveUnauthorizedListeningConnections(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var connectionsObserver = new TestConnectionsObserver();
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .WithStandardServices()
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .WithServiceTrustingTheWrongCertificate()
+                             .WithConnectionObserverOnTcpServer(connectionsObserver)
+                             .Build(CancellationToken))
+            {
+                var echo = clientAndService.CreateClient<IEchoService, IAsyncClientEchoService>();
+                await AssertionExtensions.Should(() => echo.SayHelloAsync("hello")).ThrowAsync<HalibutClientException>();
+
+                connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
+                connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);
+
+                connectionsObserver.ConnectionAcceptedAuthorized.Should().AllSatisfy(a => a.Should().BeFalse());
+                connectionsObserver.ConnectionClosedAuthorized.Should().AllSatisfy(a => a.Should().BeFalse());
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testListening: false)]
+        public async Task ObserveUnauthorizedPollingConnections(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var connectionsObserver = new TestConnectionsObserver();
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .WithStandardServices()
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .WithConnectionObserverOnTcpServer(connectionsObserver)
+                             .Build(CancellationToken))
+            {
+                clientAndBuilder.Client.TrustOnly(new List<string>());
+
+                using var cts = new CancellationTokenSource();
+                var token = cts.Token;
+                var echo = clientAndBuilder.CreateClientWithOptions<IEchoService, ISyncClientEchoServiceWithOptions, IAsyncClientEchoServiceWithOptions>(
+                    point => { point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(2000); });
+
+                var incrementCount = Task.Run(async () => await echo.SayHelloAsync("hello", new HalibutProxyRequestOptions(token, CancellationToken.None)), CancellationToken);
+
+                await Task.Delay(3000, CancellationToken);
+
+                cts.Cancel();
+
+                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<Exception>();
+
+                connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
+                connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);
+
+                connectionsObserver.ConnectionAcceptedAuthorized.Should().AllSatisfy(a => a.Should().BeFalse());
+                connectionsObserver.ConnectionClosedAuthorized.Should().AllSatisfy(a => a.Should().BeFalse());
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testListening: false)]
+        public async Task ObserveUnauthorizedPollingWebSocketConnections(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var connectionsObserver = new TestConnectionsObserver();
+            await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .WithStandardServices()
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .WithServiceTrustingTheWrongCertificate()
+                             .WithConnectionObserverOnTcpServer(connectionsObserver)
+                             .Build(CancellationToken))
+            {
+                using var cts = new CancellationTokenSource();
+                var token = cts.Token;
+                var echo = clientAndBuilder.CreateClientWithOptions<IEchoService, ISyncClientEchoServiceWithOptions, IAsyncClientEchoServiceWithOptions>(
+                    point => { point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(2000); });
+
+                var incrementCount = Task.Run(async () => await echo.SayHelloAsync("hello", new HalibutProxyRequestOptions(token, CancellationToken.None)), CancellationToken);
+
+                await Task.Delay(3000, CancellationToken);
+
+                cts.Cancel();
+
+                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<Exception>();
+
+                connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
+                connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);
+
+                connectionsObserver.ConnectionAcceptedAuthorized.Should().AllSatisfy(a => a.Should().BeFalse());
+                connectionsObserver.ConnectionClosedAuthorized.Should().AllSatisfy(a => a.Should().BeFalse());
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
+++ b/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
@@ -93,13 +93,13 @@ namespace Halibut.Tests.Transport.Observability
                 var echo = clientAndBuilder.CreateClientWithOptions<IEchoService, ISyncClientEchoServiceWithOptions, IAsyncClientEchoServiceWithOptions>(
                     point => { point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(2000); });
 
-                var incrementCount = Task.Run(async () => await echo.SayHelloAsync("hello", new HalibutProxyRequestOptions(token, CancellationToken.None)), CancellationToken);
+                var sayHelloTask = Task.Run(async () => await echo.SayHelloAsync("hello", new HalibutProxyRequestOptions(token, CancellationToken.None)), CancellationToken);
 
                 await Task.Delay(3000, CancellationToken);
 
                 cts.Cancel();
 
-                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<Exception>();
+                await AssertionExtensions.Should(() => sayHelloTask).ThrowAsync<Exception>();
 
                 connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
                 connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);
@@ -126,13 +126,13 @@ namespace Halibut.Tests.Transport.Observability
                 var echo = clientAndBuilder.CreateClientWithOptions<IEchoService, ISyncClientEchoServiceWithOptions, IAsyncClientEchoServiceWithOptions>(
                     point => { point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(2000); });
 
-                var incrementCount = Task.Run(async () => await echo.SayHelloAsync("hello", new HalibutProxyRequestOptions(token, CancellationToken.None)), CancellationToken);
+                var sayHelloTask = Task.Run(async () => await echo.SayHelloAsync("hello", new HalibutProxyRequestOptions(token, CancellationToken.None)), CancellationToken);
 
                 await Task.Delay(3000, CancellationToken);
 
                 cts.Cancel();
 
-                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<Exception>();
+                await AssertionExtensions.Should(() => sayHelloTask).ThrowAsync<Exception>();
 
                 connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
                 connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);

--- a/source/Halibut/Transport/Observability/IConnectionsObserver.cs
+++ b/source/Halibut/Transport/Observability/IConnectionsObserver.cs
@@ -1,5 +1,10 @@
 namespace Halibut.Transport.Observability
 {
+    public enum AcceptedConnectionState
+    {
+        Start,
+        Authenticated
+    }
     public interface IConnectionsObserver
     {
         /// <summary>
@@ -11,13 +16,13 @@ namespace Halibut.Transport.Observability
         /// - When a "server" accepts a connection from a polling service (either websocket or regular)
         /// - When a "server" accepts a connection from a listening client (so in this case the server is the service)
         /// </summary>
-        public void ConnectionAccepted();
+        public void ConnectionAccepted(bool authorized);
 
         /// <summary>
         /// A previously accepted connection has been closed.
         ///
         /// For every call to ConnectionClosed() their can be at most one call to this method. 
         /// </summary>
-        public void ConnectionClosed();
+        public void ConnectionClosed(bool authorized);
     }
 }

--- a/source/Halibut/Transport/Observability/IConnectionsObserver.cs
+++ b/source/Halibut/Transport/Observability/IConnectionsObserver.cs
@@ -1,10 +1,5 @@
 namespace Halibut.Transport.Observability
 {
-    public enum AcceptedConnectionState
-    {
-        Start,
-        Authenticated
-    }
     public interface IConnectionsObserver
     {
         /// <summary>

--- a/source/Halibut/Transport/Observability/NoOpConnectionsObserver.cs
+++ b/source/Halibut/Transport/Observability/NoOpConnectionsObserver.cs
@@ -6,11 +6,11 @@ namespace Halibut.Transport.Observability
 
         public static NoOpConnectionsObserver Instance => singleInstance ??= new NoOpConnectionsObserver();
 
-        public void ConnectionAccepted()
+        public void ConnectionAccepted(bool authorized)
         {
         }
 
-        public void ConnectionClosed()
+        public void ConnectionClosed(bool authorized)
         {
         }
     }


### PR DESCRIPTION
[sc-59576]

# Background

When observing logs for async Halibut, we found that tentacles with invalid thumbprints were becoming noise in the metrics for connections.

# Results

Related to https://github.com/OctopusDeploy/Issues/issues/8266

## Before

All connections were being put into metrics in Octopus Server, as we did not know if it was an initial connection, or an authorized connection.

## After
We now pass a parameter to the observer stating whether we have successfully authorized.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
