### PR TITLE
Fix flakey tests

### DIFF
--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -253,13 +253,13 @@ namespace Halibut.Tests
         static int NumberOfParallelRequests(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             int threadCount = 64;
-            if (!clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousClient())
+            if (clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousClient())
             {
                 // Reduce this down to reduce thread pool exhaustion.
                 // We already test latest => latest with 64 concurrent task
                 // So it is likely that an external old client will have no problems running
                 // 64 concurrent task on a latest service.
-                threadCount = 8;
+                threadCount = 4;
             }
 
             return threadCount;


### PR DESCRIPTION
# Background

- `SucceedsWhenPollingServicePresentsWrongCertificate_ButServiceIsConfiguredToTrustAndAllowConnection`
  - Moved assertion to a place we can guarantee there is no race condition

- `ParallelRequestsFixture`
  - Fixed issue where more tasks than expected are run for previous client parallel tests

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
