### PR TITLE
Reduce Parallel Tests

### DIFF
--- a/source/Halibut.Tests/BumpThreadPoolForAllTests.cs
+++ b/source/Halibut.Tests/BumpThreadPoolForAllTests.cs
@@ -12,8 +12,8 @@ namespace Halibut.Tests
             [OneTimeSetUp]
             public void GlobalSetup()
             {
-                var minWorkerPoolThreads = 5000;
-                var minCompletionPortThreads = 5000;
+                var minWorkerPoolThreads = 400;
+                ThreadPool.GetMinThreads(out _, out var minCompletionPortThreads);
                 ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
                 ThreadPool.SetMaxThreads(Math.Max(minWorkerPoolThreads, maxWorkerThreads), Math.Max(minCompletionPortThreads, maxCompletionPortThreads));
                 ThreadPool.SetMinThreads(minWorkerPoolThreads, minCompletionPortThreads);

--- a/source/Halibut.Tests/ParallelRequestsFixture.cs
+++ b/source/Halibut.Tests/ParallelRequestsFixture.cs
@@ -252,17 +252,16 @@ namespace Halibut.Tests
         
         static int NumberOfParallelRequests(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            int threadCount = 64;
-            if (!clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousClient())
+            if (clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousClient())
             {
                 // Reduce this down to reduce thread pool exhaustion.
                 // We already test latest => latest with 64 concurrent task
                 // So it is likely that an external old client will have no problems running
                 // 64 concurrent task on a latest service.
-                threadCount = 8;
+                return 4;
             }
 
-            return threadCount;
+            return 32;
         }
     }
 }

--- a/source/Halibut.Tests/Support/TestAttributes/CustomLevelOfParallelismAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/CustomLevelOfParallelismAttribute.cs
@@ -32,33 +32,29 @@ namespace Halibut.Tests.Support.TestAttributes
             return LevelOfParallelismFromEnvVar() ?? NUnitTestAssemblyRunner.DefaultLevelOfParallelism * 2;
         }
 
+        /// <summary>
+        /// 1 CPU = 2 Parallel Tests
+        /// 2 CPU = 2 Parallel Tests
+        /// 3 CPU = 2 Parallel Tests
+        /// 4 CPU = 2 Parallel Tests
+        /// 5 CPU = 3 Parallel Tests
+        /// 6 CPU = 4 Parallel Tests
+        /// 7 CPU = 5 Parallel Tests
+        /// 8 CPU = 6 Parallel Tests
+        /// 9 CPU = 7 Parallel Tests
+        /// 10 CPU = 8 Parallel Tests
+        /// 11 CPU = 8 Parallel Tests
+        /// 12 CPU = 8 Parallel Tests
+        /// 13 CPU = 8 Parallel Tests
+        /// 14 CPU = 8 Parallel Tests
+        /// </summary>
         static int LevelOfParallelismInTeamCity()
         {
-            if (NUnitTestAssemblyRunner.DefaultLevelOfParallelism <= 8)
-            {
-                // Its unlikely a host with 8 cores is running multiple tests so assume we have access to them all.
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && NUnitTestAssemblyRunner.DefaultLevelOfParallelism > 6)
-                {
-                    return NUnitTestAssemblyRunner.DefaultLevelOfParallelism - 2;
-                }
-
-                return NUnitTestAssemblyRunner.DefaultLevelOfParallelism;
-            }
-
-            // Larger hosts are likely to be kubernetes hosts. In this case the host is shared between multiple tests runs
-            // which means we can quickly overload the host OS resulting in test flakyness or failures. This is made worse
-            // since we are told the CPU limit of the pod which is current set to the number of CPUs on host, meaning
-            // on a 32 core host machine we will run 32 tests in parallel!
-            // Lets reduce the level of parallel tests in that case.
-            // This is probably not needed on linux, where we don't see test failures.
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return 6;
-            }
-
-            return NUnitTestAssemblyRunner.DefaultLevelOfParallelism / 2;
+            var max = 8;
+            var min = 2;
+            var defaultBasedOnCpu = NUnitTestAssemblyRunner.DefaultLevelOfParallelism;
+            
+            return Math.Min(Math.Max(min, defaultBasedOnCpu - 2), max);
         }
 
         static int? LevelOfParallelismFromEnvVar()

--- a/source/Halibut.Tests/Util/StandardIterationCount.cs
+++ b/source/Halibut.Tests/Util/StandardIterationCount.cs
@@ -11,7 +11,7 @@ namespace Halibut.Tests.Util
             if (clientAndServiceTestVersion.IsPreviousClient())
             {
                 // Old client requires that we call a halibut which calls a halibut, so keep the iterations low for this one.
-                return 25;
+                return 10;
             }
             
             switch (connectionType)


### PR DESCRIPTION
# Background

- Reduced the number of parallel tests in progress
- Reduced how much the min thread pool is increased, as very high increases can cause performance issues 
- Reduced iteration count for previous client due to the test infrastructure this has to set up

## After 

This is likely to increase test run time. There is a tradeoff between stability and speed

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
