### PR TITLE
Fix Stream CopyAndReportProgress synchronously waiting for a Task to complete

### DIFF
--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -231,9 +231,9 @@ namespace Halibut
                 while (count > 0)
                 {
                     Swap(ref readBuffer, ref writeBuffer);
-                    var asyncResult = destination.BeginWrite(writeBuffer, 0, count, null, null);
+                    var writeTask = destination.WriteAsync(writeBuffer, 0, count, cancellationToken);
                     count = await source.ReadAsync(readBuffer, 0, BufferSize, cancellationToken);
-                    destination.EndWrite(asyncResult);
+                    await writeTask;
 
                     copiedSoFar += count;
 


### PR DESCRIPTION
# Background

`CopyAndReportProgressAsync` was calling sync methods. This has the potential to block a thread (as discovered in [this PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/20302)) from the same code in Octopus Server.

# Results

Related to OctopusDeploy/Issues#8266

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
