### PR TITLE
Fix TcpClientManager Collection was modified during Disposal

### DIFF
--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -89,7 +89,9 @@ namespace Halibut.Transport
             {
                 if (client.Value?.Any() == true)
                 {
-                    foreach (var tcpClient in client.Value)
+                    var tcpClients = client.Value.ToArray();
+
+                    foreach (var tcpClient in tcpClients)
                     {
                         tcpClient?.CloseImmediately();
                         tcpClient?.Dispose();

--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -7,11 +7,12 @@ namespace Halibut.Transport
 {
     class TcpClientManager : IDisposable
     {
-        readonly Dictionary<string, HashSet<TcpClient>> activeClients = new();
+        Dictionary<string, HashSet<TcpClient>> activeClients = new();
+        readonly object syncLock = new();
 
         public void AddActiveClient(string thumbprint, TcpClient client)
         {
-            lock (activeClients)
+            lock (syncLock)
             {
                 if (activeClients.TryGetValue(thumbprint, out var tcpClients))
                 {
@@ -29,7 +30,7 @@ namespace Halibut.Transport
         // TODO - ASYNC ME UP - Should be obsolete but in use and needs an async chain
         public void Disconnect(string thumbprint)
         {
-            lock (activeClients)
+            lock (syncLock)
             {
                 if (activeClients.TryGetValue(thumbprint, out var tcpClients))
                 {
@@ -38,6 +39,7 @@ namespace Halibut.Transport
                         client.CloseImmediately();
                     }
                 }
+
                 activeClients.Remove(thumbprint);
             }
         }
@@ -45,7 +47,7 @@ namespace Halibut.Transport
         static readonly TcpClient[] NoClients = Array.Empty<TcpClient>();
         public IReadOnlyCollection<TcpClient> GetActiveClients(string thumbprint)
         {
-            lock (activeClients)
+            lock (syncLock)
             {
                 if (activeClients.TryGetValue(thumbprint, out var value))
                 {
@@ -58,40 +60,48 @@ namespace Halibut.Transport
 
         public void RemoveClient(TcpClient client)
         {
-            lock (activeClients)
+            lock (syncLock)
             {
                 foreach(var thumbprintClientsPair in activeClients)
                 {
                     if (thumbprintClientsPair.Value.Contains(client))
+                    {
                         thumbprintClientsPair.Value.Remove(client);
+                    }
                 }
 
                 var thumbprintsWithNoClients = activeClients
                     .Where(x => x.Value.Count == 0)
                     .Select(x => x.Key)
                     .ToArray();
+
                 foreach (var thumbprint in thumbprintsWithNoClients)
+                {
                     activeClients.Remove(thumbprint);
+                }
             }
         }
 
         public void Dispose()
         {
-            var clients = activeClients?.ToArray();
-            activeClients?.Clear();
+            lock (syncLock)
+            {
+                var clients = activeClients?.ToArray();
+                activeClients = null;
 
-            if (clients == null || !clients.Any())
-            {
-                return;
-            }
-            
-            foreach (var client in clients)
-            {
-                if (client.Value?.Any() == true)
+                if (clients == null || !clients.Any())
                 {
-                    var tcpClients = client.Value.ToArray();
+                    return;
+                }
 
-                    foreach (var tcpClient in tcpClients)
+                foreach (var client in clients)
+                {
+                    if (client.Value?.Any() != true)
+                    {
+                        continue;
+                    }
+
+                    foreach (var tcpClient in client.Value)
                     {
                         tcpClient?.CloseImmediately();
                         tcpClient?.Dispose();


### PR DESCRIPTION
# Background

Fix

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.HashSet`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
   at Halibut.Transport.TcpClientManager.Dispose()
   at Halibut.Transport.SecureListener.Dispose()
   at Halibut.HalibutRuntime.Dispose()
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
