### PR TITLE
Add xUnit

### DIFF
--- a/source/Halibut.Tests/Diagnostics/CachingLogFactoryFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/CachingLogFactoryFixture.cs
@@ -4,13 +4,13 @@ using FluentAssertions;
 using Halibut.Diagnostics;
 using Halibut.Diagnostics.LogCreators;
 using Halibut.Tests.Support.Logging;
-using NUnit.Framework;
+using Xunit;
 
 namespace Halibut.Tests.Diagnostics
 {
     public class CachingLogFactoryFixture
     {
-        [Test]
+        [Fact]
         public void TheSameILogIsReturnedForTheSamePrefix()
         {
             var cachingLogFactory = new InMemoryConnectionLogCreator().ToCachingLogFactory();
@@ -20,7 +20,7 @@ namespace Halibut.Tests.Diagnostics
             ReferenceEquals(first, second).Should().BeTrue();
         }
 
-        [Test]
+        [Fact]
         public void TheSameILogIsReturnedForTheSameEndPoint()
         {
             var cachingLogFactory = new InMemoryConnectionLogCreator().ToCachingLogFactory();
@@ -30,7 +30,7 @@ namespace Halibut.Tests.Diagnostics
             ReferenceEquals(first, second).Should().BeTrue();
         }
 
-        [Test]
+        [Fact]
         public void TheSameILogIsReturnedForTheSameEndPointAndPrefix()
         {
             var cachingLogFactory = new InMemoryConnectionLogCreator().ToCachingLogFactory();
@@ -40,7 +40,7 @@ namespace Halibut.Tests.Diagnostics
             ReferenceEquals(first, second).Should().BeTrue();
         }
 
-        [Test]
+        [Fact]
         public void ADifferentILogIsReturnedForTheDifferentPrefixes()
         {
             var cachingLogFactory = new InMemoryConnectionLogCreator().ToCachingLogFactory();
@@ -50,7 +50,7 @@ namespace Halibut.Tests.Diagnostics
             ReferenceEquals(first, second).Should().BeFalse();
         }
 
-        [Test]
+        [Fact]
         public void ADifferentILogIsReturnedForTheDifferentEndPoints()
         {
             var cachingLogFactory = new InMemoryConnectionLogCreator().ToCachingLogFactory();
@@ -60,7 +60,7 @@ namespace Halibut.Tests.Diagnostics
             ReferenceEquals(first, second).Should().BeFalse();
         }
 
-        [Test]
+        [Fact]
         public void CachingAInMemoryConnectionLogMeansTheLogsAreRetained()
         {
             var cachingLogFactory = new InMemoryConnectionLogCreator().ToCachingLogFactory();
@@ -83,7 +83,7 @@ namespace Halibut.Tests.Diagnostics
         /// <summary>
         ///     Something similar to what we actually want to do, so lets test it here.
         /// </summary>
-        [Test]
+        [Fact]
         public void CachingWithAggregateLogWriterLogCreatorAndInMemoryConnectionLogCreatorWorksAsExpected()
         {
             var logWriter = new InMemoryLogWriter();

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="xunit" Version="2.5.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -47,6 +47,10 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">


### PR DESCRIPTION
# Background

This PR adds xUnit to Halibut, for the following reasons:
* We believe consistency between Octopus Server (which uses xUnit) and other projects is beneficial for developer productivity.
* In order to complete [sc-56164], we must add new mechanisms for accessing the test logs and current test status, and we don't want to implement this feature twice - once now, and once when we eventually migrate to xUnit.

As well as adding the new dependencies, this PR migrates some very simple nUnit tests (`CachingLogFactoryFixture`) to xUnit as a proof of concept.

# Results

There should be no noticeable differences between test runs before and after this migration. The same tests should be run for each build, and test history in TeamCity should continue uninterrupted when a test is converted to xUnit. 

The below screenshot shows the test history for a converted test, showing that the test history is unaffected.

![20231002-145738_firefox_rMfy7juGVG](https://github.com/OctopusDeploy/Halibut/assets/277700/b956173b-63bd-4edc-bf10-e6187ef99b55)

## Before

![20231002-145819_firefox_BdpEA6zDcs](https://github.com/OctopusDeploy/Halibut/assets/277700/fb9692f7-34f1-4055-95c3-a4b32fcc81e4)

## After

![20231002-145941_firefox_ycybKiHyXT](https://github.com/OctopusDeploy/Halibut/assets/277700/3022de64-4e44-4dc6-aca8-2e2200e94a1d)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
