### PR TITLE
Keep trace logs for failed tests

### DIFF
--- a/source/Halibut.Tests/BaseTest.cs
+++ b/source/Halibut.Tests/BaseTest.cs
@@ -1,33 +1,60 @@
+using System;
 using System.Threading;
 using Halibut.Tests.Support;
 using NUnit.Framework;
-using Serilog;
+using NUnit.Framework.Interfaces;
+using ILogger = Serilog.ILogger;
 
 namespace Halibut.Tests
 {
     public class BaseTest
     {
         CancellationTokenSource? cancellationTokenSource;
+        TraceLogFileLogger? traceLogFileLogger;
+
         public CancellationToken CancellationToken { get; private set; }
         public ILogger Logger { get; private set; } = null!;
+
 
         [SetUp]
         public void SetUp()
         {
-            Logger = new SerilogLoggerBuilder().Build().ForContext(GetType());
+            traceLogFileLogger = new TraceLogFileLogger();
+            Logger = new SerilogLoggerBuilder()
+                .SetTraceLogFileLogger(traceLogFileLogger)
+                .Build()
+                .ForContext(GetType());
+
             Logger.Information("Test started");
             cancellationTokenSource = new CancellationTokenSource();
             CancellationToken = cancellationTokenSource.Token;
         }
-        
+
         [TearDown]
         public void TearDown()
         {
             Logger.Information("Staring Test Tearing Down");
+
             Logger.Information("Cancelling CancellationTokenSource");
             cancellationTokenSource?.Cancel();
             Logger.Information("Disposing CancellationTokenSource");
             cancellationTokenSource?.Dispose();
+
+            if (TestContext.CurrentContext.Result.Outcome != ResultState.Success)
+            {
+                if (traceLogFileLogger?.CopyLogFileToArtifacts() ?? false)
+                {
+                    Logger.Information("Copied trace logs to artifacts");
+                }
+                else
+                {
+                    Logger.Information("Could not copy trace logs to artifacts");
+                }
+            }
+
+            Logger.Information("Disposing Trace Log File Logger");
+            traceLogFileLogger?.Dispose();
+
             Logger.Information("Finished Test Tearing Down");
         }
     }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -23,7 +23,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         Version? version = null;
         Func<int, PortForwarder>? portForwarderFactory;
         ProxyFactory proxyFactory;
-        LogLevel halibutLogLevel = LogLevel.Info;
+        LogLevel halibutLogLevel = LogLevel.Trace;
         OldServiceAvailableServices availableServices = new(false, false);
         bool hasService = true;
         ForceClientProxyType? forceClientProxyType;

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -42,7 +42,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         IComplexObjectService complexObjectService = new ComplexObjectService();
         IReadDataStreamService readDataStreamService = new ReadDataStreamService();
         Func<int, PortForwarder>? portForwarderFactory;
-        LogLevel halibutLogLevel = LogLevel.Info;
+        LogLevel halibutLogLevel = LogLevel.Trace;
         bool withTentacleServices = false;
         ILockService lockService;
         ICountingService countingService;

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -52,7 +52,7 @@ namespace Halibut.Tests.Support
         Reference<PortForwarder>? portForwarderReference;
         Func<RetryPolicy>? pollingReconnectRetryPolicy;
         ProxyFactory? proxyFactory;
-        LogLevel halibutLogLevel = LogLevel.Info;
+        LogLevel halibutLogLevel = LogLevel.Trace;
         ConcurrentDictionary<string, ILog>? clientInMemoryLoggers;
         ConcurrentDictionary<string, ILog>? serviceInMemoryLoggers;
         ITrustProvider clientTrustProvider;

--- a/source/Halibut.Tests/Support/Logging/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests/Support/Logging/TestContextConnectionLog.cs
@@ -4,7 +4,9 @@ using System.Threading;
 using Halibut.Diagnostics;
 using Halibut.Diagnostics.LogWriters;
 using Halibut.Logging;
+using Serilog.Events;
 using ILog = Halibut.Diagnostics.ILog;
+using LogEvent = Halibut.Diagnostics.LogEvent;
 
 namespace Halibut.Tests.Support.Logging
 {
@@ -44,7 +46,7 @@ namespace Halibut.Tests.Support.Logging
             {
                 new SerilogLoggerBuilder().Build()
                     .ForContext<TestContextConnectionLog>()
-                    .Information(string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEventLogLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name));
+                    .Write(GetSerilogLevel(logEvent), string.Format("{5, 16}: {0}:{1} {2}  {3} {4}", logEventLogLevel, logEvent.Error, endpoint, Thread.CurrentThread.ManagedThreadId, logEvent.FormattedMessage, name));
             }
         }
 
@@ -62,6 +64,23 @@ namespace Halibut.Tests.Support.Logging
                     return LogLevel.Debug;
                 default:
                     return LogLevel.Info;
+            }
+        }
+
+        static LogEventLevel GetSerilogLevel(LogEvent logEvent)
+        {
+            switch (logEvent.Type)
+            {
+                case EventType.Error:
+                    return LogEventLevel.Error;
+                case EventType.Diagnostic:
+                case EventType.SecurityNegotiation:
+                case EventType.MessageExchange:
+                    return LogEventLevel.Verbose;
+                case EventType.OpeningNewConnection:
+                    return LogEventLevel.Debug;
+                default:
+                    return LogEventLevel.Information;
             }
         }
     }

--- a/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
+++ b/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using NUnit.Framework;
 using Serilog;
@@ -14,45 +13,58 @@ namespace Halibut.Tests.Support
     public class SerilogLoggerBuilder
     {
         static readonly ILogger Logger;
+        static readonly ConcurrentDictionary<string, TraceLogFileLogger> TraceLoggers = new();
+
+        TraceLogFileLogger? traceFileLogger;
 
         static SerilogLoggerBuilder()
         {
-            var outputTemplate = 
-                "{TestName} "
+            const string teamCityOutputTemplate =
+                "{TestHash} "
                 + "{Timestamp:HH:mm:ss.fff zzz} "
                 + "{ShortContext} "
                 + "{Message}{NewLine}{Exception}";
 
+            const string localOutputTemplate =
+                "{Timestamp:HH:mm:ss.fff zzz} "
+                + "{ShortContext} "
+                + "{Message}{NewLine}{Exception}";
+
+            var nUnitOutputTemplate = TeamCityDetection.IsRunningInTeamCity()
+                ? teamCityOutputTemplate
+                : localOutputTemplate;
+
             Logger = new LoggerConfiguration()
-                .MinimumLevel.Debug()
-                .WriteTo.Sink(new NonProgressNUnitSink(new MessageTemplateTextFormatter(outputTemplate)))
+                .MinimumLevel.Verbose()
+                .WriteTo.Sink(new NonProgressNUnitSink(new MessageTemplateTextFormatter(nUnitOutputTemplate)), LogEventLevel.Debug)
+                .WriteTo.Sink(new TraceLogsForFailedTestsSink(new MessageTemplateTextFormatter(localOutputTemplate)))
                 .CreateLogger();
+        }
+
+        public SerilogLoggerBuilder SetTraceLogFileLogger(TraceLogFileLogger logger)
+        {
+            this.traceFileLogger = logger;
+            return this;
         }
 
         public ILogger Build()
         {
             // In teamcity we need to know what test the log is for, since we can find hung builds and only have a single file containing all log messages.
-            var testName = "";
-            if (TeamCityDetection.IsRunningInTeamCity())
-            {
-                testName = CurrentTestHash();
-            }
+            var testName = TestContext.CurrentContext.Test.Name;
+            var testHash = CurrentTestHash();
+            var logger = Logger.ForContext("TestHash", testHash);
 
-            var logger = Logger.ForContext("TestName", testName);
-            
-            if (TeamCityDetection.IsRunningInTeamCity())
+            if (traceFileLogger != null)
             {
-                if (!HasLoggedTestHash.Contains(TestContext.CurrentContext.Test.Name))
-                {
-                    HasLoggedTestHash.Add(TestContext.CurrentContext.Test.Name);
-                    logger.Information($"Test: {TestContext.CurrentContext.Test.Name} has hash {CurrentTestHash()}");
-                }
+                TraceLoggers.AddOrUpdate(testName, traceFileLogger, (_, _) => throw new Exception("This should never be updated. If it is, it means that a test is being run multiple times in a single test run"));
+                logger.Information($"Test: {TestContext.CurrentContext.Test.Name} has hash {testHash}");
+                traceFileLogger.SetTestHash(testHash);
             }
 
             return logger;
         }
 
-        public static string CurrentTestHash()
+        static string CurrentTestHash()
         {
             using (SHA256 mySHA256 = SHA256.Create())
             {
@@ -63,8 +75,6 @@ namespace Halibut.Tests.Support
                     .Substring(0, 10); // 64 ^ 10 is a big number, most likely we wont have collisions.
             }
         }
-
-        public static ConcurrentBag<string> HasLoggedTestHash = new();
 
         public class NonProgressNUnitSink : ILogEventSink
         {
@@ -85,11 +95,10 @@ namespace Halibut.Tests.Support
                 {
                     var context = sourceContext.ToString().Substring(sourceContext.ToString().LastIndexOf('.') + 1).Replace("\"", "");
                     //output.Write("[" + context + "] ");
-                    
+
                     logEvent.AddOrUpdateProperty(new LogEventProperty("ShortContext", new ScalarValue(context)));
                 }
-                
-                
+
                 _formatter.Format(logEvent, output);
                 // This is the change, call this instead of: TestContext.Progress
 
@@ -103,6 +112,36 @@ namespace Halibut.Tests.Support
                 {
                     TestContext.Progress.Write(logLine);
                 }
+            }
+        }
+
+        public class TraceLogsForFailedTestsSink : ILogEventSink
+        {
+            private readonly MessageTemplateTextFormatter _formatter;
+
+            public TraceLogsForFailedTestsSink(MessageTemplateTextFormatter formatter) => _formatter = formatter != null ? formatter : throw new ArgumentNullException(nameof(formatter));
+
+            public void Emit(LogEvent logEvent)
+            {
+                if (logEvent == null)
+                    throw new ArgumentNullException(nameof(logEvent));
+
+                var testName = TestContext.CurrentContext.Test.Name;
+
+                if (!TraceLoggers.TryGetValue(testName, out var traceLogger))
+                    throw new Exception($"Could not find trace logger for test '{testName}'");
+
+                var output = new StringWriter();
+                if (logEvent.Properties.TryGetValue("SourceContext", out var sourceContext))
+                {
+                    var context = sourceContext.ToString().Substring(sourceContext.ToString().LastIndexOf('.') + 1).Replace("\"", "");
+                    logEvent.AddOrUpdateProperty(new LogEventProperty("ShortContext", new ScalarValue(context)));
+                }
+
+                _formatter.Format(logEvent, output);
+
+                var logLine = output.ToString().Trim();
+                traceLogger.WriteLine(logLine);
             }
         }
     }

--- a/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
+++ b/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
@@ -79,9 +79,9 @@ namespace Halibut.Tests.Support
 
         public class NonProgressNUnitSink : ILogEventSink
         {
-            private readonly MessageTemplateTextFormatter _formatter;
+            readonly MessageTemplateTextFormatter formatter;
 
-            public NonProgressNUnitSink(MessageTemplateTextFormatter formatter) => _formatter = formatter != null ? formatter : throw new ArgumentNullException(nameof(formatter));
+            public NonProgressNUnitSink(MessageTemplateTextFormatter formatter) => this.formatter = formatter;
 
             static bool IsForcingContextWrite = !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("Force_Test_Context_Write"));
 
@@ -100,7 +100,7 @@ namespace Halibut.Tests.Support
                     logEvent.AddOrUpdateProperty(new LogEventProperty("ShortContext", new ScalarValue(context)));
                 }
 
-                _formatter.Format(logEvent, output);
+                formatter.Format(logEvent, output);
                 // This is the change, call this instead of: TestContext.Progress
 
                 var logLine = output.ToString();
@@ -118,9 +118,9 @@ namespace Halibut.Tests.Support
 
         public class TraceLogsForFailedTestsSink : ILogEventSink
         {
-            private readonly MessageTemplateTextFormatter _formatter;
+            readonly MessageTemplateTextFormatter formatter;
 
-            public TraceLogsForFailedTestsSink(MessageTemplateTextFormatter formatter) => _formatter = formatter != null ? formatter : throw new ArgumentNullException(nameof(formatter));
+            public TraceLogsForFailedTestsSink(MessageTemplateTextFormatter formatter) => this.formatter = formatter;
 
             public void Emit(LogEvent logEvent)
             {
@@ -139,7 +139,7 @@ namespace Halibut.Tests.Support
                     logEvent.AddOrUpdateProperty(new LogEventProperty("ShortContext", new ScalarValue(context)));
                 }
 
-                _formatter.Format(logEvent, output);
+                formatter.Format(logEvent, output);
 
                 var logLine = output.ToString().Trim();
                 traceLogger.WriteLine(logLine);

--- a/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
+++ b/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
 using NUnit.Framework;
@@ -50,7 +51,7 @@ namespace Halibut.Tests.Support
         public ILogger Build()
         {
             // In teamcity we need to know what test the log is for, since we can find hung builds and only have a single file containing all log messages.
-            var testName = TestContext.CurrentContext.Test.Name;
+            var testName = TestContext.CurrentContext.Test.FullName;
             var testHash = CurrentTestHash();
             var logger = Logger.ForContext("TestHash", testHash);
 
@@ -68,7 +69,7 @@ namespace Halibut.Tests.Support
         {
             using (SHA256 mySHA256 = SHA256.Create())
             {
-                return Convert.ToBase64String(mySHA256.ComputeHash(TestContext.CurrentContext.Test.Name.GetUTF8Bytes()))
+                return Convert.ToBase64String(mySHA256.ComputeHash(TestContext.CurrentContext.Test.FullName.GetUTF8Bytes()))
                     .Replace("=", "")
                     .Replace("+", "")
                     .Replace("/", "")
@@ -126,7 +127,7 @@ namespace Halibut.Tests.Support
                 if (logEvent == null)
                     throw new ArgumentNullException(nameof(logEvent));
 
-                var testName = TestContext.CurrentContext.Test.Name;
+                var testName = TestContext.CurrentContext.Test.FullName;
 
                 if (!TraceLoggers.TryGetValue(testName, out var traceLogger))
                     throw new Exception($"Could not find trace logger for test '{testName}'");

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.IO;
+
+namespace Halibut.Tests
+{
+    public class TraceLogFileLogger : IDisposable
+    {
+        string tempFilePath = Path.GetTempFileName();
+        string testHash;
+
+        public void SetTestHash(string testHash)
+        {
+            this.testHash = testHash;
+        }
+        
+        public void WriteLine(string logMessage)
+        {
+            File.AppendAllLines(tempFilePath, new[] { logMessage });
+        }
+
+        public bool CopyLogFileToArtifacts()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var rootDirectory = new DirectoryInfo(currentDirectory).Parent.Parent.Parent.Parent.Parent;
+            var traceLogsDirectory = rootDirectory.CreateSubdirectory("artifacts").CreateSubdirectory("trace-logs");
+            var fileName = $"{testHash}.tracelog";
+
+            try
+            {
+                File.Copy(tempFilePath, Path.Combine(traceLogsDirectory.ToString(), fileName), true);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(tempFilePath);
+            }
+            catch
+            {
+                // Best effort clean-up, but we don't want to
+                // fail the test because we couldn't delete this file
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -20,8 +20,16 @@ namespace Halibut.Tests
 
         public bool CopyLogFileToArtifacts()
         {
+            // The current directory is expected to have the following structure
+            // (w/ variance depending on Debug/Release and dotnet framework used (net6.0, net48 etc):
+            //
+            // <REPO ROOT>\source\Halibut.Tests\bin\Debug\net6.0
+            //
+            // Therefore we go up 5 levels to get to the <REPO ROOT> directory,
+            // from which point we can navigate to the artifacts directory.
             var currentDirectory = Directory.GetCurrentDirectory();
             var rootDirectory = new DirectoryInfo(currentDirectory).Parent.Parent.Parent.Parent.Parent;
+            
             var traceLogsDirectory = rootDirectory.CreateSubdirectory("artifacts").CreateSubdirectory("trace-logs");
             var fileName = $"{testHash}.tracelog";
 


### PR DESCRIPTION
# Background

Trace logs can provide us with invaluable information about Halibut when debugging problems, but unfortunately they are too verbose to be practical on the build server, as the extra logging causes the build logs to be prohibitively large.

This PR attempts to have the best of both worlds (info-level logs when everything is fine, trace-level logs when there are problems) by logging a test's trace logs to a separate log file which can be kept if the test fails.

# Results

Fixes [sc-56164]

During the setup for each individual test (`BaseTest.SetUp`), a `TraceLogFileLogger` is created and passed to the `SerilogLoggerBuilder` when initializing the logger. This new class is responsible for writing logs to a temporary file, and copying that file to the build artifacts directory if needed.

Once the `SerilogLoggerBuilder.Build` method is called, the instance of `TraceLogFileLogger` is stored in memory for the currently running test and is utilised by a custom Serilog sink which will find and write to the appropriate trace logger for the current test each time a log message is sent.

After the test is completed, the teardown method (`BaseTest.TearDown`) will check the status of the test and have the `TraceLogFileLogger` copy the trace log file to the build artifacts if the test failed.

Trace log files are named _{TestHash}_.tracelog, where _TestHash_ is a short Base64 hash based on the test name. This TestHash is also printed in the log output, allowing a developer to easily find the corresponding trace log file for any failed test.

## Before
No trace logs for failed tests 😞 

## After
![20231013-111756_firefox_pNkiCzwGe3](https://github.com/OctopusDeploy/Halibut/assets/277700/9cba5dc7-53f6-45a1-aa97-efe0601a5d98)

![20231013-111549_firefox_Fje2qcr1nq](https://github.com/OctopusDeploy/Halibut/assets/277700/a52a3c10-eaf8-458f-8117-83248a5d9d88)

![20231013-140855_jq5jSdEWB4](https://github.com/OctopusDeploy/Halibut/assets/277700/1e20da23-d695-45fa-b9db-8829223bcb48)

# How to review this PR

Are there are any other tests or test base class which need to modified to log trace-level logs? I've modified the default for the `IClientAndServiceBuilder` implementations, but are there any tests that _don't_ use these builders that need updating?

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
