### PR TITLE
Add support for generic services

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -146,9 +146,10 @@ class Build : NukeBuild
                 .SetVerbosity(DotNetVerbosity.Normal));
         });
 
+    [PublicAPI]
     Target CopyToLocalPackages => _ => _
         .OnlyWhenStatic(() => IsLocalBuild)
-        .TriggeredBy(Pack)
+        .DependsOn(Pack)
         .Executes(() =>
         {
             EnsureExistingDirectory(LocalPackagesDirectory);

--- a/source/Halibut.TestUtils.Contracts/IGenericService`.cs
+++ b/source/Halibut.TestUtils.Contracts/IGenericService`.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.TestUtils.Contracts
+{
+    public interface IGenericService<in T>
+    {
+        string GetInfo(T value);
+    }
+
+    public interface IAsyncGenericService<in T>
+    {
+        Task<string> GetInfoAsync(T value, CancellationToken cancellationToken);
+    }
+}

--- a/source/Halibut.Tests/GenericServiceFixture.cs
+++ b/source/Halibut.Tests/GenericServiceFixture.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Logging;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices.Async;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class GenericServiceFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
+        public async Task GenericServiceNamesAreCorrectlyCalled(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .WithGenericService<string>()
+                .WithGenericService<double>()
+                .WithHalibutLoggingLevel(LogLevel.Info)
+                .Build(CancellationToken);
+
+            var stringClient = clientAndService.CreateClient<IGenericService<string>, IAsyncClientGenericService<string>>();
+            (await stringClient.GetInfoAsync("Cool string")).Should().Be("String => Cool string");
+
+            var doubleClient = clientAndService.CreateClient<IGenericService<double>, IAsyncClientGenericService<double>>();
+            (await doubleClient.GetInfoAsync(6.54321)).Should().Be("Double => 6.54321");
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -109,10 +109,18 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithCachingService() => WithCachingService();
-        
+
+
         public IClientAndServiceBuilder WithCachingService()
         {
             availableServices.HasCachingService = true;
+            return this;
+        }
+
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithGenericService<T>() => WithGenericService<T>();
+        public IClientAndServiceBuilder WithGenericService<T>()
+        {
+            availableServices.HasGenericService = true;
             return this;
         }
 
@@ -156,7 +164,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return NoService();
         }
-        
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithForcingClientProxyType(ForceClientProxyType forceClientProxyType)
         {
             return WithForcingClientProxyType(forceClientProxyType);
@@ -177,7 +185,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return await Build(cancellationToken);
         }
-        
+
         public async Task<ClientAndService> Build(CancellationToken cancellationToken)
         {
             var logger = new SerilogLoggerBuilder().Build().ForContext<LatestClientAndPreviousServiceVersionBuilder>();
@@ -368,12 +376,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TClientService>(forceClientProxyType, Client, serviceEndpoint);
             }
-            
+
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>()
             {
                 return CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(_ => { });
             }
-            
+
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 var serviceEndpoint = ServiceEndPoint;
@@ -389,7 +397,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             public async ValueTask DisposeAsync()
             {
                 var logger = new SerilogLoggerBuilder().Build().ForContext<ClientAndService>();
-                
+
                 logger.Information("****** ****** ****** ****** ****** ****** ******");
                 logger.Information("****** CLIENT AND SERVICE DISPOSE CALLED  ******");
                 logger.Information("*     Subsequent errors should be ignored      *");

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/OldServiceAvailableServices.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/OldServiceAvailableServices.cs
@@ -11,5 +11,6 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         public bool HasStandardServices { get; set; }
         public bool HasCachingService { get; set; }
         public bool HasTentacleServices { get; set; }
+        public bool HasGenericService { get; set; }
     }
 }

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -117,6 +117,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             throw new Exception("Caching service is not supported, when testing on the old Client. Since the old client is on external CLR which does not have the new caching attributes which this service is used to test.");
         }
 
+        public IClientAndServiceBuilder WithGenericService<T>()
+        {
+            throw new NotSupportedException("Generic services are not supported when testing the old client");
+        }
+
         public PreviousClientVersionAndLatestServiceBuilder WithMultipleParametersTestService(IMultipleParametersTestService multipleParametersTestService)
         {
             this.multipleParametersTestService = multipleParametersTestService;
@@ -128,13 +133,13 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             this.complexObjectService = complexObjectService;
             return this;
         }
-        
+
         public PreviousClientVersionAndLatestServiceBuilder WithLockService(ILockService lockService)
         {
             this.lockService = lockService;
             return this;
         }
-        
+
         public PreviousClientVersionAndLatestServiceBuilder WithCountingService(ICountingService countingService)
         {
             this.countingService = countingService;
@@ -185,7 +190,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
 
             return this;
         }
-        
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithHalibutLoggingLevel(LogLevel halibutLogLevel)
         {
             return WithHalibutLoggingLevel(halibutLogLevel);
@@ -202,7 +207,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return await Build(cancellationToken);
         }
-        
+
         public PreviousClientVersionAndLatestServiceBuilder NoService()
         {
             throw new NotImplementedException();
@@ -212,7 +217,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             return NoService();
         }
-        
+
         IClientAndServiceBuilder IClientAndServiceBuilder.WithForcingClientProxyType(ForceClientProxyType forceClientProxyType)
         {
             throw new Exception("Not supported");
@@ -240,7 +245,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 .WithLogFactory(new TestContextLogCreator("ProxyClient", halibutLogLevel).ToCachingLogFactory())
                 .WithAsyncHalibutFeatureEnabled()
                 .Build();
-            
+
             proxyClient.Trust(serviceCertAndThumbprint.Thumbprint);
 
             var serviceFactory = new DelegateServiceFactory()
@@ -464,9 +469,9 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 {
                     throw new Exception($"Unsupported, since types within {typeof(TClientService)} would not actually be passed on to the remote process which holds the actual client under test.", e);
                 }
-                
+
                 var serviceEndpoint = new ServiceEndPoint(serviceUri, serviceCertAndThumbprint.Thumbprint, Client.TimeoutsAndLimits);
-                
+
                 return ProxyClient.CreateAsyncClient<TService, TClientService>(serviceEndpoint);
             }
 
@@ -479,12 +484,12 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             {
                 return CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(_ => { });
             }
-            
+
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 throw new NotSupportedException("Not supported since the options can not be passed to the external binary.");
             }
-            
+
             public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
             {
                 return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -15,6 +15,7 @@ namespace Halibut.Tests.Support
         IClientAndServiceBuilder WithTentacleServices();
         IClientAndServiceBuilder WithHalibutLoggingLevel(LogLevel info);
         IClientAndServiceBuilder WithCachingService();
+        IClientAndServiceBuilder WithGenericService<T>();
         IClientAndServiceBuilder NoService();
         IClientAndServiceBuilder WithForcingClientProxyType(ForceClientProxyType forceClientProxyType);
         IClientAndServiceBuilder WithServiceAsyncHalibutFeatureEnabled();

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -35,7 +35,7 @@ namespace Halibut.Tests.Support
         ServiceFactoryBuilder serviceFactoryBuilder = new();
         IServiceFactory? serviceFactory;
         readonly CertAndThumbprint serviceCertAndThumbprint;
-        string clientTrustsThumbprint; 
+        string clientTrustsThumbprint;
         readonly CertAndThumbprint clientCertAndThumbprint;
         string serviceTrustsThumbprint;
         ForceClientProxyType? forceClientProxyType;
@@ -105,7 +105,7 @@ namespace Halibut.Tests.Support
                     throw new ArgumentOutOfRangeException(nameof(serviceConnectionType), serviceConnectionType, null);
             }
         }
-        
+
         /// <summary>
         ///     Ie no tentacle.
         ///     In the case of listening, a TCPListenerWhichKillsNewConnections will be created. This will cause connections to
@@ -122,7 +122,7 @@ namespace Halibut.Tests.Support
         {
             return NoService();
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithPollingClients(IEnumerable<Uri> pollingClientUris)
         {
             createClient = false;
@@ -137,13 +137,13 @@ namespace Halibut.Tests.Support
             this.clientStreamFactory = streamFactory;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithClientStreamFactory(IStreamFactory clientStreamFactory)
         {
             this.clientStreamFactory = clientStreamFactory;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithServiceStreamFactory(IStreamFactory serviceStreamFactory)
         {
             this.serviceStreamFactory = serviceStreamFactory;
@@ -155,13 +155,13 @@ namespace Halibut.Tests.Support
             this.serviceConnectionsObserver = connectionsObserver;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithClientConnectionsObserver(IConnectionsObserver connectionsObserver)
         {
             this.clientConnectionsObserver = connectionsObserver;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithHalibutTimeoutsAndLimits(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
@@ -183,7 +183,7 @@ namespace Halibut.Tests.Support
         public LatestClientAndLatestServiceBuilder WithService<TContract>(Func<TContract> implementation)
         {
             serviceFactoryBuilder.WithService(implementation);
-            
+
             if (serviceFactory != null)
             {
                 if (serviceFactory is DelegateServiceFactory delegateServiceFactory)
@@ -202,7 +202,7 @@ namespace Halibut.Tests.Support
         public LatestClientAndLatestServiceBuilder WithAsyncService<TContract, TClientContract>(Func<TClientContract> implementation)
         {
             serviceFactoryBuilder.WithService<TContract, TClientContract>(implementation);
-            
+
             if (serviceFactory != null)
             {
                 if (serviceFactory is DelegateServiceFactory delegateServiceFactory)
@@ -281,12 +281,18 @@ namespace Halibut.Tests.Support
         }
 
         IClientAndServiceBuilder IClientAndServiceBuilder.WithCachingService() => WithCachingService();
-        
+
         public LatestClientAndLatestServiceBuilder WithCachingService()
         {
             return this.WithService<ICachingService>(() => new CachingService());
         }
 
+        IClientAndServiceBuilder IClientAndServiceBuilder.WithGenericService<T>() => WithGenericService<T>();
+
+        public LatestClientAndLatestServiceBuilder WithGenericService<T>()
+        {
+            return this.WithService<IGenericService<T>>(() => new GenericService<T>());
+        }
         IClientAndServiceBuilder IClientAndServiceBuilder.WithProxy()
         {
             return WithProxy();
@@ -326,23 +332,23 @@ namespace Halibut.Tests.Support
         {
             return WithHalibutLoggingLevel(halibutLogLevel);
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithHalibutLoggingLevel(LogLevel halibutLogLevel)
         {
             this.halibutLogLevel = halibutLogLevel;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder RecordingClientLogs(out ConcurrentDictionary<string, ILog> inMemoryLoggers)
         {
             inMemoryLoggers = new ConcurrentDictionary<string, ILog>();
             this.clientInMemoryLoggers = inMemoryLoggers;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder RecordingServiceLogs(out ConcurrentDictionary<string, ILog> inMemoryLoggers)
         {
-            inMemoryLoggers = new ConcurrentDictionary<string, ILog>(); 
+            inMemoryLoggers = new ConcurrentDictionary<string, ILog>();
             this.serviceInMemoryLoggers = inMemoryLoggers;
             return this;
         }
@@ -352,7 +358,7 @@ namespace Halibut.Tests.Support
             clientOnUnauthorizedClientConnect = onUnauthorizedClientConnect;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithClientTrustProvider(ITrustProvider trustProvider)
         {
             clientTrustProvider = trustProvider;
@@ -364,7 +370,7 @@ namespace Halibut.Tests.Support
             clientTrustsThumbprint = CertAndThumbprint.Wrong.Thumbprint;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithServiceTrustingTheWrongCertificate()
         {
             serviceTrustsThumbprint = CertAndThumbprint.Wrong.Thumbprint;
@@ -387,7 +393,7 @@ namespace Halibut.Tests.Support
             this.forceClientProxyType = forceClientProxyType;
             return this;
         }
-        
+
         public LatestClientAndLatestServiceBuilder WithClientRpcObserver(IRpcObserver? clientRpcObserver)
         {
             this.clientRpcObserver = clientRpcObserver;
@@ -403,7 +409,7 @@ namespace Halibut.Tests.Support
         {
             var logger = new SerilogLoggerBuilder().Build().ForContext<LatestClientAndLatestServiceBuilder>();
             CancellationTokenSource cancellationTokenSource = new();
-            
+
             serviceFactory ??= serviceFactoryBuilder.Build();
             var octopusLogFactory = BuildClientLogger();
 
@@ -431,7 +437,7 @@ namespace Halibut.Tests.Support
                 client = clientBuilder.Build();
                 client.Trust(clientTrustsThumbprint);
             }
-            
+
 
             HalibutRuntime? service = null;
             if (createService)
@@ -462,7 +468,7 @@ namespace Halibut.Tests.Support
 
             Uri serviceUri;
             Uri? clientUri = null;
-            
+
             if (ServiceConnectionType == ServiceConnectionType.Polling)
             {
                 serviceUri = new Uri("poll://SQ-TENTAPOLL");
@@ -473,11 +479,11 @@ namespace Halibut.Tests.Support
                     var clientListenPort = client!.Listen();
 
                     portForwarder = portForwarderFactory?.Invoke(clientListenPort);
-                    
+
                     clientUri = new Uri($"https://localhost:{portForwarder?.ListeningPort ?? clientListenPort}");
                     clientUrisToPoll.Add(clientUri);
                 }
-                
+
                 if (service != null)
                 {
                     foreach (var clientUriToPoll in clientUrisToPoll)
@@ -492,7 +498,7 @@ namespace Halibut.Tests.Support
             else if (ServiceConnectionType == ServiceConnectionType.PollingOverWebSocket)
             {
                 serviceUri = new Uri("poll://SQ-TENTAPOLL");
-                
+
                 var clientUrsToPoll = pollingClientUris.ToList();
                 if (createClient)
                 {
@@ -595,7 +601,7 @@ namespace Halibut.Tests.Support
             )
                 .ToCachingLogFactory();
         }
-        
+
         ILogFactory BuildServiceLogger()
         {
             if (serviceInMemoryLoggers == null)
@@ -692,7 +698,7 @@ namespace Halibut.Tests.Support
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TClientService>(forceClientProxyType, Client, serviceEndpoint);
             }
-            
+
             public TAsyncClientWithOptions CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>()
             {
                 return CreateClientWithOptions<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(_ => { });
@@ -704,7 +710,7 @@ namespace Halibut.Tests.Support
                 modifyServiceEndpoint(serviceEndpoint);
                 return new AdaptToSyncOrAsyncTestCase().Adapt<TService, TSyncClientWithOptions, TAsyncClientWithOptions>(forceClientProxyType, Client, serviceEndpoint);
             }
-            
+
             public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
             {
                 return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientGenericService`.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientGenericService`.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Halibut.Tests.TestServices.Async
+{
+    public interface IAsyncClientGenericService<in T>
+    {
+        Task<string> GetInfoAsync(T value);
+    }
+}

--- a/source/Halibut.Tests/TestServices/GenericService`.cs
+++ b/source/Halibut.Tests/TestServices/GenericService`.cs
@@ -1,0 +1,30 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Halibut.TestUtils.Contracts;
+
+namespace Halibut.Tests.TestServices
+{
+    public class GenericService<T> : IGenericService<T>
+    {
+        public string GetInfo(T value)
+        {
+            return $"{typeof(T).Name} => {value}";
+        }
+    }
+
+    public class AsyncGenericService<T> : IAsyncGenericService<T>
+    {
+        readonly GenericService<T> genericService;
+
+        public AsyncGenericService(GenericService<T> genericService)
+        {
+            this.genericService = genericService;
+        }
+
+        public async Task<string> GetInfoAsync(T value, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return genericService.GetInfo(value);
+        }
+    }
+}

--- a/source/Halibut.Tests/Util/NoSanityCheckingDelegateServiceFactory.cs
+++ b/source/Halibut.Tests/Util/NoSanityCheckingDelegateServiceFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Halibut.Exceptions;
 using Halibut.ServiceModel;
+using Halibut.Util;
 
 namespace Halibut.Tests.Util
 {
@@ -16,7 +17,7 @@ namespace Halibut.Tests.Util
         public NoSanityCheckingDelegateServiceFactory Register<TContract>(Func<TContract> implementation)
         {
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.GetGenericQualifiedTypeName(), () => implementation());
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);
@@ -28,7 +29,7 @@ namespace Halibut.Tests.Util
         public NoSanityCheckingDelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
         {
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.GetGenericQualifiedTypeName(), () => implementation());
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);

--- a/source/Halibut/ServiceModel/DelegateServiceFactory.cs
+++ b/source/Halibut/ServiceModel/DelegateServiceFactory.cs
@@ -14,10 +14,10 @@ namespace Halibut.ServiceModel
         public DelegateServiceFactory Register<TContract>(Func<TContract> implementation)
         {
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.GetGenericQualifiedTypeName(), () => implementation());
             lock (serviceTypes)
             {
-                serviceTypes.Add(serviceType);    
+                serviceTypes.Add(serviceType);
             }
 
             return this;
@@ -26,9 +26,9 @@ namespace Halibut.ServiceModel
         public DelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
         {
             AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<TContract, TAsyncContract>();
-            
+
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.GetGenericQualifiedTypeName(), () => implementation());
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);
@@ -58,14 +58,14 @@ namespace Halibut.ServiceModel
             var service = serviceBuilder();
             return new Lease(service);
         }
-        
+
         public IReadOnlyList<Type> RegisteredServiceTypes
         {
             get
             {
                 lock (serviceTypes)
                 {
-                    return serviceTypes.ToList();    
+                    return serviceTypes.ToList();
                 }
             }
         }

--- a/source/Halibut/ServiceModel/HalibutProxy.cs
+++ b/source/Halibut/ServiceModel/HalibutProxy.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Halibut.Diagnostics;
 using Halibut.Exceptions;
 using Halibut.Transport.Protocol;
+using Halibut.Util;
 
 namespace Halibut.ServiceModel
 {
@@ -72,13 +73,14 @@ namespace Halibut.ServiceModel
             var activityId = Guid.NewGuid();
 
             var method = ((MethodInfo) methodCall.MethodBase);
+            var contractTypeName = contractType.GetGenericQualifiedTypeName();
             var request = new RequestMessage
             {
-                Id = contractType.Name + "::" + method.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
+                Id = contractTypeName + "::" + method.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
                 ActivityId = activityId,
                 Destination = endPoint,
                 MethodName = method.Name,
-                ServiceName = contractType.Name,
+                ServiceName = contractTypeName,
                 Params = args
             };
             return request;
@@ -140,13 +142,14 @@ namespace Halibut.ServiceModel
         {
             var activityId = Guid.NewGuid();
 
+            var contractTypeName = contractType.GetGenericQualifiedTypeName();
             var request = new RequestMessage
             {
-                Id = contractType.Name + "::" + targetMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
+                Id = contractTypeName + "::" + targetMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
                 ActivityId = activityId,
                 Destination = endPoint,
                 MethodName = targetMethod.Name,
-                ServiceName = contractType.Name,
+                ServiceName = contractTypeName,
                 Params = args
             };
             return request;

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Exceptions;
 using Halibut.Transport.Protocol;
+using Halibut.Util;
 
 namespace Halibut.ServiceModel
 {
@@ -22,10 +23,10 @@ namespace Halibut.ServiceModel
         ILog logger;
 
         public void Configure(
-            MessageRouter messageRouter, 
-            Type contractType, 
+            MessageRouter messageRouter,
+            Type contractType,
             ServiceEndPoint endPoint,
-            ILog logger, 
+            ILog logger,
             CancellationToken cancellationToken)
         {
             this.messageRouter = messageRouter;
@@ -77,12 +78,12 @@ namespace Halibut.ServiceModel
             var response = await messageRouter(request, serviceMethod, requestCancellationTokens);
 
             EnsureNotError(response);
-            
+
             return (serviceMethod, response.Result);
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="asyncMethod">The async client method called, used in the call id.</param>
         /// <param name="targetMethod">The method to actually invoke</param>
@@ -92,13 +93,14 @@ namespace Halibut.ServiceModel
         {
             var activityId = Guid.NewGuid();
 
+            var contractTypeName = contractType.GetGenericQualifiedTypeName();
             var request = new RequestMessage
             {
-                Id = contractType.Name + "::" + asyncMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
+                Id = contractTypeName + "::" + asyncMethod.Name + "[" + Interlocked.Increment(ref callId) + "] / " + activityId,
                 ActivityId = activityId,
                 Destination = endPoint,
                 MethodName = targetMethod.Name,
-                ServiceName = contractType.Name,
+                ServiceName = contractTypeName,
                 Params = args
             };
             return request;

--- a/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
+++ b/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Halibut.Util;
 
 namespace Halibut.Transport.Caching
 {
@@ -22,7 +23,7 @@ namespace Halibut.Transport.Caching
         {
             if (!string.IsNullOrWhiteSpace(prefix)) return $"{prefix}{LinkChar}";
 
-            var typeName = methodInfo.DeclaringType?.Name;
+            var typeName = methodInfo.DeclaringType?.GetGenericQualifiedTypeName();
             var methodName = methodInfo.Name;
 
             return $"{typeName}{LinkChar}{methodName}{LinkChar}";

--- a/source/Halibut/Transport/Protocol/TypeRegistry.cs
+++ b/source/Halibut/Transport/Protocol/TypeRegistry.cs
@@ -17,11 +17,11 @@ namespace Halibut.Transport.Protocol
             {
                 foreach (var method in serviceType.GetHalibutServiceMethods())
                 {
-                    RegisterType(method.ReturnType, $"{serviceType.Name}.{method.Name}:{method.ReturnType.Name}", false);
+                    RegisterType(method.ReturnType, $"{serviceType.GetGenericQualifiedTypeName()}.{method.Name}:{method.ReturnType.Name}", false);
 
                     foreach (var param in method.GetParameters())
                     {
-                        RegisterType(param.ParameterType,$"{serviceType.Name}.{method.Name}(){param.Name}:{param.ParameterType.Name}", false);
+                        RegisterType(param.ParameterType,$"{serviceType.GetGenericQualifiedTypeName()}.{method.Name}(){param.Name}:{param.ParameterType.Name}", false);
                     }
                 }
             }
@@ -58,7 +58,7 @@ namespace Halibut.Transport.Protocol
 
             foreach (var sub in SubTypesFor(type))
             {
-                RegisterType(sub, $"{path}<{sub.Name}>", ignoreObject);
+                RegisterType(sub, $"{path}<{sub.GetGenericQualifiedTypeName()}>", ignoreObject);
             }
         }
 
@@ -80,6 +80,18 @@ namespace Halibut.Transport.Protocol
                 {
                     yield return t;
                 }
+            }
+
+            if (type.IsAbstract)
+            {
+                var derivedTypes = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(asm => !asm.IsDynamic)
+                    .SelectMany(asm => asm.GetExportedTypes())
+                    .Where(t => !t.IsAbstract)
+                    .Where(type.IsAssignableFrom);
+
+                foreach (var derivedType in derivedTypes)
+                    yield return derivedType;
             }
         }
 

--- a/source/Halibut/Util/TypeExtensionMethods.cs
+++ b/source/Halibut/Util/TypeExtensionMethods.cs
@@ -37,5 +37,13 @@ namespace Halibut.Util
 
             return true;
         }
+
+        public static string GetGenericQualifiedTypeName(this Type type)
+        {
+            return !type.IsGenericType
+                ? type.Name
+                // MyService`2[string,int] or MyService`2[string,MyType`1[bool]]
+                : $"{type.Name}[{string.Join(",", type.GenericTypeArguments.Select(GetGenericQualifiedTypeName))}]";
+        }
     }
 }


### PR DESCRIPTION
# Background

Halibut doesn't currently support generic services (i.e. `IMyService<T>`). This is due to how the service name is serialized in the request message, it just uses `Type.Name`, which doesn't include any generic type argument information, just the number of generic type args (i.e. ``IMyService`1``).

This means that the service can't be correctly resolved as `IMyService<int>` and `IMyService<string>` are identified in the request message as the same service.

# Results

This PR changes the `TypeRegistry` and the `HalibutProxy` to use a new extension method, `GetGenericQualifiedName()` as the service name, rather than the `.Name` property.

This new extension method adds the generic type args to the name in the format ``IMyService`2[Arg1,Arg2]``. If a generic type arg is also generic, it will build the same structure like this ``IMyService`2[MyGenericType`1[string],string]``.

Also, I have updated the `TypeRegistry` to find all derived types if a service method parameter is abstract. That is, if the method signature is `void MyMethod(BaseType base)` and there are two derived types of `BaseType`, then those types are also registered.

I have also added new unit tests covering the new generic services. I don't have enough knowledge of Halibut testing to understand what I need to do regarding the latest/previous version test cases, but this should be backwards compatible for existing services.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
