### PR TITLE
Add support for derived types to the default TypeRegistry

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -12,7 +12,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
         {
             this.service = service;
         }
-        
+
         public ComplexObjectMultipleDataStreams Process(ComplexObjectMultipleDataStreams request)
         {
             return FixDataStreams(service.Process(FixDataStreams(request)));
@@ -28,6 +28,11 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public ComplexObjectMultipleChildren Process(ComplexObjectMultipleChildren request)
         {
             return FixDataStreams(service.Process(FixDataStreams(request)));
+        }
+
+        public ComplexObjectWithInheritance Process(ComplexObjectWithInheritance request)
+        {
+            return service.Process(request);
         }
 
         ComplexObjectMultipleChildren FixDataStreams(ComplexObjectMultipleChildren complexObject)

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -8,6 +8,7 @@ namespace Halibut.TestUtils.Contracts
     {
         ComplexObjectMultipleDataStreams Process(ComplexObjectMultipleDataStreams request);
         ComplexObjectMultipleChildren Process(ComplexObjectMultipleChildren request);
+        ComplexObjectWithInheritance Process(ComplexObjectWithInheritance request);
     }
 
     public class ComplexObjectMultipleDataStreams
@@ -20,6 +21,13 @@ namespace Halibut.TestUtils.Contracts
     {
         public ComplexChild1 Child1;
         public ComplexChild2 Child2;
+    }
+
+    public class ComplexObjectWithInheritance
+    {
+        public IComplexChild Child1;
+        public ComplexChildBase Child2;
+
     }
 
     public class ComplexChild1
@@ -35,7 +43,37 @@ namespace Halibut.TestUtils.Contracts
         public ComplexEnum EnumPayload;
         public ISet<ComplexPair<DataStream>> ComplexPayloadSet;
     }
-    
+
+    public interface IComplexChild
+    {
+        string Name { get; }
+    }
+
+    public abstract class ComplexChildBase
+    {
+        public abstract string Description { get; }
+    }
+
+    public class ComplexInheritedChild1 : IComplexChild
+    {
+        public ComplexInheritedChild1(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+
+    public class ComplexInheritedChild2 : ComplexChildBase
+    {
+        public ComplexInheritedChild2(string description)
+        {
+            Description = description;
+        }
+
+        public override string Description { get; }
+    }
+
     public enum ComplexEnum
     {
         RequestValue1,
@@ -105,6 +143,15 @@ namespace Halibut.TestUtils.Contracts
                     EnumPayload = request.Child2.EnumPayload,
                     ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, ReadIntoNewDataStream(x.Payload))).ToHashSet()
                 }
+            };
+        }
+
+        public ComplexObjectWithInheritance Process(ComplexObjectWithInheritance request)
+        {
+            return new ComplexObjectWithInheritance
+            {
+                Child1 = new ComplexInheritedChild1(request.Child1.Name),
+                Child2 = new ComplexInheritedChild2(request.Child2.Description)
             };
         }
 

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Halibut.TestUtils.Contracts
 {
@@ -25,9 +26,8 @@ namespace Halibut.TestUtils.Contracts
 
     public class ComplexObjectWithInheritance
     {
-        public IComplexChild Child1;
-        public ComplexChildBase Child2;
-
+        public IComplexChild Child1 { get; set; }
+        public ComplexChildBase Child2 { get; set; }
     }
 
     public class ComplexChild1
@@ -56,6 +56,7 @@ namespace Halibut.TestUtils.Contracts
 
     public class ComplexInheritedChild1 : IComplexChild
     {
+        [JsonConstructor]
         public ComplexInheritedChild1(string name)
         {
             Name = name;
@@ -66,6 +67,7 @@ namespace Halibut.TestUtils.Contracts
 
     public class ComplexInheritedChild2 : ComplexChildBase
     {
+        [JsonConstructor]
         public ComplexInheritedChild2(string description)
         {
             Description = description;

--- a/source/Halibut.Tests/TestServices/Async/IAsyncClientComplexObjectService.cs
+++ b/source/Halibut.Tests/TestServices/Async/IAsyncClientComplexObjectService.cs
@@ -7,5 +7,6 @@ namespace Halibut.Tests.TestServices.Async
     {
         Task<ComplexObjectMultipleDataStreams> ProcessAsync(ComplexObjectMultipleDataStreams request);
         Task<ComplexObjectMultipleChildren> ProcessAsync(ComplexObjectMultipleChildren request);
+        Task<ComplexObjectWithInheritance> ProcessAsync(ComplexObjectWithInheritance request);
     }
 }

--- a/source/Halibut.Tests/TypeRegistryFixture.cs
+++ b/source/Halibut.Tests/TypeRegistryFixture.cs
@@ -1,0 +1,167 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using FluentAssertions;
+using Halibut.Transport.Protocol;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    [TestFixture]
+    public class TypeRegistryFixture
+    {
+        [Test]
+        public void RegisteringAbstractTypeSearchesAssemblyForExportedDerivedTypes()
+        {
+            // Arrange
+            var registry = new TypeRegistry();
+
+            // Act
+            registry.RegisterType(typeof(AbstractType), "$", false);
+
+            // Assert
+            registry.IsInAllowedTypes(typeof(AbstractType)).Should().BeTrue();
+            registry.IsInAllowedTypes(typeof(IInterfaceType)).Should().BeFalse();
+            registry.IsInAllowedTypes(typeof(PublicConcreteType)).Should().BeTrue();
+            registry.IsInAllowedTypes(typeof(InternalConcreteType)).Should().BeFalse();
+        }
+
+        [Test]
+        public void RegisteringInterfaceTypeSearchesAssemblyForExportedDerivedTypes()
+        {
+            // Arrange
+            var registry = new TypeRegistry();
+
+            // Act
+            registry.RegisterType(typeof(IInterfaceType), "$", false);
+
+            // Assert
+            registry.IsInAllowedTypes(typeof(AbstractType)).Should().BeFalse();
+            registry.IsInAllowedTypes(typeof(IInterfaceType)).Should().BeTrue();
+            registry.IsInAllowedTypes(typeof(PublicConcreteType)).Should().BeTrue();
+            registry.IsInAllowedTypes(typeof(InternalConcreteType)).Should().BeFalse();
+        }
+
+        [Test]
+        public void RegisteringTypeSearchesAssemblyForExportedDerivedTypesAndShouldNotSearchEntireAppDomain()
+        {
+            // Arrange
+            var registry = new TypeRegistry();
+
+            // Act
+            registry.RegisterType(typeof(IDictionary<string, string>), "$", false);
+
+            // Assert
+            registry.IsInAllowedTypes(typeof(IDictionary<string, string>)).Should().BeTrue();
+            registry.IsInAllowedTypes(typeof(CustomDictionary)).Should().BeFalse(because: "The concrete implementation is in a different assembly to the IDictionary<string,string> type.");
+        }
+
+        [Test]
+        public void RegisteringTypeSearchesSuppliedAssembliesForExportedDerivedTypes()
+        {
+            // Arrange
+            var registry = new TypeRegistry(new[] { typeof(CustomDictionary).Assembly });
+
+            // Act
+            registry.RegisterType(typeof(IDictionary<string, string>), "$", false);
+
+            // Assert
+            registry.IsInAllowedTypes(typeof(IDictionary<string, string>)).Should().BeTrue();
+            registry.IsInAllowedTypes(typeof(CustomDictionary)).Should().BeTrue();
+        }
+    }
+
+    public abstract class AbstractType
+    {
+    }
+
+    public interface IInterfaceType
+    {
+    }
+
+    public class PublicConcreteType : AbstractType, IInterfaceType
+    {
+    }
+
+    class InternalConcreteType : AbstractType, IInterfaceType
+    {
+    }
+
+    public class CustomDictionary : IDictionary<string, string>
+    {
+        readonly IDictionary<string, string> _dictionaryImplementation;
+
+        public CustomDictionary(IDictionary<string, string> dictionaryImplementation)
+        {
+            _dictionaryImplementation = dictionaryImplementation;
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            return _dictionaryImplementation.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)_dictionaryImplementation).GetEnumerator();
+        }
+
+        public void Add(KeyValuePair<string, string> item)
+        {
+            _dictionaryImplementation.Add(item);
+        }
+
+        public void Clear()
+        {
+            _dictionaryImplementation.Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, string> item)
+        {
+            return _dictionaryImplementation.Contains(item);
+        }
+
+        public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+        {
+            _dictionaryImplementation.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<string, string> item)
+        {
+            return _dictionaryImplementation.Remove(item);
+        }
+
+        public int Count => _dictionaryImplementation.Count;
+
+        public bool IsReadOnly => _dictionaryImplementation.IsReadOnly;
+
+        public void Add(string key, string value)
+        {
+            _dictionaryImplementation.Add(key, value);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _dictionaryImplementation.ContainsKey(key);
+        }
+
+        public bool Remove(string key)
+        {
+            return _dictionaryImplementation.Remove(key);
+        }
+
+        public bool TryGetValue(string key, out string value)
+        {
+            return _dictionaryImplementation.TryGetValue(key, out value);
+        }
+
+        public string this[string key]
+        {
+            get => _dictionaryImplementation[key];
+            set => _dictionaryImplementation[key] = value;
+        }
+
+        public ICollection<string> Keys => _dictionaryImplementation.Keys;
+
+        public ICollection<string> Values => _dictionaryImplementation.Values;
+    }
+}

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -278,6 +278,7 @@ namespace Halibut.Tests
                 .Build(CancellationToken);
 
             var service = clientAndService.CreateClient<IComplexObjectService, IAsyncClientComplexObjectService>();
+
             var request = new ComplexObjectWithInheritance
             {
                 Child1 = new ComplexInheritedChild1(childPayload1),

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -266,7 +266,7 @@ namespace Halibut.Tests
         }
 
         [Test]
-        [LatestAndPreviousClientAndServiceVersionsTestCases(testNetworkConditions: false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false)]
         public async Task OctopusCanSendAndReceiveComplexObjects_WithInheritedChildren(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             const string childPayload1 = "Child Payload #1";

--- a/source/Halibut/Transport/Protocol/TypeRegistryBuilder.cs
+++ b/source/Halibut/Transport/Protocol/TypeRegistryBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+
+namespace Halibut.Transport.Protocol
+{
+    public class TypeRegistryBuilder
+    {
+        Assembly[] typeAssemblies;
+
+        /// <summary>
+        /// Adds a list of assemblies to the <see cref="ITypeRegistry"/>. Used to search for contract types for derived types.
+        /// </summary>
+        /// <param name="assemblies">An array of <see cref="Assembly">Assemblies</see> to add to the <see cref="ITypeRegistry"/>.</param>
+        public TypeRegistryBuilder WithTypeAssemblies(params Assembly[] assemblies)
+        {
+            typeAssemblies = assemblies;
+            return this;
+        }
+
+        public ITypeRegistry Build()
+        {
+            return new TypeRegistry(typeAssemblies);
+        }
+    }
+}


### PR DESCRIPTION
# Background

If you supply a complex base type as part of the request message, the `TypeRegistry` doesn't know how to resolve any derived types.

This PR updates the `TypeRegistry` to check the assembly the base type is in as well as any extra assemblies provided during setup for any derived types.

# Results

I chose to implement a new `TypeRegistryBuilder` to allow consumers to configure the built-in type registry without having to create their own (similar to how we can configure the Message Serializer as part of the `HalibutRuntimeBuilder`.

We also only look for `ExportedTypes()` in the assemblies, so types that are `private/protected/internal` are not registered.

I've added some unit tests to cover the new serialization behaviour.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
