### PR TITLE
Disposing an SslStream that leaves the inner stream open causes it to…

### DIFF
--- a/source/Halibut/Util/SilentStreamDisposer.cs
+++ b/source/Halibut/Util/SilentStreamDisposer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Halibut.Transport.Streams;
+
+namespace Halibut.Util
+{
+    public class SilentStreamDisposer : IAsyncDisposable
+    {
+        readonly Stream streamToDispose;
+        readonly Action<Exception> onFailure;
+
+        public SilentStreamDisposer(Stream streamToDispose, Action<Exception> onFailure)
+        {
+            this.streamToDispose = streamToDispose;
+            this.onFailure = onFailure;
+        }
+        
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await streamToDispose.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                onFailure.Invoke(ex);
+            }
+        }
+    }
+}

--- a/source/Halibut/Util/Try.cs
+++ b/source/Halibut/Util/Try.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace Halibut.Util
 {
@@ -14,6 +15,11 @@ namespace Halibut.Util
             {
                 onFailure(e);
             }
+        }
+
+        public static SilentStreamDisposer CatchingErrorOnDisposal(Stream streamToDispose, Action<Exception> onFailure)
+        {
+            return new SilentStreamDisposer(streamToDispose, onFailure);
         }
     }
     


### PR DESCRIPTION
… flush the stream.

But the underlying NetworkTimeoutStream throws an exception when it flushes and is in a faulted/timed out state.

That is what we are fixing.

**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

# Background

<!-- Why does this PR exist? -->

# Results

<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/Issues/issues/... _(optional public issue)_

Fixes https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/... _(optional private issue)_

See [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) (including [this flowchart](https://whimsical.com/r-d-incoming-work-workflow-aug-21-NsDnGQXcwBLwU66a88Zhue) 

## Before

<!-- Consider adding a log excerpt or screen capture. -->

![Before](https://user-images.githubusercontent.com/5088479/120727281-72762180-c51d-11eb-9776-85363dc084e2.png)

## After

<!-- Consider adding a log excerpt or screen capture. -->

![After](https://user-images.githubusercontent.com/5088479/120727258-67bb8c80-c51d-11eb-8d2a-e047095b2d01.png)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
