### PR TITLE
Fix handling of errors in async services.

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateEchoService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateEchoService.cs
@@ -29,7 +29,16 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public bool Crash()
         {
             Console.WriteLine("Forwarding Crash() call to delegate");
-            return echoService.Crash();
+            try
+            {
+                return echoService.Crash();
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Received Exception: START:\n" +
+                                    e.Message
+                                    + "\nEnd Received Exception");
+            }
         }
 
         public int CountBytes(DataStream dataStream)

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -73,7 +73,6 @@ namespace Halibut.Tests
         public async Task FailsWithInvocationServiceExceptionWhenAsyncServiceCrashes(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                             //.AsPreviousClientVersionAndLatestServiceBuilder()
                              .WithAsyncService<IEchoService, IAsyncEchoService>(() => new AsyncEchoService())
                              .Build(CancellationToken))
             {
@@ -85,13 +84,14 @@ namespace Halibut.Tests
                 {
                     // This here verifies that the client actually did see something that looks like a service invocation exception.
                     ex.Message.Replace("\r", "")
+                        .Replace("\n", "")
                         .Should()
                         .Contain(@"Received Exception: START:
 Attempted to divide by zero.
 
 Server exception: 
 System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
- ---> System.DivideByZeroException: Attempted to divide by zero".Replace("\r", ""));
+ ---> System.DivideByZeroException: Attempted to divide by zero".Replace("\r", "").Replace("\n", ""));
                 }
             }
         }

--- a/source/Halibut.Tests/Support/ClientAndServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/ClientAndServiceBuilderExtensionMethods.cs
@@ -1,3 +1,6 @@
+using System;
+using Halibut.Tests.Support.BackwardsCompatibility;
+
 namespace Halibut.Tests.Support
 {
     public static class ClientAndServiceBuilderExtensionMethods
@@ -5,6 +8,21 @@ namespace Halibut.Tests.Support
         public static LatestClientAndLatestServiceBuilder AsLatestClientAndLatestServiceBuilder(this IClientAndServiceBuilder clientAndServiceBuilder)
         {
             return (LatestClientAndLatestServiceBuilder) clientAndServiceBuilder;
+        }
+        
+        public static PreviousClientVersionAndLatestServiceBuilder AsPreviousClientVersionAndLatestServiceBuilder(this IClientAndServiceBuilder clientAndServiceBuilder)
+        {
+            return (PreviousClientVersionAndLatestServiceBuilder) clientAndServiceBuilder;
+        }
+
+        public static IClientAndServiceBuilder WithAsyncService<TContract, TClientContract>(this IClientAndServiceBuilder clientAndServiceBuilder, Func<TClientContract> implementation)
+        {
+            if (clientAndServiceBuilder is LatestClientAndLatestServiceBuilder)
+            {
+                return clientAndServiceBuilder.AsLatestClientAndLatestServiceBuilder().WithAsyncService<TContract, TClientContract>(implementation);
+            }
+
+            return clientAndServiceBuilder.AsPreviousClientVersionAndLatestServiceBuilder().WithAsyncService<TContract, TClientContract>(implementation);
         }
     }
 }

--- a/source/Halibut.Tests/Support/PreviousClientVersionAndLatestServiceBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/PreviousClientVersionAndLatestServiceBuilderExtensionMethods.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Halibut.Tests.Support.BackwardsCompatibility;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices;
+using Halibut.TestUtils.Contracts;
+using Halibut.Transport.Observability;
+using Halibut.Util;
+using ICachingService = Halibut.TestUtils.Contracts.ICachingService;
+
+namespace Halibut.Tests.Support
+{
+    static class PreviousClientVersionAndLatestServiceBuilderExtensionMethods
+    {
+        public static PreviousClientVersionAndLatestServiceBuilder WithEchoService(this PreviousClientVersionAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<IEchoService>(() => new EchoService());
+        }
+
+        public static PreviousClientVersionAndLatestServiceBuilder WithMultipleParametersTestService(this PreviousClientVersionAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<IMultipleParametersTestService>(() => new MultipleParametersTestService());
+        }
+
+        public static PreviousClientVersionAndLatestServiceBuilder WithComplexObjectService(this PreviousClientVersionAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<IComplexObjectService>(() => new ComplexObjectService());
+        }
+        
+        public static PreviousClientVersionAndLatestServiceBuilder WithLockService(this PreviousClientVersionAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<ILockService>(() => new LockService());
+        }
+        
+        public static PreviousClientVersionAndLatestServiceBuilder WithCountingService(this PreviousClientVersionAndLatestServiceBuilder builder)
+        {
+            var singleCountingService = new CountingService();
+            return builder.WithService<ICountingService>(() => singleCountingService);
+        }
+        
+        public static PreviousClientVersionAndLatestServiceBuilder WithCountingService(this PreviousClientVersionAndLatestServiceBuilder builder, ICountingService countingService)
+        {
+            return builder.WithService<ICountingService>(() => countingService);
+        }
+        
+        public static PreviousClientVersionAndLatestServiceBuilder WithReadDataStreamService(this PreviousClientVersionAndLatestServiceBuilder builder)
+        {
+            return builder.WithService<IReadDataStreamService>(() => new ReadDataStreamService());
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/TestAttributes/PreviousClientAndLatestServiceVersionsTestCasesAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/PreviousClientAndLatestServiceVersionsTestCasesAttribute.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Halibut.Tests.Support.BackwardsCompatibility;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Util;
+
+namespace Halibut.Tests.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class PreviousClientAndLatestServiceVersionsTestCasesAttribute : HalibutTestCaseSourceAttribute
+    {
+        public PreviousClientAndLatestServiceVersionsTestCasesAttribute(bool testWebSocket = true, 
+            bool testNetworkConditions = true,
+            bool testListening = true,
+            bool testPolling = true,
+            bool testAsyncClients = true,
+            bool testSyncClients = true,
+            bool testAsyncServicesAsWell = false, // False means only the sync service will be tested.
+            bool testSyncService = true
+            ) :
+            base(
+                typeof(PreviousClientAndLatestServiceVersionsTestCases),
+                nameof(PreviousClientAndLatestServiceVersionsTestCases.GetEnumerator),
+                new object[] { testWebSocket, testNetworkConditions, testListening, testPolling, testAsyncClients, testSyncClients, testAsyncServicesAsWell, testSyncService })
+        {
+        }
+        
+        static class PreviousClientAndLatestServiceVersionsTestCases
+        {
+            public static IEnumerable GetEnumerator(bool testWebSocket, bool testNetworkConditions, bool testListening, bool testPolling, bool testAsyncClients, bool testSyncClients, bool testAsyncServicesAsWell, bool testSyncService)
+            {
+                var serviceConnectionTypes = ServiceConnectionTypes.All.ToList();
+
+                if (!testWebSocket)
+                {
+                    serviceConnectionTypes.Remove(ServiceConnectionType.PollingOverWebSocket);
+                }
+
+                if (!testListening)
+                {
+                    serviceConnectionTypes.Remove(ServiceConnectionType.Listening);
+                }
+                
+                if (!testPolling)
+                {
+                    serviceConnectionTypes.Remove(ServiceConnectionType.Polling);
+                }
+                
+                List<ForceClientProxyType> clientProxyTypesToTest = new();
+
+                if (testAsyncClients)
+                {
+                    clientProxyTypesToTest.Add(ForceClientProxyType.AsyncClient);
+
+                    if (testSyncClients)
+                    {
+                        clientProxyTypesToTest.Add(ForceClientProxyType.SyncClient);
+                    }
+                }
+
+                var serviceAsyncHalibutFeatureTestCases = AsyncHalibutFeatureValues.All().ToList();
+                if (!testAsyncServicesAsWell)
+                {
+                    serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Enabled);
+                }
+                
+                if (!testSyncService)
+                {
+                    serviceAsyncHalibutFeatureTestCases.Remove(AsyncHalibutFeature.Disabled);
+                }
+                
+
+                var builder = new ClientAndServiceTestCasesBuilder(
+                    new[] {
+                        ClientAndServiceTestVersion.ClientOfVersion(PreviousVersions.v5_0_236_Used_In_Tentacle_6_3_417.ClientVersion)
+                    },
+                    serviceConnectionTypes.ToArray(),
+                    testNetworkConditions ? NetworkConditionTestCase.All : new[] { NetworkConditionTestCase.NetworkConditionPerfect },
+                    clientProxyTypesToTest,
+                    serviceAsyncHalibutFeatureTestCases
+                );
+
+                return builder.Build();
+            }
+        }
+    }
+}

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -221,7 +221,14 @@ namespace Halibut.ServiceModel
             }
 
             var task = (Task)method.Invoke(obj, parameters);
-            await task.ConfigureAwait(false);
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                throw new TargetInvocationException(e);
+            }
 
             if (returnType == typeof(Task))
             {


### PR DESCRIPTION
# Background

Fixes an issue where the exception thrown by an async service would not be wrapped in a `InvocationTargetException`, resulting in the client being unable to determine that the exception occurred within the service itself.

The change is to wrap the exception thrown by the async service in a  `InvocationTargetException` which means the halibut service invoker now always throws a `InvocationTargetException` for exceptions thrown in sync or async services.

An async service is one that looks like: (e.g. `class AsyncEchoService : IAsyncEchoService { public Task Foo() {await Task.Complete;}}) 


# How to review this PR

Review the two commits separately, the first modifies the test infrastructure and the second adds the fix and tests.