### PR TITLE
Record all log lines, and don't let logging alter the test run

### DIFF
--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Assent" Version="1.8.2" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.7.30" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 
@@ -10,18 +9,18 @@ namespace Halibut.Tests
 {
     public class TraceLogFileLogger : IDisposable
     {
-        readonly AsyncQueue<string> queue = new AsyncQueue<string>();
+        readonly AsyncQueue<string> queue = new();
         readonly string tempFilePath = Path.GetTempFileName();
         string testHash;
 
-        readonly TaskCompletionSource<bool> noMoreDelaysToWritingLogs;
-        readonly Task noMoreDelaysTask;
+        readonly TaskCompletionSource<bool> prepareForLogCollectionTaskCompletionSource;
+        readonly Task prepareForLogCollection;
         readonly Task writeDataToDiskTask;
 
         public TraceLogFileLogger()
         {
-            noMoreDelaysToWritingLogs = new TaskCompletionSource<bool>();
-            noMoreDelaysTask = noMoreDelaysToWritingLogs.Task;
+            prepareForLogCollectionTaskCompletionSource = new TaskCompletionSource<bool>();
+            prepareForLogCollection = prepareForLogCollectionTaskCompletionSource.Task;
             writeDataToDiskTask = WriteDataToFile();
         }
 
@@ -29,54 +28,42 @@ namespace Halibut.Tests
         {
             this.testHash = testHash;
         }
-        
+
         public void WriteLine(string logMessage)
         {
+            if (prepareForLogCollection.IsCompleted) return;
             queue.Enqueue(logMessage);
-        } 
-        
+        }
+
         async Task WriteDataToFile()
         {
-            while (true)
+            while (!prepareForLogCollection.IsCompleted)
             {
                 // Don't hammer the disk, let some log message queue up before writing them.
-                if (!noMoreDelaysTask.IsCompleted)
-                {
-                    await Task.WhenAny(Task.Delay(5), noMoreDelaysTask);
-                }
+                if (!prepareForLogCollection.IsCompleted) await Task.WhenAny(Task.Delay(5), prepareForLogCollection);
 
                 var list = new List<string>();
                 list.Add(await queue.DequeueAsync());
-                while (queue.TryDequeue(out var log))
-                {
-                    list.Add(log);
-                }
+                while (queue.TryDequeue(out var log)) list.Add(log);
 
                 using (var fileAppender = new StreamWriter(tempFilePath, true, Encoding.UTF8, 8192))
                 {
-                    foreach (var logLine in list)
-                    {
-                        await fileAppender.WriteLineAsync(logLine);
-                    }
+                    foreach (var logLine in list) await fileAppender.WriteLineAsync(logLine);
 
                     await fileAppender.FlushAsync();
                 }
             }
         }
-        
-        void AllowSomeTimeForTheQueueToEmpty()
+
+        void FinishWritingLogs()
         {
-            noMoreDelaysToWritingLogs.SetResult(false);
-            for (int i = 0; i < 100; i++)
-            {
-                if(queue.IsEmpty) break;
-                Thread.Sleep(1);
-            }
-        } 
+            prepareForLogCollectionTaskCompletionSource.SetResult(false);
+            writeDataToDiskTask.GetAwaiter().GetResult();
+        }
 
         public bool CopyLogFileToArtifacts()
         {
-            AllowSomeTimeForTheQueueToEmpty();
+            FinishWritingLogs();
             // The current directory is expected to have the following structure
             // (w/ variance depending on Debug/Release and dotnet framework used (net6.0, net48 etc):
             //
@@ -86,7 +73,7 @@ namespace Halibut.Tests
             // from which point we can navigate to the artifacts directory.
             var currentDirectory = Directory.GetCurrentDirectory();
             var rootDirectory = new DirectoryInfo(currentDirectory).Parent.Parent.Parent.Parent.Parent;
-            
+
             var traceLogsDirectory = rootDirectory.CreateSubdirectory("artifacts").CreateSubdirectory("trace-logs");
             var fileName = $"{testHash}.tracelog";
 
@@ -100,7 +87,7 @@ namespace Halibut.Tests
                 return false;
             }
         }
-        
+
         public void Dispose()
         {
             try

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -1,12 +1,29 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 
 namespace Halibut.Tests
 {
     public class TraceLogFileLogger : IDisposable
     {
-        string tempFilePath = Path.GetTempFileName();
+        readonly AsyncQueue<string> queue = new AsyncQueue<string>();
+        readonly string tempFilePath = Path.GetTempFileName();
         string testHash;
+
+        readonly TaskCompletionSource<bool> noMoreDelaysToWritingLogs;
+        readonly Task noMoreDelaysTask;
+        readonly Task writeDataToDiskTask;
+
+        public TraceLogFileLogger()
+        {
+            noMoreDelaysToWritingLogs = new TaskCompletionSource<bool>();
+            noMoreDelaysTask = noMoreDelaysToWritingLogs.Task;
+            writeDataToDiskTask = WriteDataToFile();
+        }
 
         public void SetTestHash(string testHash)
         {
@@ -15,11 +32,51 @@ namespace Halibut.Tests
         
         public void WriteLine(string logMessage)
         {
-            File.AppendAllLines(tempFilePath, new[] { logMessage });
+            queue.Enqueue(logMessage);
+        } 
+        
+        async Task WriteDataToFile()
+        {
+            while (true)
+            {
+                // Don't hammer the disk, let some log message queue up before writing them.
+                if (!noMoreDelaysTask.IsCompleted)
+                {
+                    await Task.WhenAny(Task.Delay(5), noMoreDelaysTask);
+                }
+
+                var list = new List<string>();
+                list.Add(await queue.DequeueAsync());
+                while (queue.TryDequeue(out var log))
+                {
+                    list.Add(log);
+                }
+
+                using (var fileAppender = new StreamWriter(tempFilePath, true, Encoding.UTF8, 8192))
+                {
+                    foreach (var logLine in list)
+                    {
+                        await fileAppender.WriteLineAsync(logLine);
+                    }
+
+                    await fileAppender.FlushAsync();
+                }
+            }
         }
+        
+        void AllowSomeTimeForTheQueueToEmpty()
+        {
+            noMoreDelaysToWritingLogs.SetResult(false);
+            for (int i = 0; i < 100; i++)
+            {
+                if(queue.IsEmpty) break;
+                Thread.Sleep(1);
+            }
+        } 
 
         public bool CopyLogFileToArtifacts()
         {
+            AllowSomeTimeForTheQueueToEmpty();
             // The current directory is expected to have the following structure
             // (w/ variance depending on Debug/Release and dotnet framework used (net6.0, net48 etc):
             //


### PR DESCRIPTION
# Background

An issue exists in which recording trace logs appears to:
- Not record all log lines, since logging can be done in parallel and this results in an exception when two threads write to the same file.
- That exception would bubble out of the sink, although maybe something catches it before it throws an exception in halibut.
- Appeared to alter the timings of test causing some web-socket tests to fail. (Which is probably a real bug?)

# Results

Logging is now done to a queue, which is async written to disk. This means:
- We don't throw exceptions in the sink.
- Writing logs is thread safe.
- Each log line written does not `open, write to, and close a file` which should stop changing the timings of tests and improve performance/decrease disk IO.

The queue is used over a lock to avoid logging introducing a hidden lock which could cause code to become dependent on the lock.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
