### PR TITLE
Reduce StandardIterationCount on linux

### DIFF
--- a/source/Halibut.Tests/Util/StandardIterationCount.cs
+++ b/source/Halibut.Tests/Util/StandardIterationCount.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestCases;
 
@@ -24,7 +25,7 @@ namespace Halibut.Tests.Util
                     return 50;
                 case ServiceConnectionType.Listening:
                     // Listening is fast on windows.
-                    if (OperatingSystem.IsWindows())
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {
                         return 1000;
                     }

--- a/source/Halibut.Tests/Util/StandardIterationCount.cs
+++ b/source/Halibut.Tests/Util/StandardIterationCount.cs
@@ -23,8 +23,13 @@ namespace Halibut.Tests.Util
                     // Assume polling over websockets is also slow
                     return 50;
                 case ServiceConnectionType.Listening:
-                    // Listening is fast
-                    return 1000;
+                    // Listening is fast on windows.
+                    if (OperatingSystem.IsWindows())
+                    {
+                        return 1000;
+                    }
+                    // It is not clear why listening is slower on linux.
+                    return 250;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(connectionType), connectionType, null);
             }


### PR DESCRIPTION
# Background

Linux is slower than windows and this does impact the time it takes to run all of the tests, which especially frustrating for local development.

This reduces the iterations for listening from 1000 to 250 on linux, which is probably still well enough.

Some tests go from `1m38s` to `28s`.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
