### PR TITLE
Add Polling Service next request timeout

### DIFF
--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -33,7 +33,8 @@ namespace Halibut.Tests
                 
                 TcpClientAuthenticationAndIdentificationTimeouts = new(sendTimeout: TimeSpan.FromSeconds(15), receiveTimeout: TimeSpan.FromSeconds(15)),
                 TcpClientConnectTimeout = TimeSpan.FromSeconds(20),
-                PollingQueueWaitTimeout = TimeSpan.FromSeconds(20)
+                PollingQueueWaitTimeout = TimeSpan.FromSeconds(20),
+                TcpClientReceiveRequestTimeoutForPolling = TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(10)
             };
         }
     }

--- a/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
@@ -13,7 +13,7 @@ namespace Halibut.Tests.Support
             halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout = timeSpan;
             halibutTimeoutsAndLimits.TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = timeSpan;
             halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts = new(timeSpan, timeSpan);
-
+            halibutTimeoutsAndLimits.TcpClientReceiveRequestTimeoutForPolling = timeSpan;
             return halibutTimeoutsAndLimits;
         }
 
@@ -21,6 +21,12 @@ namespace Halibut.Tests.Support
         {
             halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout = tcpClientReceiveTimeout;
 
+            return halibutTimeoutsAndLimits;
+        }
+
+        public static HalibutTimeoutsAndLimits Apply(this HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, Action<HalibutTimeoutsAndLimits> apply)
+        {
+            apply(halibutTimeoutsAndLimits);
             return halibutTimeoutsAndLimits;
         }
     }

--- a/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
@@ -24,7 +24,7 @@ namespace Halibut.Tests.Transport.Protocol
         {
             stream = new DumpStream();
             stream.SetRemoteIdentity(new RemoteIdentity(RemoteIdentityType.Server));
-            protocol = new MessageExchangeProtocol(stream, Substitute.For<IRpcObserver>(), Substitute.For<ILog>());
+            protocol = new MessageExchangeProtocol(stream, Substitute.For<IRpcObserver>(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), Substitute.For<ILog>());
         }
 
         // TODO - ASYNC ME UP! ExchangeAsClientAsync cancellation
@@ -363,7 +363,7 @@ namespace Halibut.Tests.Transport.Protocol
                 output.AppendLine("--> " + typeof(T).Name);
             }
 
-            public Task<RequestMessage> ReceiveRequestAsync(CancellationToken cancellationToken)
+            public Task<RequestMessage> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
             {
                 return ReceiveAsync<RequestMessage>();
             }

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -63,7 +63,7 @@ namespace Halibut.Tests.Transport
             for (int i = 0; i < halibutTimeoutsAndLimits.RetryCountLimit; i++)
             {
                 var connection = Substitute.For<IConnection>();
-                connection.Protocol.Returns(new MessageExchangeProtocol(stream, new NoRpcObserver(), log));
+                connection.Protocol.Returns(new MessageExchangeProtocol(stream, new NoRpcObserver(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), log));
 
                 await connectionManager.ReleaseConnectionAsync(endpoint, connection, CancellationToken.None);
             }
@@ -92,7 +92,7 @@ namespace Halibut.Tests.Transport
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog logger)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger), new NoRpcObserver(), logger);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger), new NoRpcObserver(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger);
         }
     }
 }

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -51,8 +51,21 @@ namespace Halibut.Diagnostics
 
         /// <summary>
         ///     Amount of time to wait for a response from an RPC call.
+        /// 
+        ///     Specifically the amount of time to wait for the first byte of the request to arrive.
         /// </summary>
         public TimeSpan TcpClientReceiveResponseTimeout { get; set; } = TimeSpan.FromMinutes(10);
+        
+        /// <summary>
+        ///     Amount of time the polling service will wait for a request from an RPC call.
+        ///     Specifically the amount of time to wait for the first byte of the request to arrive.
+        ///
+        ///     This value must never be less than the PollingQueueWaitTimeout, of the client, since this
+        ///     is the timeout of the long poll the polling service makes to the client to get the next request.
+        ///
+        ///     Currently set to 10 minutes as that is what the timeout used to be. 
+        /// </summary>
+        public TimeSpan TcpClientReceiveRequestTimeoutForPolling { get; set; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
         ///     Amount of time to wait when receiving a response from an RPC call, after data has started being received.
@@ -87,6 +100,7 @@ namespace Halibut.Diagnostics
         ///     re-request.
         /// </summary>
         public TimeSpan PollingQueueWaitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
 
         // After a client/server message exchange is complete, the client returns
         // the connection to the pool but the server continues to block and reads

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -101,7 +101,7 @@ namespace Halibut
 
         ExchangeProtocolBuilder ExchangeProtocolBuilder()
         {
-            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, messageSerializer, TimeoutsAndLimits, log), rpcObserver, log);
+            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, messageSerializer, TimeoutsAndLimits, log), rpcObserver, TimeoutsAndLimits, log);
         }
 
         public int Listen(IPEndPoint endpoint)

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -13,6 +13,16 @@ namespace Halibut.Transport.Protocol
 
         Task SendEndAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// When the service is listening, the listening service will block on this call waiting for
+        /// the client to send the control message "NEXT". For listening this is the point in the protocol
+        /// at which pooled connections will wait at.
+        /// 
+        /// Note for a polling service, it is the client which waits for the "NEXT" control message
+        /// which is sent by the service immediately after sending the response.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         Task<bool> ExpectNextOrEndAsync(CancellationToken cancellationToken);
 
         Task ExpectProceedAsync(CancellationToken cancellationToken);
@@ -25,7 +35,7 @@ namespace Halibut.Transport.Protocol
 
         Task SendAsync<T>(T message, CancellationToken cancellationToken);
 
-        Task<RequestMessage> ReceiveRequestAsync(CancellationToken cancellationToken);
+        Task<RequestMessage> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken);
         Task<ResponseMessage> ReceiveResponseAsync(CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -186,8 +186,12 @@ namespace Halibut.Transport.Protocol
             log.Write(EventType.Diagnostic, "Sent: {0}", message);
         }
 
-        public async Task<RequestMessage> ReceiveRequestAsync(CancellationToken cancellationToken)
+        public async Task<RequestMessage> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
         {
+            await stream.WithReadTimeout(
+                timeoutForReceivingTheFirstByte,
+                async () => await stream.WaitForDataToBeAvailableAsync(cancellationToken));
+            
             return await ReceiveAsync<RequestMessage>(cancellationToken);
         }
 


### PR DESCRIPTION
# Background

[[SC-59505]]

Adds timeout:
```
        /// <summary>
        ///     Amount of time the polling service will wait for a request from an RPC call.
        ///     Specifically the amount of time to wait for the first byte of the request to arrive.
        ///
        ///     This value must never be less than the PollingQueueWaitTimeout, of the client, since this
        ///     is the timeout of the long poll the polling service makes to the client to get the next request.
        ///
        ///     Currently set to 10 minutes as that is what the timeout used to be. 
        /// </summary>
        public TimeSpan TcpClientReceiveRequestTimeoutForPolling { get; set; } = TimeSpan.FromMinutes(10);
```

Which will allow as to reduce the time the polling service will wait for the beginning of a `Response` message to be received since we know the polling queue will send `null` messages every `30s` if it has no Requests to make. This makes it possible to have the service more readily  detect a stalled connection.

This value only makes sense to be set in the polling service.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
