### PR TITLE
Add timeouts for auth and identification

### DIFF
--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -31,6 +31,7 @@ namespace Halibut.Tests
                     sendTimeout: TimeSpan.FromSeconds(15), 
                     receiveTimeout: TimeSpan.FromSeconds(15)),
                 
+                TcpClientAuthenticationAndIdentificationTimeouts = new(sendTimeout: TimeSpan.FromSeconds(15), receiveTimeout: TimeSpan.FromSeconds(15)),
                 TcpClientConnectTimeout = TimeSpan.FromSeconds(20),
                 PollingQueueWaitTimeout = TimeSpan.FromSeconds(20)
             };

--- a/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
@@ -12,6 +12,7 @@ namespace Halibut.Tests.Support
             halibutTimeoutsAndLimits.TcpClientHeartbeatTimeout  = new(timeSpan, timeSpan);
             halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout = timeSpan;
             halibutTimeoutsAndLimits.TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = timeSpan;
+            halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts = new(timeSpan, timeSpan);
 
             return halibutTimeoutsAndLimits;
         }

--- a/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
+++ b/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Halibut.Diagnostics;
 using Halibut.Tests.Builders;
 using Halibut.Tests.Support;
+using Halibut.Tests.Support.PortForwarding;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
@@ -37,7 +38,9 @@ namespace Halibut.Tests.Timeouts
             var dataTransferObserverDoNothing = new DataTransferObserverBuilder().Build();
 
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build().WithAllTcpTimeoutsTo(TimeSpan.FromMinutes(20));
-            halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts = new SendReceiveTimeout(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+            halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts = new SendReceiveTimeout(TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(6));
+            
+            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
             
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
@@ -47,6 +50,7 @@ namespace Halibut.Tests.Timeouts
                                if(onClientToOrigin) return new BiDirectionalDataTransferObserver(dataTransferObserverPauser,dataTransferObserverDoNothing);
                                return new BiDirectionalDataTransferObserver(dataTransferObserverDoNothing, dataTransferObserverPauser);
                            })
+                           .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
                            .Build())
                        .WithPendingRequestQueueFactory(logFactory => new FuncPendingRequestQueueFactory(uri => new PendingRequestQueueBuilder()
                            .WithLog(logFactory.ForEndpoint(uri))
@@ -58,14 +62,26 @@ namespace Halibut.Tests.Timeouts
             {
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(IncreasePollingQueueTimeout);
                 var sw = Stopwatch.StartNew();
-                try
+                if (clientAndServiceTestCase.ServiceConnectionType == ServiceConnectionType.Listening)
                 {
-                    await echo.SayHelloAsync("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
+                    // Under listening we will always see the connection fail through the request.
+                    try
+                    {
+                        await echo.SayHelloAsync("Make a request to make sure the connection is running, and ready. Lets not measure SSL setup cost.");
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Information(e, "An exception was raised during the request, this is not an issue since we are concerned about the timings. " +
+                                              "Exceptions only occur occasionally and probably only on listening.");
+                    }
                 }
-                catch (Exception e)
+                else
                 {
-                    Logger.Information(e, "An exception was raised during the request, this is not an issue since we are concerned about the timings. " +
-                                          "Exceptions only occur occasionally and probably only on listening.");
+                    // For polling we can end up in a state in which we do pull something of the queue because the client is
+                    // happy with the service and moves on to getting stuff out of the queue, however the service is still waiting
+                    // to authentice the client but can't since the TCP connection is paused. 
+                    // So instead lets count created TCP connections.
+                    Wait.UntilActionSucceeds(() => tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().BeGreaterThanOrEqualTo(2), TimeSpan.FromSeconds(30), Logger, CancellationToken);
                 }
 
                 sw.Stop();
@@ -81,6 +97,7 @@ namespace Halibut.Tests.Timeouts
             // We don't want to measure the polling queue timeouts.
             point.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromMinutes(10);
             point.PollingRequestQueueTimeout = TimeSpan.FromMinutes(10);
+            point.RetryCountLimit = 1;
         }
     }
 }

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -68,6 +68,13 @@ namespace Halibut.Diagnostics
         ///     Amount of time to wait for a TCP or SslStream read/write to complete successfully for a control message
         /// </summary>
         public SendReceiveTimeout TcpClientHeartbeatTimeout { get; set; } = new(sendTimeout: TimeSpan.FromSeconds(60), receiveTimeout: TimeSpan.FromSeconds(60));
+
+        /// <summary>
+        ///    Timeout for read/writes during the the authentication and identification phase of communication.
+        ///
+        ///    Currently set to 10 minutes as this was the previous value, a value similar to TcpClientHeartbeatTimeout is recommended.
+        /// </summary>
+        public SendReceiveTimeout TcpClientAuthenticationAndIdentificationTimeouts { get; set; } = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10));
         
         /// <summary>
         ///     Amount of time to wait for a successful TCP or WSS connection

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -56,10 +56,13 @@ namespace Halibut.Transport.Protocol
 
         async Task SendIdentityMessageAsync(string identityLine, CancellationToken cancellationToken)
         {
-            // The identity line and the additional empty line must be sent together as a single write operation when using a stream to mimic the 
-            // buffering behaviour of the StreamWriter. When sent as 2 writes to the Stream, old Halibut Services e.g. 4.4.8 will often fail when reading the identity line.
-            await stream.WriteControlLineAsync(identityLine + StreamExtensionMethods.ControlMessageNewLine, cancellationToken);
-            await stream.FlushAsync(cancellationToken);
+            await stream.WithTimeout(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts, async () =>
+            {
+                // The identity line and the additional empty line must be sent together as a single write operation when using a stream to mimic the 
+                // buffering behaviour of the StreamWriter. When sent as 2 writes to the Stream, old Halibut Services e.g. 4.4.8 will often fail when reading the identity line.
+                await stream.WriteControlLineAsync(identityLine + StreamExtensionMethods.ControlMessageNewLine, cancellationToken);
+                await stream.FlushAsync(cancellationToken);
+            });
         }
 
         public async Task SendNextAsync(CancellationToken cancellationToken)

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -127,6 +127,12 @@ namespace Halibut.Transport.Protocol
 
         public async Task<RemoteIdentity> ReadRemoteIdentityAsync(CancellationToken cancellationToken)
         {
+            return await WithTimeout(
+                halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts,
+                async () => await ReadAndParseRemoteIdentityAsync(cancellationToken));
+        }
+        async Task<RemoteIdentity> ReadAndParseRemoteIdentityAsync(CancellationToken cancellationToken)
+        {
             var line = await controlMessageReader.ReadControlMessageAsync(stream, cancellationToken);
             if (string.IsNullOrEmpty(line))
             {

--- a/source/Halibut/Transport/Protocol/StreamTimeoutExtensionMethods.cs
+++ b/source/Halibut/Transport/Protocol/StreamTimeoutExtensionMethods.cs
@@ -97,6 +97,8 @@ namespace Halibut.Transport.Protocol
 
         public static void SetReadAndWriteTimeouts(this Stream stream, SendReceiveTimeout timeout)
         {
+            if(timeout == null) return;
+            
             if (!stream.CanTimeout)
             {
                 return;
@@ -104,6 +106,16 @@ namespace Halibut.Transport.Protocol
 
             stream.WriteTimeout = (int)timeout.SendTimeout.TotalMilliseconds;
             stream.ReadTimeout = (int)timeout.ReceiveTimeout.TotalMilliseconds;
+        }
+        
+        public static SendReceiveTimeout GetReadAndWriteTimeouts(this Stream stream)
+        {
+            if (!stream.CanTimeout)
+            {
+                return null;
+            }
+
+            return new SendReceiveTimeout(sendTimeout: TimeSpan.FromMilliseconds(stream.WriteTimeout), receiveTimeout: TimeSpan.FromMilliseconds(stream.ReadTimeout));
         }
 
         public static void SetReadTimeouts(this Stream stream, TimeSpan timeout)

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -218,6 +218,9 @@ namespace Halibut.Transport
                 await using (Try.CatchingErrorOnDisposal(ssl, ex => log.WriteException(EventType.Diagnostic, "Could not dispose SSL stream", ex)))
                 {
                     log.Write(EventType.SecurityNegotiation, "Performing TLS server handshake");
+                    var previousTimeouts = ssl.GetReadAndWriteTimeouts();
+                    ssl.SetReadAndWriteTimeouts(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts);
+                    
                     await ssl.AuthenticateAsServerAsync(serverCertificate, true, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false).ConfigureAwait(false);
 
                     log.Write(EventType.SecurityNegotiation, "Secure connection established, client is not yet authenticated, client connected with {0}", ssl.SslProtocol.ToString());
@@ -249,6 +252,7 @@ namespace Halibut.Transport
                         connectionsObserver.ConnectionAccepted(true);
                         tcpClientManager.AddActiveClient(thumbprint, client);
                         errorEventType = EventType.Error;
+                        ssl.SetReadAndWriteTimeouts(previousTimeouts);
                         await ExchangeMessages(ssl).ConfigureAwait(false);
                     }
                 }

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -143,7 +143,7 @@ namespace Halibut.Transport
             {
                 var webSocketContext = await listenerContext.AcceptWebSocketAsync("Octopus").ConfigureAwait(false);
                 webSocketStream = streamFactory.CreateStream(webSocketContext.WebSocket);
-                var currentTimeouts = webSocketStream.GetReadAndWriteTimeouts();
+                var previousTimeouts = webSocketStream.GetReadAndWriteTimeouts();
                 webSocketStream.SetReadAndWriteTimeouts(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts);
 
                 var req = await webSocketStream.ReadTextMessage(halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, cts.Token).ConfigureAwait(false);
@@ -170,7 +170,7 @@ namespace Halibut.Transport
                     errorEventType = EventType.Error;
 
                     // Delegate the open stream to the protocol handler - we no longer own the stream lifetime
-                    webSocketStream.SetReadAndWriteTimeouts(currentTimeouts);
+                    webSocketStream.SetReadAndWriteTimeouts(previousTimeouts);
                     await ExchangeMessages(webSocketStream).ConfigureAwait(false);
                 }
             }

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -143,6 +143,8 @@ namespace Halibut.Transport
             {
                 var webSocketContext = await listenerContext.AcceptWebSocketAsync("Octopus").ConfigureAwait(false);
                 webSocketStream = streamFactory.CreateStream(webSocketContext.WebSocket);
+                var currentTimeouts = webSocketStream.GetReadAndWriteTimeouts();
+                webSocketStream.SetReadAndWriteTimeouts(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts);
 
                 var req = await webSocketStream.ReadTextMessage(halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, cts.Token).ConfigureAwait(false);
 
@@ -168,6 +170,7 @@ namespace Halibut.Transport
                     errorEventType = EventType.Error;
 
                     // Delegate the open stream to the protocol handler - we no longer own the stream lifetime
+                    webSocketStream.SetReadAndWriteTimeouts(currentTimeouts);
                     await ExchangeMessages(webSocketStream).ConfigureAwait(false);
                 }
             }

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -37,26 +37,30 @@ namespace Halibut.Transport
             log.Write(EventType.Diagnostic, $"Connection established to {client.Client.RemoteEndPoint} for {serviceEndpoint.BaseUri}");
             
             var networkTimeoutStream = streamFactory.CreateStream(client);
-            client.EnableTcpKeepAlive(halibutTimeoutsAndLimits);
 
-            var ssl = new SslStream(networkTimeoutStream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
+            return await networkTimeoutStream.WithTimeout(this.halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts, async () =>
+            {
+                client.EnableTcpKeepAlive(halibutTimeoutsAndLimits);
 
-            log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
+                var ssl = new SslStream(networkTimeoutStream, false, certificateValidator.Validate, UserCertificateSelectionCallback);
+
+                log.Write(EventType.SecurityNegotiation, "Performing TLS handshake");
 
 #if NETFRAMEWORK
             // TODO: ASYNC ME UP!
             // AuthenticateAsClientAsync in .NET 4.8 does not support cancellation tokens. So `cancellationToken` is not respected here.
             await ssl.AuthenticateAsClientAsync(serviceEndpoint.BaseUri.Host, new X509Certificate2Collection(clientCertificate), SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
 #else
-            await ssl.AuthenticateAsClientEnforcingTimeout(serviceEndpoint, new X509Certificate2Collection(clientCertificate), cancellationToken);
+                await ssl.AuthenticateAsClientEnforcingTimeout(serviceEndpoint, new X509Certificate2Collection(clientCertificate), cancellationToken);
 #endif
 
-            await ssl.WriteAsync(MxLine, 0, MxLine.Length, cancellationToken);
-            await ssl.FlushAsync(cancellationToken);
+                await ssl.WriteAsync(MxLine, 0, MxLine.Length, cancellationToken);
+                await ssl.FlushAsync(cancellationToken);
 
-            log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
+                log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
 
-            return new SecureConnection(client, ssl, exchangeProtocolBuilder, halibutTimeoutsAndLimits, log);
+                return new SecureConnection(client, ssl, exchangeProtocolBuilder, halibutTimeoutsAndLimits, log);
+            });
         }
         
         internal static async Task<TcpClient> CreateConnectedTcpClientAsync(ServiceEndPoint endPoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, IStreamFactory streamFactory, ILog log, CancellationToken cancellationToken)


### PR DESCRIPTION
# Background

[SC-65303]

Adds:
```
        /// <summary>
        ///    Timeout for read/writes during the the authentication and identification phase of communication.
        ///
        ///    Currently set to 10 minutes as this was the previous value, a value similar to TcpClientHeartbeatTimeout is recommended.
        /// </summary>
        public SendReceiveTimeout TcpClientAuthenticationAndIdentificationTimeouts { get; set; } = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10));
```

Which applies during:
* SSL handshake
* thumbprint verification
* exchange  of MX control messages.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
