### PR TITLE
Adding a test to ensure data streams respect TcpClientReceiveResponseTransmissionAfterInitialReadTimeout

### DIFF
--- a/source/Halibut.TestUtils.CompatBinary.v5_0_236/Halibut.TestUtils.CompatBinary.v5_0_236.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_236/Halibut.TestUtils.CompatBinary.v5_0_236.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
-        <RootNamespace>Halibut.TestUtils.SampleProgram.v5_0_237</RootNamespace>
+        <RootNamespace>Halibut.TestUtils.SampleProgram.v5_0_236</RootNamespace>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_236/Program.cs
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_236/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Halibut.TestUtils.SampleProgram.Base;
 
-namespace Halibut.TestUtils.SampleProgram.v5_0_237
+namespace Halibut.TestUtils.SampleProgram.v5_0_236
 {
     public class Program
     {

--- a/source/Halibut.Tests/Timeouts/ReceiveResponseTimeoutTests.cs
+++ b/source/Halibut.Tests/Timeouts/ReceiveResponseTimeoutTests.cs
@@ -9,11 +9,12 @@ using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.TestServices.Async;
+using Halibut.Tests.Util;
 using Halibut.TestUtils.Contracts;
 using NUnit.Framework;
 using Octopus.TestPortForwarder;
 
-namespace Halibut.Tests
+namespace Halibut.Tests.Timeouts
 {
     public class ReceiveResponseTimeoutTests : BaseTest
     {
@@ -21,14 +22,11 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
         public async Task WhenRpcExecutionExceedsReceiveResponseTimeout_ThenInitialDataReadShouldTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits
-            {
-                TcpClientReceiveResponseTimeout = TimeSpan.FromMilliseconds(100),
-                // Ensure subsequent reads do not trigger timeouts
-                TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = TimeSpan.FromHours(1)
-            };
-
             // Arrange
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
+            halibutTimeoutsAndLimits.WithAllTcpTimeoutsTo(TimeSpan.FromHours(1));
+            halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout = TimeSpan.FromMilliseconds(100);
+            
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                              .AsLatestClientAndLatestServiceBuilder()
                              .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
@@ -50,19 +48,16 @@ namespace Halibut.Tests
         public async Task WhenRpcExecutionIsWithinReceiveResponseTimeout_ButSubsequentDataIsDelayed_ThenTimeoutShouldOccur(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             // Arrange
-            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits
-            {
-                // Ensure execution time does not trigger timeouts
-                TcpClientReceiveResponseTimeout = TimeSpan.FromHours(1),
-                TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = TimeSpan.FromMilliseconds(100)
-            };
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
+            halibutTimeoutsAndLimits.WithAllTcpTimeoutsTo(TimeSpan.FromHours(1));
+            halibutTimeoutsAndLimits.TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = TimeSpan.FromMilliseconds(100);
 
             var enoughDataToCauseMultipleReadOperations = Enumerable.Range(0, 1024 * 1024)
                 .Select(_ => Guid.NewGuid().ToString())
                 .ToList();
-            
+
             var listService = new AsyncListService(enoughDataToCauseMultipleReadOperations);
-            
+
             var dataTransferObserver = new DataTransferObserverBuilder()
                 .WithWritingDataObserver((_, _) =>
                 {
@@ -87,6 +82,35 @@ namespace Halibut.Tests
 
                 // Act
                 (await AssertionExtensions.Should(() => lastServiceClient.GetListAsync()).ThrowAsync<HalibutClientException>())
+                    .And.Message.Should().ContainAny(
+                        "Connection timed out.",
+                        "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
+            }
+        }
+        
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false)]
+        public async Task WhenRpcExecutionIsWithinReceiveResponseTimeout_ButDataStreamDataIsDelayed_ThenTimeoutShouldOccur(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
+            halibutTimeoutsAndLimits.WithAllTcpTimeoutsTo(TimeSpan.FromHours(1));
+            halibutTimeoutsAndLimits.TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = TimeSpan.FromSeconds(1);
+
+            // Arrange
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                             .WithPortForwarding(out var portForwarderRef)
+                             .WithReturnSomeDataStreamService(() => DataStreamUtil.From(
+                                 firstSend: "hello",
+                                 andThenRun: portForwarderRef.Value!.PauseExistingConnections,
+                                 thenSend: "All done"))
+                             .Build(CancellationToken))
+            {
+                var returnDataStreamService = clientAndService.CreateAsyncClient<IReturnSomeDataStreamService, IAsyncClientReturnSomeDataStreamService>();
+
+                // Act
+                (await AssertionExtensions.Should(() => returnDataStreamService.SomeDataStreamAsync()).ThrowAsync<HalibutClientException>())
                     .And.Message.Should().ContainAny(
                         "Connection timed out.",
                         "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");


### PR DESCRIPTION
[sc-42848]

# Background

We wanted to make sure data streams respected the new `TcpClientReceiveResponseTransmissionAfterInitialReadTimeout`. Turns out they did. So let's write a test to prove it.

The data streams work because `MessageExchangeStream.ReceiveResponseAsync` calls `ReceiveAsync` using the new timeouts, and `ReceiveAsync` calls `ReadStreamsAsync`. So the timeouts are in place already.

```
public async Task<ResponseMessage> ReceiveResponseAsync(CancellationToken cancellationToken)
{
    // Wait for data to become available using existing timeouts, then once we have data streaming in, use the smaller timeout (so we do not wait as long if an error happens here).
    await stream.WithReadTimeout(
        halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout,
        async () => await stream.WaitForDataToBeAvailableAsync(cancellationToken));

    return await stream.WithReadTimeout(
        halibutTimeoutsAndLimits.TcpClientReceiveResponseTransmissionAfterInitialReadTimeout,
        async () => await ReceiveAsync<ResponseMessage>(cancellationToken));
}

async Task<T> ReceiveAsync<T>(CancellationToken cancellationToken)
{
    var (result, dataStreams) = await serializer.ReadMessageAsync<T>(stream, cancellationToken);
    await ReadStreamsAsync(dataStreams, cancellationToken);
    log.Write(EventType.Diagnostic, "Received: {0}", result);
    return result;
}
```

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
