### PR TITLE
Reduce timeouts on sending and receiving some control messages

### DIFF
--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -31,7 +31,7 @@ namespace Halibut.Tests
                     sendTimeout: TimeSpan.FromSeconds(15), 
                     receiveTimeout: TimeSpan.FromSeconds(15)),
                 
-                TcpClientAuthenticationAndIdentificationTimeouts = new(sendTimeout: TimeSpan.FromSeconds(15), receiveTimeout: TimeSpan.FromSeconds(15)),
+                TcpClientAuthenticationAndIdentificationTimeouts = new(sendTimeout: TimeSpan.FromSeconds(20), receiveTimeout: TimeSpan.FromSeconds(20)),
                 TcpClientConnectTimeout = TimeSpan.FromSeconds(20),
                 PollingQueueWaitTimeout = TimeSpan.FromSeconds(20),
                 TcpClientReceiveRequestTimeoutForPolling = TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(10)

--- a/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
@@ -313,7 +313,7 @@ namespace Halibut.Tests.Transport.Protocol
                 output.AppendLine("--> END");
             }
 
-            public async Task<bool> ExpectNextOrEndAsync(CancellationToken cancellationToken)
+            public async Task<bool> ExpectNextOrEndAsync(TimeSpan readTimeout, CancellationToken cancellationToken)
             {
                 await Task.CompletedTask;
 

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -79,7 +79,7 @@ namespace Halibut.Diagnostics
         
         /// <summary>
         ///     Amount of time to wait for a TCP or SslStream read/write to complete successfully for a control message
-        ///     This applies only to NEXT/PROCEED/EMD control messages, and not for the NEXT control message for a
+        ///     This applies only to NEXT/PROCEED/END control messages, and not for the NEXT control message for a
         ///     listening service. 
         /// </summary>
         public SendReceiveTimeout TcpClientHeartbeatTimeout { get; set; } = new(sendTimeout: TimeSpan.FromSeconds(60), receiveTimeout: TimeSpan.FromSeconds(60));

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -79,6 +79,8 @@ namespace Halibut.Diagnostics
         
         /// <summary>
         ///     Amount of time to wait for a TCP or SslStream read/write to complete successfully for a control message
+        ///     This applies only to NEXT/PROCEED/EMD control messages, and not for the NEXT control message for a
+        ///     listening service. 
         /// </summary>
         public SendReceiveTimeout TcpClientHeartbeatTimeout { get; set; } = new(sendTimeout: TimeSpan.FromSeconds(60), receiveTimeout: TimeSpan.FromSeconds(60));
 
@@ -88,6 +90,11 @@ namespace Halibut.Diagnostics
         ///    Currently set to 10 minutes as this was the previous value, a value similar to TcpClientHeartbeatTimeout is recommended.
         /// </summary>
         public SendReceiveTimeout TcpClientAuthenticationAndIdentificationTimeouts { get; set; } = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10));
+        
+        /// <summary>
+        ///     When true the TcpClientHeartbeatTimeout is used in all places it can be.
+        /// </summary>
+        public bool TcpClientHeartbeatTimeoutShouldActuallyBeUsed { get; set; } = false;
         
         /// <summary>
         ///     Amount of time to wait for a successful TCP or WSS connection

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -12,7 +12,7 @@ namespace Halibut.Transport.Protocol
         Task SendProceedAsync(CancellationToken cancellationToken);
 
         Task SendEndAsync(CancellationToken cancellationToken);
-
+        
         /// <summary>
         /// When the service is listening, the listening service will block on this call waiting for
         /// the client to send the control message "NEXT". For listening this is the point in the protocol
@@ -23,7 +23,7 @@ namespace Halibut.Transport.Protocol
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<bool> ExpectNextOrEndAsync(CancellationToken cancellationToken);
+        Task<bool> ExpectNextOrEndAsync(TimeSpan readTimeout, CancellationToken cancellationToken);
 
         Task ExpectProceedAsync(CancellationToken cancellationToken);
 

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -241,6 +241,9 @@ namespace Halibut.Transport.Protocol
 
             try
             {
+                // The polling service will send the "NEXT" control message immediately after it has sent the response.
+                // Thus the NEXT control message is likely to have already arrived or will arrive in a very short amount
+                // of time
                 var receiveTimeout = halibutTimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout;
                 if (!halibutTimeoutsAndLimits.TcpClientHeartbeatTimeoutShouldActuallyBeUsed)
                 {

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -74,7 +74,15 @@ namespace Halibut.Transport.Protocol
 
         public async Task SendProceedAsync(CancellationToken cancellationToken)
         {
-            await SendControlMessageAsync(Proceed, cancellationToken);
+            var sendTimeout = this.stream.GetReadAndWriteTimeouts();
+            if (halibutTimeoutsAndLimits.TcpClientHeartbeatTimeoutShouldActuallyBeUsed)
+            {
+                sendTimeout = halibutTimeoutsAndLimits.TcpClientHeartbeatTimeout;
+            }
+            
+            await WithTimeout(
+                sendTimeout,
+                async () => await SendControlMessageAsync(Proceed, cancellationToken));
         }
 
         public async Task SendEndAsync(CancellationToken cancellationToken)

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -84,9 +84,9 @@ namespace Halibut.Transport.Protocol
                 async () => await SendControlMessageAsync(End, cancellationToken));
         }
 
-        public async Task<bool> ExpectNextOrEndAsync(CancellationToken cancellationToken)
+        public async Task<bool> ExpectNextOrEndAsync(TimeSpan readTimeout, CancellationToken cancellationToken)
         {
-            var line = await controlMessageReader.ReadUntilNonEmptyControlMessageAsync(stream, cancellationToken);
+            var line = await stream.WithReadTimeout(readTimeout, async () => await controlMessageReader.ReadUntilNonEmptyControlMessageAsync(stream, cancellationToken));
     
             return line switch
             {


### PR DESCRIPTION
# Background

* Timeout for the polling client reading the `NEXT` control message can now use the heart beat timeout if enabled.
* Timeout for sending `PROCEED` control message can now use the heart beat timeout if enabled.

Neither of those operations should take 10 minutes to run.

Also increase the auth timeouts in tests, since when running `64` tests in parallel locally while building octopus server I would sometimes timeouts in the auth stage.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

Is it possible to test these timeouts?

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
