### PR TITLE
Consolidate timeouts

### DIFF
--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -23,18 +23,18 @@ namespace Halibut.Tests
                 TcpClientTimeout = new(
                     sendTimeout: TcpReceiveTimeout, 
                     receiveTimeout: TcpReceiveTimeout),
+                TcpListeningNextRequestIdleTimeout = TcpReceiveTimeout,
 
                 TcpClientReceiveResponseTimeout = TcpReceiveTimeout,
-                TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = TcpReceiveTimeout,
 
                 TcpClientHeartbeatTimeout = new(
-                    sendTimeout: TimeSpan.FromSeconds(15), 
+                    sendTimeout: TimeSpan.FromSeconds(15),
                     receiveTimeout: TimeSpan.FromSeconds(15)),
                 
-                TcpClientAuthenticationAndIdentificationTimeouts = new(sendTimeout: TimeSpan.FromSeconds(20), receiveTimeout: TimeSpan.FromSeconds(20)),
                 TcpClientConnectTimeout = TimeSpan.FromSeconds(20),
                 PollingQueueWaitTimeout = TimeSpan.FromSeconds(20),
-                TcpClientReceiveRequestTimeoutForPolling = TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(10)
+                TcpClientReceiveRequestTimeoutForPolling = TimeSpan.FromSeconds(20) + TimeSpan.FromSeconds(10),
+                TcpClientHeartbeatTimeoutShouldActuallyBeUsed = true
             };
         }
     }

--- a/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutTimeoutsAndLimitsExtensionMethods.cs
@@ -11,8 +11,7 @@ namespace Halibut.Tests.Support
             halibutTimeoutsAndLimits.TcpClientTimeout = new(timeSpan, timeSpan);
             halibutTimeoutsAndLimits.TcpClientHeartbeatTimeout  = new(timeSpan, timeSpan);
             halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout = timeSpan;
-            halibutTimeoutsAndLimits.TcpClientReceiveResponseTransmissionAfterInitialReadTimeout = timeSpan;
-            halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts = new(timeSpan, timeSpan);
+            halibutTimeoutsAndLimits.TcpListeningNextRequestIdleTimeout = timeSpan;
             halibutTimeoutsAndLimits.TcpClientReceiveRequestTimeoutForPolling = timeSpan;
             return halibutTimeoutsAndLimits;
         }

--- a/source/Halibut.Tests/Timeouts/ReceiveResponseTimeoutTests.cs
+++ b/source/Halibut.Tests/Timeouts/ReceiveResponseTimeoutTests.cs
@@ -50,7 +50,7 @@ namespace Halibut.Tests.Timeouts
             // Arrange
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
             halibutTimeoutsAndLimits.WithAllTcpTimeoutsTo(TimeSpan.FromHours(1));
-            halibutTimeoutsAndLimits.TcpClientTimeout = new SendReceiveTimeout(sendTimeout:TimeSpan.FromHours(1), TimeSpan.FromMilliseconds(100));
+            halibutTimeoutsAndLimits.TcpClientTimeout = new SendReceiveTimeout(sendTimeout:TimeSpan.FromHours(1), TimeSpan.FromSeconds(10));
 
             var enoughDataToCauseMultipleReadOperations = Enumerable.Range(0, 1024 * 1024)
                 .Select(_ => Guid.NewGuid().ToString())
@@ -64,6 +64,7 @@ namespace Halibut.Tests.Timeouts
                     if (listService.WasCalled)
                     {
                         //Sleep for < TcpClientReceiveResponseTimeout to pass initial data receipt, but > TcpClientReceiveResponseTransmissionAfterInitialReadTimeout for timeout.
+                        Thread.Sleep(halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout);
                         Thread.Sleep(1000);
                     }
                 })
@@ -94,7 +95,7 @@ namespace Halibut.Tests.Timeouts
         {
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
             halibutTimeoutsAndLimits.WithAllTcpTimeoutsTo(TimeSpan.FromHours(1));
-            halibutTimeoutsAndLimits.TcpClientTimeout = new SendReceiveTimeout(sendTimeout:TimeSpan.FromHours(1), TimeSpan.FromMilliseconds(100));
+            halibutTimeoutsAndLimits.TcpClientTimeout = new SendReceiveTimeout(sendTimeout:TimeSpan.FromHours(1), TimeSpan.FromSeconds(10));
 
             // Arrange
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()

--- a/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
+++ b/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
@@ -38,7 +38,7 @@ namespace Halibut.Tests.Timeouts
             var dataTransferObserverDoNothing = new DataTransferObserverBuilder().Build();
 
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build().WithAllTcpTimeoutsTo(TimeSpan.FromMinutes(20));
-            halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts = new SendReceiveTimeout(TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(6));
+            halibutTimeoutsAndLimits.TcpClientTimeout = new SendReceiveTimeout(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
             
             TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
             
@@ -86,7 +86,7 @@ namespace Halibut.Tests.Timeouts
 
                 sw.Stop();
                 sw.Elapsed.Should()
-                    .BeCloseTo(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts.ReceiveTimeout, TimeSpan.FromSeconds(15), "Since a paused connection early on should not hang forever.");
+                    .BeCloseTo(halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, TimeSpan.FromSeconds(15), "Since a paused connection early on should not hang forever.");
 
                 await echo.SayHelloAsync("The pump wont be paused here so this should work.");
             }

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -45,7 +45,14 @@ namespace Halibut.Diagnostics
         public int RewindableBufferStreamSize { get; set; } = 8192;
 
         /// <summary>
-        ///     Amount of time to wait for a TCP or SslStream read/write to complete successfully
+        /// Amount of time to wait for a TCP read/write to complete successfully.
+        ///
+        /// This Timeout is used when no other more specific timeout applies.
+        /// 
+        /// This applies to:
+        /// - Initial authentication and identification
+        /// - Sending and receiving of Request/Response messages, except for the first byte in some instances.
+        /// - Sending/receiving data streams. 
         /// </summary>
         public SendReceiveTimeout TcpClientTimeout { get; set; } = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10));
 

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -169,7 +169,8 @@ namespace Halibut.Diagnostics
         {
             return new HalibutTimeoutsAndLimits()
             {
-                TcpClientTimeout = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10)),
+                // In general all writes/read calls should take less than a minute.
+                TcpClientTimeout = new(sendTimeout: TimeSpan.FromMinutes(1), receiveTimeout: TimeSpan.FromMinutes(1)),
                 TcpClientReceiveResponseTimeout = TimeSpan.FromMinutes(5), // ~ 5 minutes to execute a RPC call
                 TcpClientReceiveRequestTimeoutForPolling = new HalibutTimeoutsAndLimits().PollingQueueWaitTimeout + TimeSpan.FromSeconds(30),
                 TcpClientHeartbeatTimeoutShouldActuallyBeUsed = true

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -50,9 +50,9 @@ namespace Halibut.Diagnostics
         public SendReceiveTimeout TcpClientTimeout { get; set; } = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10));
 
         /// <summary>
-        ///     Amount of time to wait for a response from an RPC call.
-        /// 
-        ///     Specifically the amount of time to wait for the first byte of the request to arrive.
+        ///    Approximately the amount of time the service can take to execute the RPC call.
+        ///    
+        ///    Specifically the amount of time to wait for the first byte of the response to arrive.
         /// </summary>
         public TimeSpan TcpClientReceiveResponseTimeout { get; set; } = TimeSpan.FromMinutes(10);
         
@@ -68,15 +68,22 @@ namespace Halibut.Diagnostics
         public TimeSpan TcpClientReceiveRequestTimeoutForPolling { get; set; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
-        ///     Amount of time to wait when receiving a response from an RPC call, after data has started being received.
-        /// </summary>
-        public TimeSpan TcpClientReceiveResponseTransmissionAfterInitialReadTimeout { get; set; } = TimeSpan.FromMinutes(10);
-
-        /// <summary>
         ///     Amount of time a connection can stay in the pool
         /// </summary>
         public TimeSpan TcpClientPooledConnectionTimeout { get; set; } = TimeSpan.FromMinutes(9);
         
+        /// <summary>
+        /// The duration that the listening service will wait for the next request (specifically the
+        /// control message NEXT) before closing the connection.
+        ///
+        /// The default is ten minutes, and so the service on an existing TCP connection will wait ten
+        /// minutes for another request before "idling out" and closing the connection.
+        ///
+        /// Connections can be kept idle in the pool (client side) for no more than this timeout, thus 
+        /// TcpClientPooledConnectionTimeout ought to be less than this.
+        /// </summary>
+        public TimeSpan TcpListeningNextRequestIdleTimeout { get; set; } = TimeSpan.FromMinutes(10);
+
         /// <summary>
         ///     Amount of time to wait for a TCP or SslStream read/write to complete successfully for a control message
         ///     This applies only to NEXT/PROCEED/END control messages, and not for the NEXT control message for a
@@ -85,14 +92,8 @@ namespace Halibut.Diagnostics
         public SendReceiveTimeout TcpClientHeartbeatTimeout { get; set; } = new(sendTimeout: TimeSpan.FromSeconds(60), receiveTimeout: TimeSpan.FromSeconds(60));
 
         /// <summary>
-        ///    Timeout for read/writes during the the authentication and identification phase of communication.
-        ///
-        ///    Currently set to 10 minutes as this was the previous value, a value similar to TcpClientHeartbeatTimeout is recommended.
-        /// </summary>
-        public SendReceiveTimeout TcpClientAuthenticationAndIdentificationTimeouts { get; set; } = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10));
-        
-        /// <summary>
         ///     When true the TcpClientHeartbeatTimeout is used in all places it can be.
+        ///     Will be removed in the future.
         /// </summary>
         public bool TcpClientHeartbeatTimeoutShouldActuallyBeUsed { get; set; } = false;
         
@@ -108,25 +109,27 @@ namespace Halibut.Diagnostics
         /// </summary>
         public TimeSpan PollingQueueWaitTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
-
         // After a client/server message exchange is complete, the client returns
-        // the connection to the pool but the server continues to block and reads
-        // from the connection until the TcpClientReceiveTimeout.
+        // the connection to the pool but the service continues to block and reads
+        // from the connection until the TcpListeningNextRequestIdleTimeout.
         // If TcpClientPooledConnectionTimeout is greater than TcpClientReceiveTimeout
         // when the client goes to the pool to get a connection for the next
         // exchange it can get one that has timed out, so make sure our pool
         // timeout is smaller than the tcp timeout.
+        // Note that if a timed out connection is picked up, the control messages initially
+        // sent in the exchange will detect the dead connection resulting in a new connection
+        // created for the request.
         public TimeSpan SafeTcpClientPooledConnectionTimeout
         {
             get
             {
-                if (TcpClientPooledConnectionTimeout < TcpClientTimeout.ReceiveTimeout)
+                if (TcpClientPooledConnectionTimeout < TcpListeningNextRequestIdleTimeout)
                 {
                     return TcpClientPooledConnectionTimeout;
                 }
 
-                var timeout = TcpClientTimeout.ReceiveTimeout - TimeSpan.FromSeconds(10);
-                return timeout > TimeSpan.Zero ? timeout : TcpClientTimeout.ReceiveTimeout;
+                var timeout = TcpListeningNextRequestIdleTimeout - TimeSpan.FromSeconds(10);
+                return timeout > TimeSpan.Zero ? timeout : TcpListeningNextRequestIdleTimeout;
             }
         }
 
@@ -149,5 +152,21 @@ namespace Halibut.Diagnostics
         /// The duration a TCP connection will wait for a keepalive response before sending another keepalive probe.
         /// </summary>
         public TimeSpan TcpKeepAliveInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+        
+        /// <summary>
+        /// In the future these will become the default
+        /// </summary>
+        /// <returns></returns>
+        public static HalibutTimeoutsAndLimits RecommendedValues()
+        {
+            return new HalibutTimeoutsAndLimits()
+            {
+                TcpClientTimeout = new(sendTimeout: TimeSpan.FromMinutes(10), receiveTimeout: TimeSpan.FromMinutes(10)),
+                TcpClientReceiveResponseTimeout = TimeSpan.FromMinutes(5), // ~ 5 minutes to execute a RPC call
+                TcpClientReceiveRequestTimeoutForPolling = new HalibutTimeoutsAndLimits().PollingQueueWaitTimeout + TimeSpan.FromSeconds(30),
+                TcpClientHeartbeatTimeoutShouldActuallyBeUsed = true
+            };
+        }
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -160,7 +160,7 @@ namespace Halibut.Transport.Protocol
             {
                 // This timeout is probably too high since we know that we either just send identification control messages
                 // or we just sent NEXT and PROCEED control messages.
-                var request = await stream.ReceiveRequestAsync(halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, cancellationToken);
+                var request = await stream.ReceiveRequestAsync(halibutTimeoutsAndLimits.TcpListeningNextRequestIdleTimeout, cancellationToken);
 
                 if (request == null || !acceptClientRequests)
                 {

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -218,9 +218,7 @@ namespace Halibut.Transport
                 await using (Try.CatchingErrorOnDisposal(ssl, ex => log.WriteException(EventType.Diagnostic, "Could not dispose SSL stream", ex)))
                 {
                     log.Write(EventType.SecurityNegotiation, "Performing TLS server handshake");
-                    var previousTimeouts = ssl.GetReadAndWriteTimeouts();
-                    ssl.SetReadAndWriteTimeouts(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts);
-                    
+
                     await ssl.AuthenticateAsServerAsync(serverCertificate, true, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false).ConfigureAwait(false);
 
                     log.Write(EventType.SecurityNegotiation, "Secure connection established, client is not yet authenticated, client connected with {0}", ssl.SslProtocol.ToString());
@@ -252,7 +250,6 @@ namespace Halibut.Transport
                         connectionsObserver.ConnectionAccepted(true);
                         tcpClientManager.AddActiveClient(thumbprint, client);
                         errorEventType = EventType.Error;
-                        ssl.SetReadAndWriteTimeouts(previousTimeouts);
                         await ExchangeMessages(ssl).ConfigureAwait(false);
                     }
                 }

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -143,8 +143,6 @@ namespace Halibut.Transport
             {
                 var webSocketContext = await listenerContext.AcceptWebSocketAsync("Octopus").ConfigureAwait(false);
                 webSocketStream = streamFactory.CreateStream(webSocketContext.WebSocket);
-                var previousTimeouts = webSocketStream.GetReadAndWriteTimeouts();
-                webSocketStream.SetReadAndWriteTimeouts(halibutTimeoutsAndLimits.TcpClientAuthenticationAndIdentificationTimeouts);
 
                 var req = await webSocketStream.ReadTextMessage(halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, cts.Token).ConfigureAwait(false);
 
@@ -170,7 +168,6 @@ namespace Halibut.Transport
                     errorEventType = EventType.Error;
 
                     // Delegate the open stream to the protocol handler - we no longer own the stream lifetime
-                    webSocketStream.SetReadAndWriteTimeouts(previousTimeouts);
                     await ExchangeMessages(webSocketStream).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
# Background

Rather than have a timeout for every operation in Halibut, split out the special timeouts and let the rest be covered by `TcpClientTimeout`.

This adds a new timeout `TcpListeningNextRequestIdleTimeout` which is the amount of time the listening service will wait for another request to be sent to it before timing out and closing the TCP connection. Previously it was set to `TcpClientTimeout`

Adds a `RecommendedValues()` which returns the recommended values for `HalibutTimeoutsAndLimits`.

some test timeouts are bumped since those low timeouts apply in more places and so increase the chance of failure.
 
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

Read the `[HalibutTimeoutsAndLimits.cs](https://github.com/OctopusDeploy/Halibut/pull/553/files#diff-75aab142e5800f7b568155e3b13e51d403fb29773dc6a6872341943fae8f9821)` top to bottom and see if it makes sense.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
