### PR TITLE
Update System.Configuration.ConfigurationManager library

### DIFF
--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -36,13 +36,12 @@
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
     <PackageReference Include="NetCoreStack.DispatchProxyAsync" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
# Background

A customer is [reporting](https://octopus.zendesk.com/agent/tickets/158875) packages vulnerable to [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112) are turning up on their security scanning. The affected package is `System.Drawing.Common`. 

We don't reference `System.Drawing.Common` directly in Halibut. It is a transitive dependency through `System.Configuration.ConfigurationManager`. In Halibut, we also don't directly use `System.Configuration.ConfigurationManager`. It is transitively referenced via `System.Runtime.Caching`. 

**The vulnerability is not exploitable because we are not using the affected versions of .NET Core/Mono.**

# Results

Fixing this has required two changes: 

I've removed the direct reference to `System.Configuration.ConfigurationManager` as we aren't using it anywhere in Halibut. 

The Config Manager is referenced by `System.Runtime.Caching`, which we do use to cache certain requests at the transport layer. I've upgraded `System.Runtime.Caching` from 5.0.0 to 8.0.0. This also upgrades `System.Configuration.ConfigurationManager` from 5.0.0 to 8.0.0. At some point in those changes, the Config Manager library no longer references the `System.Drawing.Common` library which removes the vulnerable package.

Doing this will remove one of the transitive dependencies Tentacle has on `System.Drawing.Common` - see [this issue](https://github.com/OctopusDeploy/OctopusTentacle/issues/689).

Some vulnerable versions remain inside Halibut - but those are in projects that are not included in the Production build of Halibut, specifically various Test and Build projects. I haven't upgraded those at this point because I want to keep the set of changes required to fix the Production side of this as streamlined as possible. Turning on auto-updates for dependencies will ensure these get fixed in a timely manner - that work is currently under way.

Fixes https://github.com/OctopusDeploy/Halibut/issues/555


## Before

`System.Drawing.Common` 5.0.0 is implicitly referenced in the Halibut project. 

![image](https://github.com/OctopusDeploy/Halibut/assets/6320469/eb52eb6a-04d2-4a65-88b3-c4a6e52d4727)



## After
The only implicit references to `System.Drawing.Common` are in non-production projects.

![image](https://github.com/OctopusDeploy/Halibut/assets/6320469/6d47b682-1083-42b7-a460-df17a04e5f53)



# How to review this PR

Any thoughts on removing the explicit reference to `System.Configuration.ConfigurationManager`? I think this makes it tidier but open to discussion.

Quality :heavy_check_mark:

We have a decent set of tests around the caching where we use `System.Runtime.Caching`, so it's likely we'd catch any changes in behaviour.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
