### PR TITLE
Capture the inner exception type for a halibut client exception

### DIFF
--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -12,6 +12,7 @@ using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
 using Halibut.TestUtils.Contracts;
 using Halibut.Transport.Protocol;
+using Halibut.Util;
 using NUnit.Framework;
 
 namespace Halibut.Tests
@@ -41,7 +42,7 @@ namespace Halibut.Tests
                 tokenSourceToCancel.CancelAfter(TimeSpan.FromMilliseconds(100));
 
                 (await AssertAsync.Throws<Exception>(() => echo.IncrementAsync(halibutRequestOption)))
-                    .And.Should().Match(x => x is ConnectingRequestCancelledException || (x is HalibutClientException && x.As<HalibutClientException>().Message.Contains("The Request was cancelled while Connecting")));
+                    .And.Should().Match(x => x is ConnectingRequestCancelledException || (x is HalibutClientException && x.As<HalibutClientException>().InnerExceptionTypeIs<ConnectingRequestCancelledException>()));
 
                 clientAndService.PortForwarder.ReturnToNormalMode();
                 
@@ -96,7 +97,7 @@ namespace Halibut.Tests
                 await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
 
                 (await AssertionExtensions.Should(async () => await inFlightRequest).ThrowAsync<Exception>())
-                    .And.Should().Match(x => x is TransferringRequestCancelledException || (x is HalibutClientException && x.As<HalibutClientException>().Message.Contains("The Request was cancelled while Transferring")));
+                    .And.Should().Match(x => x is TransferringRequestCancelledException || (x is HalibutClientException && x.As<HalibutClientException>().InnerExceptionTypeIs<TransferringRequestCancelledException>()));
             }
         }
 

--- a/source/Halibut/HalibutClientException.cs
+++ b/source/Halibut/HalibutClientException.cs
@@ -1,9 +1,12 @@
+#nullable enable
 using System;
 
 namespace Halibut
 {
     public class HalibutClientException : Exception
     {
+        public Type? InnerExceptionType { get; set; }
+
         public HalibutClientException(string message)
             : base(message)
         {
@@ -12,6 +15,7 @@ namespace Halibut
         public HalibutClientException(string message, Exception inner)
             : base(message, inner)
         {
+            this.InnerExceptionType = inner?.GetType();
         }
 
         public HalibutClientException(string message, string serverException)

--- a/source/Halibut/Util/HalibutClientExceptionExtensionMethods.cs
+++ b/source/Halibut/Util/HalibutClientExceptionExtensionMethods.cs
@@ -1,0 +1,13 @@
+#nullable enable
+using System;
+
+namespace Halibut.Util
+{
+    public static class HalibutClientExceptionExtensionMethods
+    {
+        public static bool InnerExceptionTypeIs<T>(this HalibutClientException exception)
+        {
+            return exception.InnerExceptionType == typeof(T);
+        }
+    }
+}


### PR DESCRIPTION
# Background

This PR capture the inner exception type for a halibut client exception.

Usage of this will be in process, rather than from Tentacle to TentacleClient so there is no issue with exceptions from Tentalce not setting this property. However, it does add a property to Halibut Client Exception that may or may not be set depending on the source of the exception. If the source of the error is In-process it will be set, if the source is out of process, it won't be set.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
