### PR TITLE
Always make available trace logs

### DIFF
--- a/source/Halibut.Tests/BaseTest.cs
+++ b/source/Halibut.Tests/BaseTest.cs
@@ -15,15 +15,16 @@ namespace Halibut.Tests
         public CancellationToken CancellationToken { get; private set; }
         public ILogger Logger { get; private set; } = null!;
 
-
         [SetUp]
         public void SetUp()
         {
-            traceLogFileLogger = new TraceLogFileLogger();
+            traceLogFileLogger = new TraceLogFileLogger(SerilogLoggerBuilder.CurrentTestHash());
             Logger = new SerilogLoggerBuilder()
                 .SetTraceLogFileLogger(traceLogFileLogger)
                 .Build()
                 .ForContext(GetType());
+            
+            Logger.Information("Trace log file {LogFile}", traceLogFileLogger.logFilePath);
 
             Logger.Information("Test started");
             cancellationTokenSource = new CancellationTokenSource();
@@ -40,21 +41,10 @@ namespace Halibut.Tests
             Logger.Information("Disposing CancellationTokenSource");
             cancellationTokenSource?.Dispose();
 
-            if (TestContext.CurrentContext.Result.Outcome != ResultState.Success)
-            {
-                if (traceLogFileLogger?.CopyLogFileToArtifacts() ?? false)
-                {
-                    Logger.Information("Copied trace logs to artifacts");
-                }
-                else
-                {
-                    Logger.Information("Could not copy trace logs to artifacts");
-                }
-            }
+            
 
             Logger.Information("Disposing Trace Log File Logger");
             traceLogFileLogger?.Dispose();
-
             Logger.Information("Finished Test Tearing Down");
         }
     }

--- a/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
+++ b/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
@@ -66,13 +66,12 @@ namespace Halibut.Tests.Support
             if (traceFileLogger != null)
             {
                 TraceLoggers.AddOrUpdate(testName, traceFileLogger, (_, _) => throw new Exception("This should never be updated. If it is, it means that a test is being run multiple times in a single test run"));
-                traceFileLogger.SetTestHash(testHash);
             }
 
             return logger;
         }
 
-        static string CurrentTestHash()
+        public static string CurrentTestHash()
         {
             using (SHA256 mySHA256 = SHA256.Create())
             {

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -11,20 +11,19 @@ namespace Halibut.Tests
     public class TraceLogFileLogger : IDisposable
     {
         readonly AsyncQueue<string> queue = new();
-        readonly string tempFilePath = Path.GetTempFileName();
-        string testHash;
+        public readonly string logFilePath;
+        readonly string testHash;
 
         readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
         readonly Task writeDataToDiskTask;
 
-        public TraceLogFileLogger()
-        {
-            writeDataToDiskTask = WriteDataToFile();
-        }
-
-        public void SetTestHash(string testHash)
+        public TraceLogFileLogger(string testHash)
         {
             this.testHash = testHash;
+            this.logFilePath = LogFilePath(testHash);
+            File.Delete(logFilePath);
+
+            writeDataToDiskTask = WriteDataToFile();
         }
 
         public void WriteLine(string logMessage)
@@ -55,7 +54,8 @@ namespace Halibut.Tests
                 // So what we can write it down as one chunk.
                 while (queue.TryDequeue(out var log)) list.Add(log);
 
-                using (var fileAppender = new StreamWriter(tempFilePath, true, Encoding.UTF8, 8192))
+                using(var fileWriter = new FileStream(logFilePath, FileMode.Append, FileAccess.Write, FileShare.Delete | FileShare.ReadWrite))
+                using (var fileAppender = new StreamWriter(fileWriter, Encoding.UTF8, 8192))
                 {
                     foreach (var logLine in list) await fileAppender.WriteLineAsync(logLine);
 
@@ -64,16 +64,18 @@ namespace Halibut.Tests
             }
         }
 
-        void FinishWritingLogs()
+        
+
+        static string LogFilePath(string testHash)
         {
-            cancellationTokenSource.Cancel();
-            writeDataToDiskTask.GetAwaiter().GetResult();
-            cancellationTokenSource.Dispose();
+            var traceLogsDirectory = LogFileDirectory();
+            var fileName = $"{testHash}.tracelog";
+            var logFilePath = Path.Combine(traceLogsDirectory.ToString(), fileName);
+            return logFilePath;
         }
 
-        public bool CopyLogFileToArtifacts()
+        public static DirectoryInfo LogFileDirectory()
         {
-            FinishWritingLogs();
             // The current directory is expected to have the following structure
             // (w/ variance depending on Debug/Release and dotnet framework used (net6.0, net48 etc):
             //
@@ -85,30 +87,14 @@ namespace Halibut.Tests
             var rootDirectory = new DirectoryInfo(currentDirectory).Parent.Parent.Parent.Parent.Parent;
 
             var traceLogsDirectory = rootDirectory.CreateSubdirectory("artifacts").CreateSubdirectory("trace-logs");
-            var fileName = $"{testHash}.tracelog";
-
-            try
-            {
-                File.Copy(tempFilePath, Path.Combine(traceLogsDirectory.ToString(), fileName), true);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            return traceLogsDirectory;
         }
 
         public void Dispose()
         {
-            try
-            {
-                File.Delete(tempFilePath);
-            }
-            catch
-            {
-                // Best effort clean-up, but we don't want to
-                // fail the test because we couldn't delete this file
-            }
+            cancellationTokenSource.Cancel();
+            writeDataToDiskTask.GetAwaiter().GetResult();
+            cancellationTokenSource.Dispose();
         }
     }
 }


### PR DESCRIPTION
# Background

We always recorded trace logs to file, this PR changes the tests so that those trace logs are always available.

This means:
* On teamcity if a test times out and never reaches a tear down, we can still see trace logs.
* Locally we can view trace logs.

This test will also print the location of the trace log for easy debugging.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
