### PR TITLE
Code analysis fixes

### DIFF
--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# VSTHRD200: Use "Async" suffix for async methods
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/source/Halibut.TestProxy/CancellationTokenExtensionMethods.cs
+++ b/source/Halibut.TestProxy/CancellationTokenExtensionMethods.cs
@@ -24,7 +24,7 @@ namespace Halibut.TestProxy
         {
             var tcs = new TaskCompletionSource<VoidResult>();
 
-            IDisposable registration = null;
+            IDisposable? registration = null;
             registration = cancellationToken.Register(() =>
             {
                 tcs.TrySetCanceled();

--- a/source/Halibut.TestProxy/Halibut.TestProxy.csproj
+++ b/source/Halibut.TestProxy/Halibut.TestProxy.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Halibut.TestProxy</RootNamespace>
+	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestProxy/HttpProxyService.cs
+++ b/source/Halibut.TestProxy/HttpProxyService.cs
@@ -104,7 +104,7 @@ namespace Halibut.TestProxy
                         using var socketCancellationTokenSource = new CancellationTokenSource();
                         using (cancellationToken.Register(() => Try.CatchingError(() => socketCancellationTokenSource.Cancel(), _ => { })))
                         {
-                            var cancelTask = socketCancellationTokenSource.Token.AsTask<TcpClient?>();
+                            var cancelTask = socketCancellationTokenSource.Token.AsTask<TcpClient>();
                             var actionTask = Task.Run(async () =>
                             {
                                 using var _ = cancellationToken.Register(() => Try.CatchingError(() =>
@@ -188,7 +188,7 @@ namespace Halibut.TestProxy
                 try
                 {
                     logger.LogInformation("Creating Proxy Connection Forwarder");
-                    await CreateProxyConnectionAndForward(client, connectionRequest, cancellationToken);
+                    CreateProxyConnectionAndForward(client, connectionRequest, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -219,10 +219,10 @@ namespace Halibut.TestProxy
             }
         }
 
-        async Task CreateProxyConnectionAndForward(TcpClient client, HttpProxyConnectionRequest connectionRequest, CancellationToken cancellationToken)
+        void CreateProxyConnectionAndForward(TcpClient client, HttpProxyConnectionRequest connectionRequest, CancellationToken cancellationToken)
         {
             var proxyConnection = proxyConnectionService.GetProxyConnection(connectionRequest.Endpoint);
-            await proxyConnection.Connect(client, cancellationToken);
+            proxyConnection.Connect(client, cancellationToken);
         }
 
         async Task SendConnectResponse(ProxyEndpoint endpoint, string httpVersion, int responseCode, string message, PipeWriter writer, CancellationToken cancellationToken)

--- a/source/Halibut.TestProxy/ProxyConnection.cs
+++ b/source/Halibut.TestProxy/ProxyConnection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -11,7 +10,7 @@ namespace Halibut.TestProxy
 {
     interface IProxyConnection : IDisposable
     {
-        Task Connect(TcpClient source, CancellationToken cancellationToken);
+        void Connect(TcpClient source, CancellationToken cancellationToken);
     }
 
     class ProxyConnection : IProxyConnection
@@ -26,7 +25,7 @@ namespace Halibut.TestProxy
             this.logger = logger;
         }
 
-        public async Task Connect(TcpClient source, CancellationToken cancellationToken)
+        public void Connect(TcpClient source, CancellationToken cancellationToken)
         {
             if (source.Client.RemoteEndPoint is not IPEndPoint sourceRemoteEndpoint)
             {

--- a/source/Halibut.TestProxy/TcpListenerHelpers.cs
+++ b/source/Halibut.TestProxy/TcpListenerHelpers.cs
@@ -16,7 +16,7 @@ namespace Halibut.TestProxy
         {
             if (TryParse(listenEndpoint, out var ipEndPoint))
             {
-                return new TcpListener(ipEndPoint);
+                return new TcpListener(ipEndPoint!);
             }
             else
             {

--- a/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/BackwardsCompatProgramBase.cs
@@ -42,7 +42,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
             var serviceConnectionType = SettingsHelper.GetServiceConnectionType();
             var octopusThumbprint = SettingsHelper.GetClientThumbprint();
 
-            string addressToPoll = null;
+            var addressToPoll = string.Empty;
 
             if (serviceConnectionType is ServiceConnectionType.Polling or ServiceConnectionType.PollingOverWebSocket)
             {
@@ -62,14 +62,14 @@ namespace Halibut.TestUtils.SampleProgram.Base
                 switch (serviceConnectionType)
                 {
                     case ServiceConnectionType.Polling:
-                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll!), octopusThumbprint, proxyDetails));
+                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll), octopusThumbprint, proxyDetails));
                         break;
                     case ServiceConnectionType.PollingOverWebSocket:
                         FixHungWebSocketsHack.EnableHack();
                         var sslThubprint = SettingsHelper.GetSetting("sslthubprint");
                         Console.WriteLine($"Using SSL thumbprint: {sslThubprint}");
 
-                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll!), sslThubprint, proxyDetails));
+                        tentaclePolling.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(addressToPoll), sslThubprint, proxyDetails));
                         break;
                     case ServiceConnectionType.Listening:
                         var port = tentaclePolling.Listen();

--- a/source/Halibut.TestUtils.CompatBinary.Base/CompatBaseDelegateServiceFactory.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/CompatBaseDelegateServiceFactory.cs
@@ -13,7 +13,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
         public CompatBaseDelegateServiceFactory Register<TContract>(Func<TContract> implementation)
         {
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.Name, () => implementation()!);
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);

--- a/source/Halibut.TestUtils.CompatBinary.Base/DataStreamExtensionMethods.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DataStreamExtensionMethods.cs
@@ -7,7 +7,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
     {
         public static string ReadAsString(this DataStream stream)
         {
-            string result = null;
+            var result = string.Empty;
             stream.Receiver().Read(s =>
             {
                 using (var reader = new StreamReader(s))

--- a/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/DelegateComplexObjectService.cs
@@ -20,8 +20,8 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         ComplexObjectMultipleDataStreams FixDataStreams(ComplexObjectMultipleDataStreams complexObject)
         {
-            complexObject.Payload1 = complexObject.Payload1.ConfigureWriterOnReceivedDataStream();
-            complexObject.Payload2 = complexObject.Payload2.ConfigureWriterOnReceivedDataStream();
+            complexObject.Payload1 = complexObject.Payload1!.ConfigureWriterOnReceivedDataStream();
+            complexObject.Payload2 = complexObject.Payload2!.ConfigureWriterOnReceivedDataStream();
             return complexObject;
         }
 
@@ -37,10 +37,10 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         ComplexObjectMultipleChildren FixDataStreams(ComplexObjectMultipleChildren complexObject)
         {
-            complexObject.Child1.ChildPayload1 = complexObject.Child1.ChildPayload1.ConfigureWriterOnReceivedDataStream();
-            complexObject.Child1.ChildPayload2 = complexObject.Child1.ChildPayload2.ConfigureWriterOnReceivedDataStream();
-            complexObject.Child1.ListOfStreams = complexObject.Child1.ListOfStreams.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
-            complexObject.Child2.ComplexPayloadSet = complexObject.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
+            complexObject.Child1!.ChildPayload1 = complexObject.Child1.ChildPayload1!.ConfigureWriterOnReceivedDataStream();
+            complexObject.Child1.ChildPayload2 = complexObject.Child1.ChildPayload2!.ConfigureWriterOnReceivedDataStream();
+            complexObject.Child1.ListOfStreams = complexObject.Child1.ListOfStreams!.Select(x => x.ConfigureWriterOnReceivedDataStream()).ToList();
+            complexObject.Child2!.ComplexPayloadSet = complexObject.Child2.ComplexPayloadSet!.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             complexObject.Child2.ComplexPayloadSet = complexObject.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, x.Payload.ConfigureWriterOnReceivedDataStream())).ToHashSet();
             return complexObject;
         }

--- a/source/Halibut.TestUtils.CompatBinary.Base/Halibut.TestUtils.CompatBinary.Base.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Halibut.TestUtils.CompatBinary.Base.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.Base</RootNamespace>
+	    <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.Base/Halibut.TestUtils.CompatBinary.Base.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Halibut.TestUtils.CompatBinary.Base.csproj
@@ -4,6 +4,7 @@
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.Base</RootNamespace>
 	    <Nullable>enable</Nullable>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/ProxyServiceForwardingRequestToClient.cs
@@ -25,14 +25,14 @@ namespace Halibut.TestUtils.SampleProgram.Base
             var clientCert = SettingsHelper.GetClientCertificate();
             var proxyDetails = SettingsHelper.GetProxyDetails();
 
-            string proxyClientAddressToPoll = null;
+            var proxyClientAddressToPoll = string.Empty;
             if (serviceConnectionType is ServiceConnectionType.Polling or ServiceConnectionType.PollingOverWebSocket)
             {
                 proxyClientAddressToPoll = SettingsHelper.GetSetting("octopusservercommsport");
                 Console.WriteLine($"Proxy Service will Poll: {proxyClientAddressToPoll}");
             }
 
-            string serviceAddressToConnectTo = null;
+            var serviceAddressToConnectTo = string.Empty;
             if (serviceConnectionType == ServiceConnectionType.Listening)
             {
                 serviceAddressToConnectTo = SettingsHelper.GetSetting("realServiceListenAddress");
@@ -69,7 +69,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                         }
                         break;
                     case ServiceConnectionType.Listening:
-                        realServiceEndpoint = new ServiceEndPoint(new Uri(serviceAddressToConnectTo!), serviceCert.Thumbprint, proxyDetails);
+                        realServiceEndpoint = new ServiceEndPoint(new Uri(serviceAddressToConnectTo), serviceCert.Thumbprint, proxyDetails);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
@@ -90,7 +90,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
                         case ServiceConnectionType.Polling:
                         case ServiceConnectionType.PollingOverWebSocket:
                             // PollingOverWebsockets exposes a proxy client that is just Polling for simplicity
-                            proxyService.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(proxyClientAddressToPoll!), clientCert.Thumbprint));
+                            proxyService.Poll(new Uri("poll://SQ-TENTAPOLL"), new ServiceEndPoint(new Uri(proxyClientAddressToPoll), clientCert.Thumbprint));
                             break;
                         case ServiceConnectionType.Listening:
                             var proxyServiceListeningPort = proxyService.Listen();
@@ -115,7 +115,6 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         public static int WebSocketListeningPort(HalibutRuntime client, out string webSocketListeningUrl, CancellationToken cancellationToken)
         {
-            webSocketListeningUrl = null;
             for (int i = 0; i < 9; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/ComplexObjectService.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/ComplexObjectService.cs
@@ -10,8 +10,8 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
         {
             return new ComplexObjectMultipleDataStreams
             {
-                Payload1 = ReadIntoNewDataStream(request.Payload1),
-                Payload2 = ReadIntoNewDataStream(request.Payload2)
+                Payload1 = ReadIntoNewDataStream(request.Payload1!),
+                Payload2 = ReadIntoNewDataStream(request.Payload2!)
             };
         }
 
@@ -21,15 +21,15 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
             {
                 Child1 = new ComplexChild1
                 {
-                    ChildPayload1 = ReadIntoNewDataStream(request.Child1.ChildPayload1),
-                    ChildPayload2 = ReadIntoNewDataStream(request.Child1.ChildPayload2),
-                    ListOfStreams = request.Child1.ListOfStreams.Select(ReadIntoNewDataStream).ToList(),
-                    DictionaryPayload = request.Child1.DictionaryPayload.ToDictionary(pair => pair.Key, pair => pair.Value),
+                    ChildPayload1 = ReadIntoNewDataStream(request.Child1!.ChildPayload1!),
+                    ChildPayload2 = ReadIntoNewDataStream(request.Child1!.ChildPayload2!),
+                    ListOfStreams = request.Child1.ListOfStreams!.Select(ReadIntoNewDataStream).ToList(),
+                    DictionaryPayload = request.Child1.DictionaryPayload!.ToDictionary(pair => pair.Key, pair => pair.Value),
                 },
                 Child2 = new ComplexChild2
                 {
-                    EnumPayload = request.Child2.EnumPayload,
-                    ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, ReadIntoNewDataStream(x.Payload))).ToHashSet()
+                    EnumPayload = request.Child2!.EnumPayload,
+                    ComplexPayloadSet = request.Child2.ComplexPayloadSet!.Select(x => new ComplexPair<DataStream>(x.EnumValue, ReadIntoNewDataStream(x.Payload))).ToHashSet()
                 }
             };
         }
@@ -38,8 +38,8 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
         {
             return new ComplexObjectWithInheritance
             {
-                Child1 = new ComplexInheritedChild1(request.Child1.Name),
-                Child2 = new ComplexInheritedChild2(request.Child2.Description)
+                Child1 = new ComplexInheritedChild1(request.Child1!.Name),
+                Child2 = new ComplexInheritedChild2(request.Child2!.Description)
             };
         }
 

--- a/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/Services/StayAliveUntilHelper.cs
@@ -32,7 +32,7 @@ namespace Halibut.TestUtils.SampleProgram.Base.Services
                         Environment.Exit(0);
                     }
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 
                 }

--- a/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
+++ b/source/Halibut.TestUtils.CompatBinary.Base/SettingsHelper.cs
@@ -7,7 +7,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
 {
     static class SettingsHelper
     {
-        public static ProxyDetails GetProxyDetails()
+        public static ProxyDetails? GetProxyDetails()
         {
             var host = GetSetting("proxydetails_host");
 
@@ -39,7 +39,7 @@ namespace Halibut.TestUtils.SampleProgram.Base
 
         public static string GetSetting(string name)
         {
-            return Environment.GetEnvironmentVariable(name);
+            return Environment.GetEnvironmentVariable(name) ?? string.Empty;
         }
         
         static bool GetMandatoryBool(string name)

--- a/source/Halibut.TestUtils.CompatBinary.v4_4_8/Halibut.TestUtils.CompatBinary.v4_4_8.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v4_4_8/Halibut.TestUtils.CompatBinary.v4_4_8.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.v4_4_8</RootNamespace>
+	    <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.v4_4_8/Halibut.TestUtils.CompatBinary.v4_4_8.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v4_4_8/Halibut.TestUtils.CompatBinary.v4_4_8.csproj
@@ -5,6 +5,7 @@
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.v4_4_8</RootNamespace>
 	    <Nullable>enable</Nullable>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_236/Halibut.TestUtils.CompatBinary.v5_0_236.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_236/Halibut.TestUtils.CompatBinary.v5_0_236.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.v5_0_236</RootNamespace>
 	    <Nullable>enable</Nullable>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.v5_0_236/Halibut.TestUtils.CompatBinary.v5_0_236.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v5_0_236/Halibut.TestUtils.CompatBinary.v5_0_236.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.v5_0_236</RootNamespace>
+	    <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.v6_0_658/Halibut.TestUtils.CompatBinary.v6_0_658.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v6_0_658/Halibut.TestUtils.CompatBinary.v6_0_658.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.v6_0_658</RootNamespace>
+	    <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.CompatBinary.v6_0_658/Halibut.TestUtils.CompatBinary.v6_0_658.csproj
+++ b/source/Halibut.TestUtils.CompatBinary.v6_0_658/Halibut.TestUtils.CompatBinary.v6_0_658.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.SampleProgram.v6_0_658</RootNamespace>
 	    <Nullable>enable</Nullable>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.Contracts/Halibut.TestUtils.Contracts.csproj
+++ b/source/Halibut.TestUtils.Contracts/Halibut.TestUtils.Contracts.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.Contracts</RootNamespace>
+	    <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.Contracts/Halibut.TestUtils.Contracts.csproj
+++ b/source/Halibut.TestUtils.Contracts/Halibut.TestUtils.Contracts.csproj
@@ -4,6 +4,7 @@
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Halibut.TestUtils.Contracts</RootNamespace>
 	    <Nullable>enable</Nullable>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -105,7 +105,7 @@ namespace Halibut.TestUtils.Contracts
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return EnumValue.Equals(other.EnumValue) && Payload is not null && Payload.Equals(other.Payload);
+            return EnumValue.Equals(other.EnumValue) && Equals(Payload, other.Payload);
         }
 
         public override int GetHashCode()

--- a/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
+++ b/source/Halibut.TestUtils.Contracts/IComplexObjectService.cs
@@ -13,34 +13,34 @@ namespace Halibut.TestUtils.Contracts
 
     public class ComplexObjectMultipleDataStreams
     {
-        public DataStream Payload1;
-        public DataStream Payload2;
+        public DataStream? Payload1;
+        public DataStream? Payload2;
     }
 
     public class ComplexObjectMultipleChildren
     {
-        public ComplexChild1 Child1;
-        public ComplexChild2 Child2;
+        public ComplexChild1? Child1;
+        public ComplexChild2? Child2;
     }
 
     public class ComplexObjectWithInheritance
     {
-        public IComplexChild Child1 { get; set; }
-        public ComplexChildBase Child2 { get; set; }
+        public IComplexChild? Child1 { get; set; }
+        public ComplexChildBase? Child2 { get; set; }
     }
 
     public class ComplexChild1
     {
-        public DataStream ChildPayload1;
-        public DataStream ChildPayload2;
-        public IList<DataStream> ListOfStreams;
-        public IDictionary<Guid, string> DictionaryPayload;
+        public DataStream? ChildPayload1;
+        public DataStream? ChildPayload2;
+        public IList<DataStream>? ListOfStreams;
+        public IDictionary<Guid, string>? DictionaryPayload;
     }
 
     public class ComplexChild2
     {
         public ComplexEnum EnumPayload;
-        public ISet<ComplexPair<DataStream>> ComplexPayloadSet;
+        public ISet<ComplexPair<DataStream>>? ComplexPayloadSet;
     }
 
     public interface IComplexChild
@@ -93,7 +93,7 @@ namespace Halibut.TestUtils.Contracts
         public readonly ComplexEnum EnumValue;
         public readonly T Payload;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -101,18 +101,18 @@ namespace Halibut.TestUtils.Contracts
             return Equals((ComplexPair<T>)obj);
         }
 
-        public bool Equals(ComplexPair<T> other)
+        public bool Equals(ComplexPair<T>? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return EnumValue.Equals(other.EnumValue) && Payload.Equals(other.Payload);
+            return EnumValue.Equals(other.EnumValue) && Payload is not null && Payload.Equals(other.Payload);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return (EqualityComparer<ComplexEnum>.Default.GetHashCode(EnumValue) * 397) ^ EqualityComparer<T>.Default.GetHashCode(Payload);
+                return (EqualityComparer<ComplexEnum>.Default.GetHashCode(EnumValue) * 397) ^ EqualityComparer<T>.Default.GetHashCode(Payload!);
             }
         }
     }

--- a/source/Halibut.TestUtils.Contracts/Tentacle/Services/AsyncScriptService.cs
+++ b/source/Halibut.TestUtils.Contracts/Tentacle/Services/AsyncScriptService.cs
@@ -85,9 +85,9 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
         }
         class RunningScript
         {
-            public StartScriptCommand StartScriptCommand { get; set; }
-            public string FullScriptOutput { get; set; }
-            public ScriptTicket ScriptTicket { get; set; }
+            public StartScriptCommand? StartScriptCommand { get; set; }
+            public string? FullScriptOutput { get; set; }
+            public ScriptTicket? ScriptTicket { get; set; }
             public ProcessState ProcessState { get; set; }
             public int ExitCode { get; set; }
             public int RemainingGetStatusCallsBeforeComplete { get; set; }
@@ -95,7 +95,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
             public (List<ProcessOutput> logs, int nextSequenceNumber) GetStatusOrCancelCalled(int lastLogSequence)
             {
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
                 var take = new Random().Next(1, 20);
                 var logs = logLines.Skip(lastLogSequence).Take(take).Select(x => new ProcessOutput(ProcessOutputSource.StdOut, x.Trim('\r', '\n'))).ToList();
                 --RemainingGetStatusCallsBeforeComplete;
@@ -111,7 +111,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
             public (List<ProcessOutput> logs, int nextSequenceNumber) CompleteCalled(int lastLogSequence)
             {
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
                 var logs = logLines.Skip(lastLogSequence).Select(x => new ProcessOutput(ProcessOutputSource.StdOut, x.Trim('\r', '\n'))).ToList();
                 
                 return (logs, lastLogSequence + logs.Count);

--- a/source/Halibut.TestUtils.Contracts/Tentacle/Services/AsyncScriptServiceV2.cs
+++ b/source/Halibut.TestUtils.Contracts/Tentacle/Services/AsyncScriptServiceV2.cs
@@ -77,9 +77,9 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
         class RunningScript
         {
-            public StartScriptCommandV2 StartScriptCommand { get; set; }
-            public string FullScriptOutput { get; set; }
-            public ScriptTicket ScriptTicket { get; set; }
+            public StartScriptCommandV2? StartScriptCommand { get; set; }
+            public string? FullScriptOutput { get; set; }
+            public ScriptTicket? ScriptTicket { get; set; }
             public ProcessState ProcessState { get; set; }
             public int ExitCode { get; set; }
             public int RemainingGetStatusCallsBeforeComplete { get; set; }
@@ -95,7 +95,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
                     ProcessState = ProcessState.Complete;
                 }
 
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
                 var take = ProcessState == ProcessState.Complete ? int.MaxValue : new Random().Next(1, 20);
                 var logs = logLines.Skip(lastLogSequence).Take(take).Select(x => new ProcessOutput(ProcessOutputSource.StdOut, x.Trim('\r', '\n'))).ToList();
 
@@ -104,7 +104,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
             public List<ProcessOutput> GetProcessOutput(int index)
             {
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
 
                 return new List<ProcessOutput>{ new (ProcessOutputSource.StdOut, logLines.ElementAt(index).Trim('\r', '\n')) };
             }

--- a/source/Halibut.TestUtils.Contracts/Tentacle/Services/ScriptService.cs
+++ b/source/Halibut.TestUtils.Contracts/Tentacle/Services/ScriptService.cs
@@ -84,9 +84,9 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
         }
         class RunningScript
         {
-            public StartScriptCommand StartScriptCommand { get; set; }
-            public string FullScriptOutput { get; set; }
-            public ScriptTicket ScriptTicket { get; set; }
+            public StartScriptCommand? StartScriptCommand { get; set; }
+            public string? FullScriptOutput { get; set; }
+            public ScriptTicket? ScriptTicket { get; set; }
             public ProcessState ProcessState { get; set; }
             public int ExitCode { get; set; }
             public int RemainingGetStatusCallsBeforeComplete { get; set; }
@@ -94,7 +94,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
             public (List<ProcessOutput> logs, int nextSequenceNumber) GetStatusOrCancelCalled(int lastLogSequence)
             {
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
                 var take = new Random().Next(1, 20);
                 var logs = logLines.Skip(lastLogSequence).Take(take).Select(x => new ProcessOutput(ProcessOutputSource.StdOut, x.Trim('\r', '\n'))).ToList();
                 --RemainingGetStatusCallsBeforeComplete;
@@ -110,7 +110,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
             public (List<ProcessOutput> logs, int nextSequenceNumber) CompleteCalled(int lastLogSequence)
             {
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
                 var logs = logLines.Skip(lastLogSequence).Select(x => new ProcessOutput(ProcessOutputSource.StdOut, x.Trim('\r', '\n'))).ToList();
                 
                 return (logs, lastLogSequence + logs.Count);

--- a/source/Halibut.TestUtils.Contracts/Tentacle/Services/ScriptServiceV2.cs
+++ b/source/Halibut.TestUtils.Contracts/Tentacle/Services/ScriptServiceV2.cs
@@ -76,9 +76,9 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
         class RunningScript
         {
-            public StartScriptCommandV2 StartScriptCommand { get; set; }
-            public string FullScriptOutput { get; set; }
-            public ScriptTicket ScriptTicket { get; set; }
+            public StartScriptCommandV2? StartScriptCommand { get; set; }
+            public string? FullScriptOutput { get; set; }
+            public ScriptTicket? ScriptTicket { get; set; }
             public ProcessState ProcessState { get; set; }
             public int ExitCode { get; set; }
             public int RemainingGetStatusCallsBeforeComplete { get; set; }
@@ -94,7 +94,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
                     ProcessState = ProcessState.Complete;
                 }
 
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
                 var take = ProcessState == ProcessState.Complete ? int.MaxValue : new Random().Next(1, 20);
                 var logs = logLines.Skip(lastLogSequence).Take(take).Select(x => new ProcessOutput(ProcessOutputSource.StdOut, x.Trim('\r', '\n'))).ToList();
 
@@ -103,7 +103,7 @@ namespace Halibut.TestUtils.Contracts.Tentacle.Services
 
             public List<ProcessOutput> GetProcessOutput(int index)
             {
-                var logLines = FullScriptOutput.Split('\n');
+                var logLines = FullScriptOutput!.Split('\n');
 
                 return new List<ProcessOutput>{ new (ProcessOutputSource.StdOut, logLines.ElementAt(index).Trim('\r', '\n')) };
             }

--- a/source/Halibut.Tests.DotMemory/Certificates.cs
+++ b/source/Halibut.Tests.DotMemory/Certificates.cs
@@ -24,7 +24,7 @@ namespace Halibut.Tests.DotMemory
         static Certificates()
         {
             //jump through hoops to find certs because the nunit test runner is messing with directories
-            var directory = Path.Combine(Path.GetDirectoryName(new Uri(typeof(Certificates).Assembly.CodeBase!).LocalPath)!, "Certificates");
+            var directory = Path.Combine(Path.GetDirectoryName(new Uri(typeof(Certificates).Assembly.Location).LocalPath)!, "Certificates");
             TentacleListeningPfxPath = Path.Combine(directory, "TentacleListening.pfx");
             TentacleListening = new X509Certificate2(TentacleListeningPfxPath);
             TentacleListeningPublicThumbprint = TentacleListening.Thumbprint;

--- a/source/Halibut.Tests.DotMemory/Certificates.cs
+++ b/source/Halibut.Tests.DotMemory/Certificates.cs
@@ -24,7 +24,7 @@ namespace Halibut.Tests.DotMemory
         static Certificates()
         {
             //jump through hoops to find certs because the nunit test runner is messing with directories
-            var directory = Path.Combine(Path.GetDirectoryName(new Uri(typeof(Certificates).Assembly.CodeBase).LocalPath), "Certificates");
+            var directory = Path.Combine(Path.GetDirectoryName(new Uri(typeof(Certificates).Assembly.CodeBase!).LocalPath)!, "Certificates");
             TentacleListeningPfxPath = Path.Combine(directory, "TentacleListening.pfx");
             TentacleListening = new X509Certificate2(TentacleListeningPfxPath);
             TentacleListeningPublicThumbprint = TentacleListening.Thumbprint;

--- a/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
+++ b/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
@@ -6,6 +6,7 @@
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
         <LangVersion>9.0</LangVersion>
+	    <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
         <TargetFrameworks>net48;net6.0</TargetFrameworks>

--- a/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
+++ b/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <VersionPrefix>0.0.0</VersionPrefix>
         <AssemblyName>Halibut.Tests</AssemblyName>
@@ -6,6 +6,7 @@
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
         <LangVersion>9.0</LangVersion>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	    <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Halibut.Tests.DotMemory/MemoryFixture.cs
+++ b/source/Halibut.Tests.DotMemory/MemoryFixture.cs
@@ -59,7 +59,7 @@ namespace Halibut.Tests.DotMemory
                 .WriteTo.NUnitOutput()
                 .CreateLogger();
 
-            HalibutRuntime server = null;
+            HalibutRuntime? server = null;
 
             try
             {
@@ -105,7 +105,7 @@ namespace Halibut.Tests.DotMemory
             }
             finally
             {
-                server.DisposeAsync().GetAwaiter().GetResult();
+                server?.DisposeAsync().GetAwaiter().GetResult();
             }
         }
 

--- a/source/Halibut.Tests.DotMemory/Support/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests.DotMemory/Support/TestContextConnectionLog.cs
@@ -21,12 +21,12 @@ namespace Halibut.Tests.Support.Logging
             this.logLevel = logLevel;
         }
 
-        public void Write(EventType type, string message, params object[] args)
+        public void Write(EventType type, string message, params object?[] args)
         {
             WriteInternal(new LogEvent(type, message, null, args));
         }
 
-        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        public void WriteException(EventType type, string message, Exception ex, params object?[] args)
         {
             WriteInternal(new LogEvent(type, message, ex, args));
         }

--- a/source/Halibut.Tests/AsyncClientAndServiceMustNotUseSyncNetworkIO.cs
+++ b/source/Halibut.Tests/AsyncClientAndServiceMustNotUseSyncNetworkIO.cs
@@ -45,10 +45,10 @@ namespace Halibut.Tests
                     var response = await service.ProcessAsync(request);
 
                     response.Payload1.Should().NotBeSameAs(request.Payload1);
-                    response.Payload1.ReadAsString().Should().Be(payload1);
+                    response.Payload1!.ReadAsString().Should().Be(payload1);
 
                     response.Payload2.Should().NotBeSameAs(request.Payload2);
-                    response.Payload2.ReadAsString().Should().Be(payload2);
+                    response.Payload2!.ReadAsString().Should().Be(payload2);
                 }
             }
 

--- a/source/Halibut.Tests/AsyncServiceVerifierFixture.cs
+++ b/source/Halibut.Tests/AsyncServiceVerifierFixture.cs
@@ -10,27 +10,27 @@ namespace Halibut.Tests
     public class AsyncServiceVerifierFixture
     {
         [Test]
-        public async Task AsyncMatchesSync()
+        public void AsyncMatchesSync()
         {
             AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncGoodService>();
         }
 
         [Test]
-        public async Task AsyncBreaksCancellationTokenConvention()
+        public void AsyncBreaksCancellationTokenConvention()
         {
             Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>
                 (AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncBrokenCancellationTokenConventionService>);
         }
 
         [Test]
-        public async Task AsyncBreaksSuffixConvention()
+        public void AsyncBreaksSuffixConvention()
         {
             Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>
                 (AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncBrokenSuffixConventionService>);
         }
 
         [Test]
-        public async Task AsyncBreaksReturnTypeConvention()
+        public void AsyncBreaksReturnTypeConvention()
         {
             Assert.Throws<NoMatchingServiceOrMethodHalibutClientException>
                 (AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<IGoodService, IAsyncBrokenReturnTypeConventionService>);

--- a/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
+++ b/source/Halibut.Tests/BackwardsCompatibility/InvocationExceptionsAreMappedCorrectlyFixture.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests.BackwardsCompatibility
             {
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
 
-                await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await echo.CrashAsync());
+                await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await echo.CrashAsync());
             }
         }
     }

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -111,8 +111,8 @@ namespace Halibut.Tests
                     CancellationToken);
                 
                 cts.Cancel();
-                
-                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<OperationCanceledException>();
+
+                await AssertAsync.Throws<OperationCanceledException>(incrementCount);
 
                 // don't assert things until we've seen the client actually connect
                 await unauthorizedClientHasConnected.Task;
@@ -161,7 +161,7 @@ namespace Halibut.Tests
 
                 cts.Cancel();
 
-                var exception = await AssertionExtensions.Should(() => incrementCount).ThrowAsync<Exception>();
+                var exception = await AssertAsync.Throws<Exception>(incrementCount);
 
                 exception.And.Should().Match(e => e.GetType() == typeof(HalibutClientException) 
                                                   || e.GetType() == typeof(OperationCanceledException) 
@@ -226,7 +226,7 @@ namespace Halibut.Tests
                 
                 cts.Cancel();
                 
-                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<OperationCanceledException>();
+                await AssertAsync.Throws<Exception>(incrementCount);
                 
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }
@@ -282,7 +282,7 @@ namespace Halibut.Tests
 
                 cts.Cancel();
 
-                await AssertionExtensions.Should(() => incrementCount).ThrowAsync<OperationCanceledException>();
+                await AssertAsync.Throws<Exception>(incrementCount);
 
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -112,7 +112,7 @@ namespace Halibut.Tests
                 
                 cts.Cancel();
 
-                await AssertAsync.Throws<OperationCanceledException>(incrementCount);
+                await AssertException.Throws<OperationCanceledException>(incrementCount);
 
                 // don't assert things until we've seen the client actually connect
                 await unauthorizedClientHasConnected.Task;
@@ -161,7 +161,7 @@ namespace Halibut.Tests
 
                 cts.Cancel();
 
-                var exception = await AssertAsync.Throws<Exception>(incrementCount);
+                var exception = await AssertException.Throws<Exception>(incrementCount);
 
                 exception.And.Should().Match(e => e.GetType() == typeof(HalibutClientException) 
                                                   || e.GetType() == typeof(OperationCanceledException) 
@@ -226,7 +226,7 @@ namespace Halibut.Tests
                 
                 cts.Cancel();
                 
-                await AssertAsync.Throws<Exception>(incrementCount);
+                await AssertException.Throws<Exception>(incrementCount);
                 
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }
@@ -282,7 +282,7 @@ namespace Halibut.Tests
 
                 cts.Cancel();
 
-                await AssertAsync.Throws<Exception>(incrementCount);
+                await AssertException.Throws<Exception>(incrementCount);
 
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -226,7 +226,7 @@ namespace Halibut.Tests
                 
                 cts.Cancel();
                 
-                await AssertException.Throws<Exception>(incrementCount);
+                await AssertException.Throws<OperationCanceledException>(incrementCount);
                 
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }
@@ -282,7 +282,7 @@ namespace Halibut.Tests
 
                 cts.Cancel();
 
-                await AssertException.Throws<Exception>(incrementCount);
+                await AssertException.Throws<OperationCanceledException>(incrementCount);
 
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -227,7 +227,7 @@ namespace Halibut.Tests
                 cts.Cancel();
                 
                 await AssertionExtensions.Should(() => incrementCount).ThrowAsync<OperationCanceledException>();
-
+                
                 countingService.CurrentValue().Should().Be(0, "With a bad certificate the request never should have been made");
             }
         }

--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -152,7 +152,7 @@ namespace Halibut.Tests
                 await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None));
                 
                 // Act
-                clientAndBuilder.Client.TrustOnly(new List<string>());
+                clientAndBuilder.Client?.TrustOnly(new List<string>());
                 
                 // Assert
                 var incrementCount = Task.Run(async () => await clientCountingService.IncrementAsync(new HalibutProxyRequestOptions(cts.Token, CancellationToken.None)), CancellationToken);

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -47,7 +47,7 @@ namespace Halibut.Tests
                        .WithStandardServices()
                        .Build(CancellationToken))
             {
-                clientAndService.PortForwarder.EnterKillNewAndExistingConnectionsMode();
+                clientAndService.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
                 var data = new byte[1024 * 1024 + 15];
                 new Random().NextBytes(data);
 
@@ -174,7 +174,7 @@ namespace Halibut.Tests
             {
                 Assert.Throws<TypeNotAllowedException>(() =>
                 {
-                    clientAndService.Client.CreateAsyncClient<IAmNotAllowed, IAsyncClientAmNotAllowed>(clientAndService.GetServiceEndPoint());
+                    clientAndService.Client!.CreateAsyncClient<IAmNotAllowed, IAsyncClientAmNotAllowed>(clientAndService.GetServiceEndPoint());
                 });
             }
         }

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -56,7 +56,7 @@ namespace Halibut.Tests
                 
                 tokenSourceToCancel.CancelAfter(TimeSpan.FromMilliseconds(100));
                 
-                (await AssertAsync.Throws<Exception>(() => echo.IncrementAsync(halibutRequestOption)))
+                (await AssertException.Throws<Exception>(() => echo.IncrementAsync(halibutRequestOption)))
                     .And.Message.Contains("The operation was canceled");
 
                 clientAndService.PortForwarder.ReturnToNormalMode();
@@ -156,7 +156,7 @@ namespace Halibut.Tests
                 // Give time for the cancellation to do something
                 await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
 
-                (await AssertAsync.Throws<Exception>(inFlightRequest))
+                (await AssertException.Throws<Exception>(inFlightRequest))
                     .And
                     .Should().Match<Exception>(x => x is OperationCanceledException || (x.GetType() == typeof(HalibutClientException) && x.Message.Contains("The ReadAsync operation was cancelled")));
             }

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -156,8 +156,8 @@ namespace Halibut.Tests
                 // Give time for the cancellation to do something
                 await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
 
-                (await AssertionExtensions.Should(async () => await inFlightRequest)
-                    .ThrowAsync<Exception>()).And
+                (await AssertAsync.Throws<Exception>(inFlightRequest))
+                    .And
                     .Should().Match<Exception>(x => x is OperationCanceledException || (x.GetType() == typeof(HalibutClientException) && x.Message.Contains("The ReadAsync operation was cancelled")));
             }
         }

--- a/source/Halibut.Tests/DataStreamFixture.cs
+++ b/source/Halibut.Tests/DataStreamFixture.cs
@@ -23,7 +23,7 @@ namespace Halibut.Tests
                        .AsLatestClientAndLatestServiceBuilder()
                        .Build(CancellationToken))
             {
-                var echo = clientAndService.Client.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(clientAndService.GetServiceEndPoint());
+                var echo = clientAndService.Client!.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(clientAndService.GetServiceEndPoint());
 
                 var data = new byte[1337];
                 new Random().NextBytes(data);

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -58,7 +58,7 @@ namespace Halibut.Tests.Diagnostics
                     var svc = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionService>();
 
                     // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
-                    var exception = (await AssertAsync.Throws<HalibutClientException>(async () => await svc.ActionAsync())).And;
+                    var exception = (await AssertException.Throws<HalibutClientException>(async () => await svc.ActionAsync())).And;
                     new SerilogLoggerBuilder().Build().Information(exception, "Got an exception, we were expecting one");
                     exception.IsNetworkError()
                         .Should()
@@ -89,7 +89,7 @@ namespace Halibut.Tests.Diagnostics
                     var svc = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionService>();
 
                     // When svc.Action() is executed, tentacle will kill the TCP connection and dispose the port forwarder preventing new connections.
-                    var exception = (await AssertAsync.Throws<HalibutClientException>(() => svc.ActionAsync())).And;
+                    var exception = (await AssertException.Throws<HalibutClientException>(() => svc.ActionAsync())).And;
                     new SerilogLoggerBuilder().Build().Information(exception, "Got an exception, we were expecting one");
                     exception.IsNetworkError()
                         .Should()
@@ -114,7 +114,7 @@ namespace Halibut.Tests.Diagnostics
                 {
                     var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(point => point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(1));
 
-                    (await AssertAsync.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello"))).And
+                    (await AssertException.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello"))).And
                         .IsNetworkError()
                         .Should()
                         .Be(HalibutNetworkExceptionType.UnknownError);
@@ -131,7 +131,7 @@ namespace Halibut.Tests.Diagnostics
                 {
                     var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(serviceEndPoint => { serviceEndPoint.RetryCountLimit = 1; });
 
-                    (await AssertAsync.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello"))).And
+                    (await AssertException.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello"))).And
                         .IsNetworkError()
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
@@ -153,7 +153,7 @@ namespace Halibut.Tests.Diagnostics
                     {
                         point.RetryCountLimit = 1;
                     });
-                    (await AssertAsync.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello")))
+                    (await AssertException.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello")))
                         .And
                         .IsNetworkError()
                         .Should()
@@ -173,7 +173,7 @@ namespace Halibut.Tests.Diagnostics
                 {
                     var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
 
-                    (await AssertAsync.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello")))
+                    (await AssertException.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Hello")))
                         .And
                         .IsNetworkError()
                         .Should()
@@ -201,7 +201,7 @@ namespace Halibut.Tests.Diagnostics
 
                             });
 
-                    (await AssertAsync.Throws<HalibutClientException>(async () => await echo.CountBytesAsync(dataStream)))
+                    (await AssertException.Throws<HalibutClientException>(async () => await echo.CountBytesAsync(dataStream)))
                         .And
                         .IsNetworkError()
                         .Should()
@@ -226,7 +226,7 @@ namespace Halibut.Tests.Diagnostics
                             throw new FileNotFoundException();
                         });
 
-                    (await AssertAsync.Throws<HalibutClientException>(() => echo.CountBytesAsync(dataStream)))
+                    (await AssertException.Throws<HalibutClientException>(() => echo.CountBytesAsync(dataStream)))
                         .And
                         .IsNetworkError()
                         .Should()
@@ -244,7 +244,7 @@ namespace Halibut.Tests.Diagnostics
                 {
                     var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
 
-                    var exception = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
+                    var exception = (await AssertException.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
                     exception.IsNetworkError().Should().Be(HalibutNetworkExceptionType.NotANetworkError);
                 }
             }

--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -195,8 +195,10 @@ namespace Halibut.Tests.Diagnostics
                         async (_, _) =>
                             {
                                 await Task.CompletedTask;
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                                 new FileStream("DoesNotExist2497546", FileMode.Open).Dispose();
-                                
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
+
                             });
 
                     (await AssertAsync.Throws<HalibutClientException>(async () => await echo.CountBytesAsync(dataStream)))

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -43,7 +43,7 @@ namespace Halibut.Tests
                 });
 
                 
-                var error = (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Paul"))).And;
+                var error = (await AssertException.Throws<HalibutClientException>(() => echo.SayHelloAsync("Paul"))).And;
                 error.Message.Should().Contain("the polling endpoint did not collect the request within the allowed time");
             }
         }
@@ -58,7 +58,7 @@ namespace Halibut.Tests
                        .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
-                var ex = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
+                var ex = (await AssertException.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
                 if (clientAndServiceTestCase.ClientAndServiceTestVersion.IsPreviousService())
                 {
                     ex.Message.Should().Contain("at Halibut.TestUtils.SampleProgram.Base.Services.EchoService.Crash()").And.Contain("divide by zero");
@@ -89,7 +89,7 @@ namespace Halibut.Tests
                              .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
-                var ex = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
+                var ex = (await AssertException.Throws<ServiceInvocationHalibutClientException>(() => echo.CrashAsync())).And;
                 var expected = "at Halibut.Tests.TestServices.AsyncEchoService.CrashAsync(";
 #if NETFRAMEWORK
                     expected = "at Halibut.Tests.TestServices.AsyncEchoService.<CrashAsync>";
@@ -178,7 +178,7 @@ System.Reflection.TargetInvocationException: Exception has been thrown by the ta
                 // This loop ensures (at the time) the test shows the problem.
                 for (var i = 0; i < 128; i++)
                 {
-                    await AssertAsync.Throws<HalibutClientException>(async () => await readDataSteamService.SendDataAsync(
+                    await AssertException.Throws<HalibutClientException>(async () => await readDataSteamService.SendDataAsync(
                         new DataStream(10000, 
                             async (_, _) =>
                                 {

--- a/source/Halibut.Tests/FailureModesFixture.cs
+++ b/source/Halibut.Tests/FailureModesFixture.cs
@@ -124,7 +124,7 @@ System.Reflection.TargetInvocationException: Exception has been thrown by the ta
             {
                 var echo = octopus.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(new ServiceEndPoint("https://sduj08ud9382ujd98dw9fh934hdj2389u982:8000", Certificates.TentacleListeningPublicThumbprint, octopus.TimeoutsAndLimits));
                 var ex = Assert.ThrowsAsync<HalibutClientException>(async () => await echo.CrashAsync());
-                var message = ex.Message;
+                var message = ex!.Message;
 
                 message.Should().Contain("when sending a request to 'https://sduj08ud9382ujd98dw9fh934hdj2389u982:8000/', before the request");
 
@@ -157,7 +157,7 @@ System.Reflection.TargetInvocationException: Exception has been thrown by the ta
                 };
                 var echo = octopus.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(endpoint);
                 var ex = Assert.ThrowsAsync<HalibutClientException>(async () => await echo.CrashAsync());
-                ex.Message.Should().Be("An error occurred when sending a request to 'https://google.com:88/', before the request could begin: The client was unable to establish the initial connection within the timeout 00:00:02.");
+                ex!.Message.Should().Be("An error occurred when sending a request to 'https://google.com:88/', before the request could begin: The client was unable to establish the initial connection within the timeout 00:00:02.");
             }
         }
 

--- a/source/Halibut.Tests/FriendlyHtmlPageTests.cs
+++ b/source/Halibut.Tests/FriendlyHtmlPageTests.cs
@@ -83,7 +83,7 @@ namespace Halibut.Tests
                 var listenPort = octopus.Listen();
                 logger.Information("Got port to listen on..");
                 var sw = new Stopwatch();
-                await AssertAsync.Throws<HttpRequestException>(() =>
+                await AssertException.Throws<HttpRequestException>(() =>
                 {
                     logger.Information("Sending request.");
                     sw.Start();

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -8,6 +8,7 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
+	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net48;net6.0</TargetFrameworks>

--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -19,7 +19,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling:false)]
         public async Task ListeningRetriesAttemptsUpToTheConfiguredValue(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            TcpConnectionsCreatedCounter? tcpConnectionsCreatedCounter = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
@@ -45,7 +45,7 @@ namespace Halibut.Tests
                 
                 await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
 
-                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(20);
+                tcpConnectionsCreatedCounter!.ConnectionsCreatedCount.Should().Be(20);
             }
         }
         
@@ -53,13 +53,12 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
         public async Task ListeningRetriesAttemptsUpToTheConfiguredTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
                        {
                            var portForwarder = PortForwarderUtil.ForwardingToLocalPort(port)
-                               .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                               .WithCountTcpConnectionsCreated(out _)
                                .Build();
 
                            return portForwarder;
@@ -90,13 +89,12 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
         public async Task ListeningRetryListeningSleepIntervalWorks(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
                        {
                            var portForwarder = PortForwarderUtil.ForwardingToLocalPort(port)
-                               .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
+                               .WithCountTcpConnectionsCreated(out _)
                                .Build();
 
                            return portForwarder;
@@ -127,7 +125,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testWebSocket: false, testPolling: false)]
         public async Task ListeningRetriesAttemptsCanEventuallyWork(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            TcpConnectionsCreatedCounter? tcpConnectionsCreatedCounter = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
                        .WithPortForwarding(port =>
@@ -152,7 +150,7 @@ namespace Halibut.Tests
                 });
 
                 var echoCallThatShouldEventuallySucceed = Task.Run(() => echoService.SayHelloAsync("hello"));
-                while (tcpConnectionsCreatedCounter.ConnectionsCreatedCount < 5)
+                while (tcpConnectionsCreatedCounter!.ConnectionsCreatedCount < 5)
                 {
                     Logger.Information("TCP count is at: {Count}", tcpConnectionsCreatedCounter.ConnectionsCreatedCount);
                     await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken);

--- a/source/Halibut.Tests/ListeningConnectRetryFixture.cs
+++ b/source/Halibut.Tests/ListeningConnectRetryFixture.cs
@@ -43,7 +43,7 @@ namespace Halibut.Tests
                     point.RetryCountLimit = 20;
                 });
                 
-                await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
+                await AssertException.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
 
                 tcpConnectionsCreatedCounter!.ConnectionsCreatedCount.Should().Be(20);
             }
@@ -77,7 +77,7 @@ namespace Halibut.Tests
                 });
 
                 var sw = Stopwatch.StartNew();
-                await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
+                await AssertException.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
                 sw.Stop();
 
                 
@@ -113,7 +113,7 @@ namespace Halibut.Tests
                 });
 
                 var sw = Stopwatch.StartNew();
-                await AssertAsync.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
+                await AssertException.Throws<HalibutClientException>(() => echoService.SayHelloAsync("hello"));
                 sw.Stop();
 
                 // Expected ~30s since we sleep 10s _between_ each attempt.

--- a/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
+++ b/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
@@ -19,7 +19,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testPolling: false, testWebSocket: false, testNetworkConditions: false)]
         public async Task TestOnlyHealthConnectionsAreKeptInThePool(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            TcpConnectionsCreatedCounter? tcpConnectionsCreatedCounter = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                            .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
@@ -38,7 +38,7 @@ namespace Halibut.Tests
                 var pauseCurrentTcpConnections = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionService>();
 
                 await echoService.SayHelloAsync("This should make one connection");
-                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1);
+                tcpConnectionsCreatedCounter!.ConnectionsCreatedCount.Should().Be(1);
                 
                 await echoService.SayHelloAsync("Should re-use the same connection");
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "We should use the same connection since the last was healthy");
@@ -53,7 +53,7 @@ namespace Halibut.Tests
                 
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(2, "Since the last connection should not have been put back into the pool.");
 
-                sw.Elapsed.Should().BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout, "we should not be putting the bad connection back into the pool, " +
+                sw.Elapsed.Should().BeLessThan(clientAndService.Service!.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout, "we should not be putting the bad connection back into the pool, " +
                                                                                                                                     "then pulling it out detecting it is bad and then attempting to create a new connection");
             }
         }

--- a/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
+++ b/source/Halibut.Tests/ListeningTentaclesUseAPoolOfConnectionsFixture.cs
@@ -43,7 +43,7 @@ namespace Halibut.Tests
                 await echoService.SayHelloAsync("Should re-use the same connection");
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "We should use the same connection since the last was healthy");
 
-                await AssertAsync.Throws<HalibutClientException>(() => pauseCurrentTcpConnections.ActionAsync());
+                await AssertException.Throws<HalibutClientException>(() => pauseCurrentTcpConnections.ActionAsync());
                 // Connection should not be put back into the pool
                 tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1, "This should still be using the same connection since it is on this call we break the connection.");
 

--- a/source/Halibut.Tests/LocalDataStreamFixture.cs
+++ b/source/Halibut.Tests/LocalDataStreamFixture.cs
@@ -13,7 +13,7 @@ namespace Halibut.Tests
             const string input = "Hello World!";
             var dataStream = DataStream.FromString(input);
 
-            string result = null;
+            var result = string.Empty;
             await dataStream.Receiver().ReadAsync(async (stream, _) => result = await ReadStreamAsStringAsync(stream), CancellationToken);
 
             result.Should().Be(input);

--- a/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
+++ b/source/Halibut.Tests/PollingClientConnectionHandlingFixture.cs
@@ -61,7 +61,7 @@ namespace Halibut.Tests
                 {
                     await doSomeActionService.ActionAsync();
                 }
-                catch (HalibutClientException ex)
+                catch (HalibutClientException)
                 {
                     // Work around the known dequeue to a broken tcp connection issue
                     await doSomeActionService.ActionAsync();
@@ -74,7 +74,7 @@ namespace Halibut.Tests
                 {
                     await doSomeActionService.ActionAsync();
                 }
-                catch (HalibutClientException ex)
+                catch (HalibutClientException)
                 {
                     // Work around the known dequeue to a broken tcp connection issue
                     await doSomeActionService.ActionAsync();

--- a/source/Halibut.Tests/PollingTentacleDequeuesRequestsInOrderFixture.cs
+++ b/source/Halibut.Tests/PollingTentacleDequeuesRequestsInOrderFixture.cs
@@ -21,7 +21,7 @@ namespace Halibut.Tests
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
         public async Task QueuedUpRequestsShouldBeDequeuedInOrder(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            IPendingRequestQueue pendingRequestQueue = null;
+            IPendingRequestQueue ?pendingRequestQueue = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .WithStandardServices()
                        .AsLatestClientAndLatestServiceBuilder()
@@ -68,7 +68,7 @@ namespace Halibut.Tests
                     await Wait.For(async () =>
                     {
                         await task.AwaitIfFaulted();
-                        return pendingRequestQueue.Count == i + 1;
+                        return pendingRequestQueue!.Count == i + 1;
                     }, CancellationToken);
                 }
 

--- a/source/Halibut.Tests/PollingTentacleDequeuesRequestsInOrderFixture.cs
+++ b/source/Halibut.Tests/PollingTentacleDequeuesRequestsInOrderFixture.cs
@@ -52,7 +52,9 @@ namespace Halibut.Tests
                 var pollingTentacleKeptBusyRequest = Task.Run(async () => await lockService.WaitForFileToBeDeletedAsync(fileStoppingNewRequests, fileThatLetsUsKnowThePollingTentacleIsBusy));
                 await Wait.For(async () =>
                 {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                     await pollingTentacleKeptBusyRequest.AwaitIfFaulted();
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
                     return File.Exists(fileThatLetsUsKnowThePollingTentacleIsBusy);
                 }, CancellationToken);
 
@@ -67,7 +69,9 @@ namespace Halibut.Tests
                     // Wait for the RPC call to get on to the queue before proceeding
                     await Wait.For(async () =>
                     {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
                         await task.AwaitIfFaulted();
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
                         return pendingRequestQueue!.Count == i + 1;
                     }, CancellationToken);
                 }

--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -52,7 +52,7 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
                 });
 
-                (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello")))
+                (await AssertException.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello")))
                     .And.Message.Should().ContainAny(
                         "No connection could be made because the target machine actively refused it",
                         "the polling endpoint did not collect the request within the allowed time",
@@ -79,7 +79,7 @@ namespace Halibut.Tests
                     point.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
                 });
 
-                var exception = (await AssertAsync.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello"))).And;
+                var exception = (await AssertException.Throws<HalibutClientException>(() => echo.SayHelloAsync("Hello"))).And;
                 Logger.Information(exception, "Got exception, we were expecting one.");    
                 exception.Message.Should().ContainAny(
                         "No connection could be made because the target machine actively refused it",

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -203,7 +203,7 @@ namespace Halibut.Tests
                        .WithCachingService()
                        .Build(CancellationToken))
             {
-                clientAndService.Client.OverrideErrorResponseMessageCaching = response => response.Error.Message.Contains("CACHE ME");
+                clientAndService.Client!.OverrideErrorResponseMessageCaching = response => response.Error!.Message.Contains("CACHE ME");
 
                 var client = clientAndService.CreateAsyncClient<ICachingService, IAsyncClientCachingService>();
 
@@ -249,7 +249,7 @@ namespace Halibut.Tests
             OverrideErrorResponseMessageCachingAction action = message => false;
             
             // Actual test, testing a null response.
-            cache.CacheResponse(serviceEndpoint, request, methodInfo, null, action);
+            cache.CacheResponse(serviceEndpoint, request, methodInfo, null!, action);
             cache.GetCachedResponse(serviceEndpoint, request, methodInfo).Should().BeNull();
             
             // This just checks we are using the cache correctly, ensuring the above is valid.

--- a/source/Halibut.Tests/ResponseMessageCacheFixture.cs
+++ b/source/Halibut.Tests/ResponseMessageCacheFixture.cs
@@ -207,13 +207,13 @@ namespace Halibut.Tests
 
                 var client = clientAndService.CreateAsyncClient<ICachingService, IAsyncClientCachingService>();
 
-                var exception1 = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"UNCACHED"))).And;
-                var exception2 = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"UNCACHED"))).And;
+                var exception1 = (await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"UNCACHED"))).And;
+                var exception2 = (await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"UNCACHED"))).And;
                 exception1!.Message.Should().NotBe(exception2!.Message);
 
 
-                var exception3 = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"CACHE ME"))).And;
-                var exception4 = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"CACHE ME"))).And;
+                var exception3 = (await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"CACHE ME"))).And;
+                var exception4 = (await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"CACHE ME"))).And;
                 exception3!.Message.Should().Be(exception4!.Message);
             }
         }
@@ -229,8 +229,8 @@ namespace Halibut.Tests
             {
                 var client = clientAndService.CreateAsyncClient<ICachingService, IAsyncClientCachingService>();
 
-                var exception1 = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"Exception"))).And;
-                var exception2 = (await AssertAsync.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"Exception"))).And;
+                var exception1 = (await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"Exception"))).And;
+                var exception2 = (await AssertException.Throws<ServiceInvocationHalibutClientException>(async () => await client.CachableCallThatThrowsAnExceptionWithARandomExceptionMessageAsync($"Exception"))).And;
 
                 exception1!.Message.Should().StartWith("Exception");
                 exception2!.Message.Should().StartWith("Exception");

--- a/source/Halibut.Tests/ServiceEndPointFixture.cs
+++ b/source/Halibut.Tests/ServiceEndPointFixture.cs
@@ -12,7 +12,7 @@ namespace Halibut.Tests
             var json = "{BaseUri: \"http://google.com\", RemoteThumbprint: \"AAAA\"}";
             var result = JsonConvert.DeserializeObject<ServiceEndPoint>(json);
 
-            result.BaseUri.Host.Should().Be("google.com");
+            result!.BaseUri.Host.Should().Be("google.com");
             result.RemoteThumbprint.Should().Be("AAAA");
             Assert.Null(result.Proxy);
         }

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -61,7 +61,7 @@ namespace Halibut.Tests.ServiceModel
             queueAndWaitTask.IsCompleted.Should().BeFalse();
 
             // Apply unrelated responses
-            await sut.ApplyResponse(null, request.Destination);
+            await sut.ApplyResponse(null!, request.Destination);
             await sut.ApplyResponse(unexpectedResponse, request.Destination);
 
             await Task.Delay(1000, CancellationToken);
@@ -95,7 +95,7 @@ namespace Halibut.Tests.ServiceModel
             // Although we sleep for 1 second, sometimes it can be just under. So be generous with the buffer.
             stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(800));
             response.Id.Should().Be(request.Id);
-            response.Error.Message.Should().Be("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:01), so the request timed out.");
+            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:01), so the request timed out.");
 
             var next = await sut.DequeueAsync(CancellationToken);
             next.Should().BeNull();
@@ -125,7 +125,7 @@ namespace Halibut.Tests.ServiceModel
             // Although we sleep for 2 second, sometimes it can be just under. So be generous with the buffer.
             stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(1800));
             response.Id.Should().Be(request.Id);
-            response.Error.Message.Should().Be("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:01), so the request timed out.");
+            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:01), so the request timed out.");
 
             var next = await sut.DequeueAsync(CancellationToken);
             next.Should().BeNull();
@@ -213,7 +213,7 @@ namespace Halibut.Tests.ServiceModel
             await WaitForQueueCountToBecome(sut, requestsInOrder.Count);
 
             // Assert
-            var requests = new List<RequestMessage>();
+            var requests = new List<RequestMessage?>();
             for (int i = 0; i < requestsInOrder.Count; i++)
             {
                 var request = await sut.DequeueAsync(CancellationToken);
@@ -285,7 +285,7 @@ namespace Halibut.Tests.ServiceModel
             
             var index = 0;
             var cancelled = 0;
-            var dequeueTasks = new ConcurrentBag<Task<RequestMessage>>();
+            var dequeueTasks = new ConcurrentBag<Task<RequestMessage?>>();
 
             var cancelSomeTask = Task.Run(() =>
             {
@@ -416,7 +416,7 @@ namespace Halibut.Tests.ServiceModel
             // Although we sleep for 1 second, sometimes it can be just under. So be generous with the buffer.
             stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(800));
             response.Id.Should().Be(request.Id);
-            response.Error.Message.Should().Be("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:01), so the request timed out.");
+            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:01), so the request timed out.");
         }
         
         [Test]

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.ServiceModel;
 using Halibut.Tests.Builders;
+using Halibut.Tests.Support;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
@@ -349,7 +350,7 @@ namespace Halibut.Tests.ServiceModel
             cancellationTokenSource.Cancel();
 
             // Assert
-            await AssertionExtensions.Should(() => queueAndWaitTask).ThrowAsync<OperationCanceledException>();
+            await AssertAsync.Throws<OperationCanceledException>(queueAndWaitTask);
 
             var next = await sut.DequeueAsync(CancellationToken);
             next.Should().BeNull();
@@ -554,7 +555,7 @@ namespace Halibut.Tests.ServiceModel
             await Task.Delay(1000, CancellationToken);
             await sut.DequeueAsync(CancellationToken);
 
-            await AssertionExtensions.Should(() => queueAndWaitTask).ThrowAsync<OperationCanceledException>();
+            await AssertAsync.Throws<OperationCanceledException>(queueAndWaitTask);
 
 
             // Act

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -350,7 +350,7 @@ namespace Halibut.Tests.ServiceModel
             cancellationTokenSource.Cancel();
 
             // Assert
-            await AssertAsync.Throws<OperationCanceledException>(queueAndWaitTask);
+            await AssertException.Throws<OperationCanceledException>(queueAndWaitTask);
 
             var next = await sut.DequeueAsync(CancellationToken);
             next.Should().BeNull();
@@ -555,7 +555,7 @@ namespace Halibut.Tests.ServiceModel
             await Task.Delay(1000, CancellationToken);
             await sut.DequeueAsync(CancellationToken);
 
-            await AssertAsync.Throws<OperationCanceledException>(queueAndWaitTask);
+            await AssertException.Throws<OperationCanceledException>(queueAndWaitTask);
 
 
             // Act

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -527,7 +527,7 @@ namespace Halibut.Tests.ServiceModel
             await sut.ApplyResponse(expectedResponse, request.Destination);
             await queueAndWaitTask;
 
-            var singleDequeuedRequest = dequeueTasks.Should().ContainSingle(t => t.Result != null).Subject.Result;
+            var singleDequeuedRequest = await dequeueTasks.Should().ContainSingle(t => t.Result != null).Subject;
             singleDequeuedRequest.Should().Be(request);
         }
 

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -636,7 +636,7 @@ namespace Halibut.Tests.ServiceModel
 
             //Concurrently apply responses to prove this does not cause issues.
             var applyResponseTasks = requestsInOrder
-                .Select((r,i) => Task.Factory.StartNew(async () => await sut.ApplyResponse(expectedResponsesInOrder[i], r.Destination)))
+                .Select((r,i) => Task.Run(async () => await sut.ApplyResponse(expectedResponsesInOrder[i], r.Destination)))
                 .ToList();
             
             await Task.WhenAll(applyResponseTasks);

--- a/source/Halibut.Tests/ServiceModel/ServiceInvokerFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/ServiceInvokerFixture.cs
@@ -68,7 +68,7 @@ namespace Halibut.Tests.ServiceModel
                 MethodName = nameof(IBrokenConventionService.GetRandomNumberMissingSuffix)
             };
 
-            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+            await AssertException.Throws<Exception>(() => sut.InvokeAsync(request));
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace Halibut.Tests.ServiceModel
                 MethodName = nameof(IBrokenConventionService.GetRandomNumberMissingCancellationToken)
             };
 
-            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+            await AssertException.Throws<Exception>(() => sut.InvokeAsync(request));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace Halibut.Tests.ServiceModel
                 Params = new[] { value }
             };
 
-            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+            await AssertException.Throws<Exception>(() => sut.InvokeAsync(request));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace Halibut.Tests.ServiceModel
                 MethodName = nameof(IBrokenConventionService.SayHelloMissingCancellationToken)
             };
 
-            await AssertAsync.Throws<Exception>(() => sut.InvokeAsync(request));
+            await AssertException.Throws<Exception>(() => sut.InvokeAsync(request));
         }
     }
 }

--- a/source/Halibut.Tests/Support/AssertAsync.cs
+++ b/source/Halibut.Tests/Support/AssertAsync.cs
@@ -11,5 +11,11 @@ namespace Halibut.Tests.Support
         {
             return await task.Should().ThrowAsync<T>(because);
         }
+
+        //TODO: @server-at-scale this does not belong here. Move it, or rename this class.
+        public static ExceptionAssertions<T> Throws<T>(this Action task, string because = "") where T : Exception
+        {
+            return task.Should().Throw<T>(because);
+        }
     }
 }

--- a/source/Halibut.Tests/Support/AssertAsync.cs
+++ b/source/Halibut.Tests/Support/AssertAsync.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Specialized;
+using NSubstitute.ExceptionExtensions;
 
 namespace Halibut.Tests.Support
 {
@@ -10,6 +11,13 @@ namespace Halibut.Tests.Support
         public static async Task<ExceptionAssertions<T>> Throws<T>(this Func<Task> task, string because = "") where T : Exception
         {
             return await task.Should().ThrowAsync<T>(because);
+        }
+
+        public static async Task<ExceptionAssertions<TExpectedException>> Throws<TExpectedException>(Task task, string because = "") where TExpectedException : Exception
+        {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+            return await AssertionExtensions.Should(() => task).ThrowAsync<TExpectedException>(because);
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
 
         //TODO: @server-at-scale this does not belong here. Move it, or rename this class.

--- a/source/Halibut.Tests/Support/AssertException.cs
+++ b/source/Halibut.Tests/Support/AssertException.cs
@@ -2,11 +2,10 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Specialized;
-using NSubstitute.ExceptionExtensions;
 
 namespace Halibut.Tests.Support
 {
-    public static class AssertAsync
+    public static class AssertException
     {
         public static async Task<ExceptionAssertions<T>> Throws<T>(this Func<Task> task, string because = "") where T : Exception
         {
@@ -20,7 +19,6 @@ namespace Halibut.Tests.Support
 #pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
 
-        //TODO: @server-at-scale this does not belong here. Move it, or rename this class.
         public static ExceptionAssertions<T> Throws<T>(this Action task, string because = "") where T : Exception
         {
             return task.Should().Throw<T>(because);

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryPath.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryPath.cs
@@ -10,7 +10,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             var onDiskVersion = version.Replace(".", "_");
             var assemblyDir = new DirectoryInfo(Path.GetDirectoryName(typeof(HalibutTestBinaryRunner).Assembly.Location)!);
-            var upAt = assemblyDir.Parent.Parent.Parent.Parent;
+            var upAt = assemblyDir.Parent!.Parent!.Parent!.Parent!;
             var projectName = $"Halibut.TestUtils.CompatBinary.v{onDiskVersion}";
             var executable = Path.Combine(upAt.FullName, projectName, assemblyDir.Parent.Parent.Name, assemblyDir.Parent.Name, assemblyDir.Name, projectName);
             executable = AddExeForWindows(executable);

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/HalibutTestBinaryRunner.cs
@@ -19,11 +19,11 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly int? clientServicePort;
         readonly CertAndThumbprint clientCertAndThumbprint;
         readonly CertAndThumbprint serviceCertAndThumbprint;
-        readonly string version;
+        readonly string? version;
         readonly ProxyDetails? proxyDetails;
         readonly LogLevel halibutLogLevel;
         readonly ILogger logger;
-        readonly Uri webSocketServiceEndpointUri;
+        readonly Uri? webSocketServiceEndpointUri;
         readonly OldServiceAvailableServices availableServices;
 
         public HalibutTestBinaryRunner(
@@ -91,7 +91,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 { "TestTimeout", TestContext.CurrentContext.GetTestTimeout()?.ToString() ?? string.Empty }
             };
 
-            if (proxyDetails != null)
+            if (proxyDetails is not null)
             {
                 settings.Add("proxydetails_host", proxyDetails.Host);
                 settings.Add("proxydetails_password", proxyDetails.Password);
@@ -120,7 +120,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         }
 
         async Task<(Task RunningTentacleTask, int? ServiceListenPort, CancellationTokenSource RunningTentacleCancellationTokenSource)> StartHalibutTestBinary(
-            string version, 
+            string? version, 
             Dictionary<string, string?> settings, 
             TmpDirectory tmp)
         {
@@ -150,7 +150,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                             if (s.Contains("RunningAndReady")) hasTentacleStarted.Set();
                         }
 
-                        await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version))
+                        await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version!))
                             .WithArguments(new string[0])
                             .WithWorkingDirectory(tmp.FullPath)
                             .WithStandardOutputPipe(PipeTarget.ToDelegate(ProcessLogs))

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/LatestClientAndPreviousServiceVersionBuilder.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
         Version? version = null;
         Func<int, PortForwarder>? portForwarderFactory;
-        ProxyFactory proxyFactory;
+        ProxyFactory? proxyFactory;
         LogLevel halibutLogLevel = LogLevel.Trace;
         OldServiceAvailableServices availableServices = new(false, false);
         bool hasService = true;
@@ -184,7 +184,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
             if (proxy != null)
             {
                 await proxy.StartAsync();
-                proxyDetails = new ProxyDetails("localhost", proxy.Endpoint.Port, ProxyType.HTTP);
+                proxyDetails = new ProxyDetails("localhost", proxy.Endpoint!.Port, ProxyType.HTTP);
             }
 
             Uri serviceUri;
@@ -208,7 +208,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                         clientCertAndThumbprint,
                         serviceCertAndThumbprint,
                         version?.ToString(),
-                        proxyDetails,
+                        proxyDetails!,
                         halibutLogLevel,
                         availableServices,
                         logger).Run();

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/PreviousClientVersionAndLatestServiceBuilder.cs
@@ -30,17 +30,14 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
     {
         readonly ServiceConnectionType serviceConnectionType;
         
-        ServiceFactoryBuilder serviceFactoryBuilder = new();
-        IServiceFactory? serviceFactory;
+        readonly ServiceFactoryBuilder serviceFactoryBuilder = new();
         readonly CertAndThumbprint serviceCertAndThumbprint;
         readonly CertAndThumbprint clientCertAndThumbprint = CertAndThumbprint.Octopus;
         Version? version = null;
         ProxyFactory? proxyFactory;
         Func<int, PortForwarder>? portForwarderFactory;
         LogLevel halibutLogLevel = LogLevel.Trace;
-        ILockService lockService;
-        ICountingService countingService;
-
+        
         PreviousClientVersionAndLatestServiceBuilder(ServiceConnectionType serviceConnectionType, CertAndThumbprint serviceCertAndThumbprint)
         {
             this.serviceConnectionType = serviceConnectionType;
@@ -103,18 +100,6 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         {
             serviceFactoryBuilder.WithService<TContract, TClientContract>(implementation);
             
-            if (serviceFactory != null)
-            {
-                if (serviceFactory is DelegateServiceFactory delegateServiceFactory)
-                {
-                    delegateServiceFactory.Register<TContract, TClientContract>(implementation);
-                }
-                else
-                {
-                    throw new Exception("WithService can only be used with a custom ServiceFactory if it is a DelegateServiceFactory");
-                }
-            }
-
             return this;
         }
 

--- a/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
+++ b/source/Halibut.Tests/Support/BackwardsCompatibility/ProxyHalibutTestBinaryRunner.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         readonly int? proxyClientListeningPort;
         readonly CertAndThumbprint clientCertAndThumbprint;
         readonly CertAndThumbprint serviceCertAndThumbprint;
-        readonly string version;
+        readonly string? version;
         readonly ProxyDetails? proxyDetails;
         readonly string? webSocketPath;
         readonly LogLevel halibutLogLevel;
@@ -64,7 +64,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 { CompatBinaryStayAlive.StayAliveFilePathEnvVarKey, compatBinaryStayAlive.LockFile }
             };
 
-            if (proxyDetails != null)
+            if (proxyDetails is not null)
             {
                 settings.Add("proxydetails_host", proxyDetails.Host);
                 settings.Add("proxydetails_password", proxyDetails.Password);
@@ -91,7 +91,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
         }
 
         async Task<(Task RunningTentacleTask, int? ServiceListenPort, int? ProxyClientListenPort, CancellationTokenSource RunningTentacleCancellationTokenSource)> StartHalibutTestBinary(
-            string version, 
+            string? version, 
             Dictionary<string, string?> settings,
             TmpDirectory tmp)
         {
@@ -109,7 +109,7 @@ namespace Halibut.Tests.Support.BackwardsCompatibility
                 {
                     try
                     {
-                        await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version))
+                        await Cli.Wrap(new HalibutTestBinaryPath().BinPath(version!))
                             .WithArguments(Array.Empty<string>())
                             .WithWorkingDirectory(tmp.FullPath)
                             .WithStandardOutputPipe(PipeTarget.ToDelegate(ProcessLogs))

--- a/source/Halibut.Tests/Support/Certificates.cs
+++ b/source/Halibut.Tests/Support/Certificates.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests.Support
         static Certificates()
         {
             //jump through hoops to find certs because the nunit test runner is messing with directories
-            var directory = Path.Combine(Path.GetDirectoryName(new Uri(typeof(Certificates).Assembly.CodeBase).LocalPath), "Certificates");
+            var directory = Path.Combine(Path.GetDirectoryName(new Uri(typeof(Certificates).Assembly.Location).LocalPath)!, "Certificates");
             TentacleListeningPfxPath = Path.Combine(directory, "TentacleListening.pfx");
             TentacleListening = new X509Certificate2(TentacleListeningPfxPath);
             TentacleListeningPublicThumbprint = TentacleListening.Thumbprint;

--- a/source/Halibut.Tests/Support/ExtensionMethods/TestContextExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/ExtensionMethods/TestContextExtensionMethods.cs
@@ -10,7 +10,7 @@ namespace Halibut.Tests.Support.ExtensionMethods
         public static TestExecutionContext GetTestExecutionContext(this TestContext testContext)
         {
             var testExecutionContextField = testContext.GetType().GetField("_testExecutionContext", BindingFlags.NonPublic | BindingFlags.Instance);
-            var testExecutionContext = (TestExecutionContext)testExecutionContextField!.GetValue(testContext);
+            var testExecutionContext = (TestExecutionContext)testExecutionContextField!.GetValue(testContext)!;
 
             return testExecutionContext;
         }

--- a/source/Halibut.Tests/Support/IClientAndService.cs
+++ b/source/Halibut.Tests/Support/IClientAndService.cs
@@ -7,7 +7,7 @@ namespace Halibut.Tests.Support
 {
     public interface IClientAndService : IAsyncDisposable
     {
-        HalibutRuntime Client { get; }
+        HalibutRuntime? Client { get; }
         ServiceEndPoint ServiceEndPoint { get; }
         PortForwarder? PortForwarder { get; }
         HttpProxyService? HttpProxy { get; }

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -52,14 +52,14 @@ namespace Halibut.Tests.Support
         LogLevel halibutLogLevel = LogLevel.Trace;
         ConcurrentDictionary<string, ILog>? clientInMemoryLoggers;
         ConcurrentDictionary<string, ILog>? serviceInMemoryLoggers;
-        ITrustProvider clientTrustProvider;
-        Func<string, string, UnauthorizedClientConnectResponse> clientOnUnauthorizedClientConnect;
+        ITrustProvider? clientTrustProvider;
+        Func<string, string, UnauthorizedClientConnectResponse>? clientOnUnauthorizedClientConnect;
         HalibutTimeoutsAndLimits halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
 
         IStreamFactory? clientStreamFactory;
         IStreamFactory? serviceStreamFactory;
-        IConnectionsObserver serviceConnectionsObserver;
-        IConnectionsObserver clientConnectionsObserver;
+        IConnectionsObserver? serviceConnectionsObserver;
+        IConnectionsObserver? clientConnectionsObserver;
 
         public LatestClientAndLatestServiceBuilder(
             ServiceConnectionType serviceConnectionType,
@@ -371,11 +371,11 @@ namespace Halibut.Tests.Support
                     .WithServerCertificate(clientCertAndThumbprint.Certificate2)
                     .WithLogFactory(octopusLogFactory)
                     .WithPendingRequestQueueFactory(factory)
-                    .WithTrustProvider(clientTrustProvider)
+                    .WithTrustProvider(clientTrustProvider!)
                     .WithStreamFactoryIfNotNull(clientStreamFactory)
-                    .WithConnectionsObserver(clientConnectionsObserver)
+                    .WithConnectionsObserver(clientConnectionsObserver!)
                     .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
-                    .WithOnUnauthorizedClientConnect(clientOnUnauthorizedClientConnect);
+                    .WithOnUnauthorizedClientConnect(clientOnUnauthorizedClientConnect!);
 
                 if (clientRpcObserver is not null)
                 {
@@ -395,7 +395,7 @@ namespace Halibut.Tests.Support
                     .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                     .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                     .WithStreamFactoryIfNotNull(serviceStreamFactory)
-                    .WithConnectionsObserver(serviceConnectionsObserver)
+                    .WithConnectionsObserver(serviceConnectionsObserver!)
                     .WithLogFactory(BuildServiceLogger());
 
                 if(pollingReconnectRetryPolicy != null) serviceBuilder.WithPollingReconnectRetryPolicy(pollingReconnectRetryPolicy);
@@ -410,7 +410,7 @@ namespace Halibut.Tests.Support
             if (httpProxy != null)
             {
                 await httpProxy.StartAsync();
-                httpProxyDetails = new ProxyDetails("localhost", httpProxy.Endpoint.Port, ProxyType.HTTP);
+                httpProxyDetails = new ProxyDetails("localhost", httpProxy.Endpoint!.Port, ProxyType.HTTP);
             }
 
             Uri serviceUri;
@@ -449,7 +449,7 @@ namespace Halibut.Tests.Support
                 var clientUrsToPoll = pollingClientUris.ToList();
                 if (createClient)
                 {
-                    var webSocketListeningInfo = await TryListenWebSocket.WebSocketListeningPort(logger, client, cancellationToken);
+                    var webSocketListeningInfo = await TryListenWebSocket.WebSocketListeningPort(logger, client!, cancellationToken);
 
                     var webSocketSslCertificate = new WebSocketSslCertificateBuilder(webSocketListeningInfo.WebSocketSslCertificateBindingAddress)
                         .WithCertificate(clientCertAndThumbprint)
@@ -578,7 +578,7 @@ namespace Halibut.Tests.Support
             public ClientAndService(
                 HalibutRuntime? client,
                 Uri? clientUri,
-                HalibutRuntime service,
+                HalibutRuntime? service,
                 Uri serviceUri,
                 string thumbprint,
                 PortForwarder? portForwarder,
@@ -609,19 +609,19 @@ namespace Halibut.Tests.Support
 
             public ServiceEndPoint GetServiceEndPoint()
             {
-                return new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails, Client.TimeoutsAndLimits);
+                return new ServiceEndPoint(ServiceUri, thumbprint, proxyDetails, Client!.TimeoutsAndLimits);
             }
             
             public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>(Action<ServiceEndPoint> modifyServiceEndpoint)
             {
                 var serviceEndpoint = GetServiceEndPoint();
                 modifyServiceEndpoint(serviceEndpoint);
-                return Client.CreateAsyncClient<TService, TAsyncClientService>(serviceEndpoint);
+                return Client!.CreateAsyncClient<TService, TAsyncClientService>(serviceEndpoint);
             }
             
             public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
             {
-                return Client.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
+                return Client!.CreateAsyncClient<TService, TAsyncClientService>(ServiceEndPoint);
             }
 
             public async ValueTask DisposeAsync()

--- a/source/Halibut.Tests/Support/Logging/InMemoryLogWriter.cs
+++ b/source/Halibut.Tests/Support/Logging/InMemoryLogWriter.cs
@@ -10,13 +10,13 @@ namespace Halibut.Tests.Support.Logging
     {
         readonly ConcurrentQueue<LogEvent> events = new ConcurrentQueue<LogEvent>();
 
-        public void Write(EventType type, string message, params object[] args)
+        public void Write(EventType type, string message, params object?[] args)
         {
             var logEvent = new LogEvent(type, message, null, args);
             WriteInternal(logEvent);
         }
 
-        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        public void WriteException(EventType type, string message, Exception ex, params object?[] args)
         {
             WriteInternal(new LogEvent(type, message, ex, args));
         }

--- a/source/Halibut.Tests/Support/Logging/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests/Support/Logging/TestContextConnectionLog.cs
@@ -23,12 +23,12 @@ namespace Halibut.Tests.Support.Logging
             this.logLevel = logLevel;
         }
 
-        public void Write(EventType type, string message, params object[] args)
+        public void Write(EventType type, string message, params object?[] args)
         {
             WriteInternal(new LogEvent(type, message, null, args));
         }
 
-        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        public void WriteException(EventType type, string message, Exception ex, params object?[] args)
         {
             WriteInternal(new LogEvent(type, message, ex, args));
         }

--- a/source/Halibut.Tests/Support/Reference.cs
+++ b/source/Halibut.Tests/Support/Reference.cs
@@ -2,7 +2,9 @@
 {
     public class Reference<T>
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public Reference()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
         }
 

--- a/source/Halibut.Tests/Support/TaskExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/TaskExtensionMethods.cs
@@ -6,7 +6,9 @@ namespace Halibut.Tests.Support
     {
         public static async Task AwaitIfFaulted(this Task task)
         {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
             if (task.IsFaulted) await task;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
     }
 }

--- a/source/Halibut.Tests/Support/TestAttributes/HalibutTestCaseSourceAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/HalibutTestCaseSourceAttribute.cs
@@ -199,14 +199,14 @@ namespace Halibut.Tests.Support.TestAttributes
                 var field = member as FieldInfo;
                 if (field != null)
                     return field.IsStatic
-                        ? (MethodParams == null ? (IEnumerable)field.GetValue(null)
+                        ? (MethodParams == null ? (IEnumerable)field.GetValue(null)!
                                                 : ReturnErrorAsParameter(ParamGivenToField))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
 
                 var property = member as PropertyInfo;
                 if (property != null)
-                    return property.GetGetMethod(true).IsStatic
-                        ? (MethodParams == null ? (IEnumerable)property.GetValue(null, null)
+                    return property.GetGetMethod(true)!.IsStatic
+                        ? (MethodParams == null ? (IEnumerable)property.GetValue(null, null)!
                                                 : ReturnErrorAsParameter(ParamGivenToProperty))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
 
@@ -214,7 +214,7 @@ namespace Halibut.Tests.Support.TestAttributes
                 if (m != null)
                     return m.IsStatic
                         ? (MethodParams == null || m.GetParameters().Length == MethodParams.Length
-                            ? (IEnumerable)m.Invoke(null, MethodParams)
+                            ? (IEnumerable)m.Invoke(null, MethodParams)!
                             : ReturnErrorAsParameter(NumberOfArgsDoesNotMatch))
                         : ReturnErrorAsParameter(SourceMustBeStatic);
             }
@@ -267,7 +267,7 @@ namespace Halibut.Tests.Support.TestAttributes
     // ***********************************************************************
     static class ContextUtils
     {
-        public static T DoIsolated<T>(Func<T> func)
+        public static T? DoIsolated<T>(Func<T> func)
         {
             var returnValue = default(T);
             DoIsolated(_ => returnValue = func.Invoke(), state: null);
@@ -275,7 +275,7 @@ namespace Halibut.Tests.Support.TestAttributes
         }
 
         [SecuritySafeCritical]
-        public static void DoIsolated(ContextCallback callback, object state)
+        public static void DoIsolated(ContextCallback callback, object? state)
         {
             var previousState = SandboxedThreadState.Capture();
             try
@@ -354,7 +354,7 @@ namespace Halibut.Tests.Support.TestAttributes
                 CultureInfo.CurrentCulture,
                 CultureInfo.CurrentUICulture,
                 ThreadUtility.GetCurrentThreadPrincipal(),
-                SynchronizationContext.Current);
+                SynchronizationContext.Current!);
         }
 
         /// <summary>

--- a/source/Halibut.Tests/Support/TestAttributes/ValuesOfTypeAttribute.cs
+++ b/source/Halibut.Tests/Support/TestAttributes/ValuesOfTypeAttribute.cs
@@ -13,7 +13,8 @@ namespace Halibut.Tests.Support.TestAttributes
 
         static object[] CreateValues(Type sourceType)
         {
-            var enumerable = ((IEnumerable) Activator.CreateInstance(sourceType));
+            var instance = Activator.CreateInstance(sourceType)!;
+            var enumerable = ((IEnumerable) instance);
             return enumerable.ToArrayOfObjects();
         }
     }

--- a/source/Halibut.Tests/Support/TestConnection.cs
+++ b/source/Halibut.Tests/Support/TestConnection.cs
@@ -13,7 +13,7 @@ namespace Halibut.Tests.Support
 
         public bool Disposed { get; private set; }
 
-        public MessageExchangeProtocol Protocol => null;
+        public MessageExchangeProtocol Protocol => null!;
 
         public void Dispose()
         {

--- a/source/Halibut.Tests/Support/TmpDirectory.cs
+++ b/source/Halibut.Tests/Support/TmpDirectory.cs
@@ -18,7 +18,7 @@ namespace Halibut.Tests.Support
             var path = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
             Directory.CreateDirectory(path);
 
-            path = Path.Combine(path, Assembly.GetEntryAssembly() != null ? Assembly.GetEntryAssembly().GetName().Name : "Octopus");
+            path = Path.Combine(path, Assembly.GetEntryAssembly()?.GetName().Name ?? "Octopus");
             return Path.Combine(path, "Temp");
         }
 

--- a/source/Halibut.Tests/TcpClientCloseImmediatelyFixture.cs
+++ b/source/Halibut.Tests/TcpClientCloseImmediatelyFixture.cs
@@ -34,7 +34,7 @@ namespace Halibut.Tests
             // It's hard to see the data in the sender's buffers being dropped, however we can observe a TCP RST is received
             // by the receiver, so we assert on that.
             // An ordinary Close will not result in the receiver receiving a TCP RST.
-            await AssertAsync.Throws<IOException>(async () => {
+            await AssertException.Throws<IOException>(async () => {
                 while (await serverStream.ReadAsync(received, 0, received.Length, CancellationToken) != 0)
                 {
                     // If there's more data (i.e. non-zero data was just read), keep reading

--- a/source/Halibut.Tests/Tentacle/WhenCallingServicesSimilarToTheOnesInTentacle.cs
+++ b/source/Halibut.Tests/Tentacle/WhenCallingServicesSimilarToTheOnesInTentacle.cs
@@ -109,7 +109,7 @@ namespace Halibut.Tests.Tentacle
                 var capabilitiesService = clientAndService.CreateAsyncClient<ICapabilitiesServiceV2, IAsyncClientCapabilitiesServiceV2>();
 
                 var scriptBody = GetRandomMultiLineString();
-                var startScriptCommand = new StartScriptCommand(scriptBody, ScriptIsolationLevel.NoIsolation, TimeSpan.MaxValue, null, null, taskId: Guid.NewGuid().ToString());
+                var startScriptCommand = new StartScriptCommand(scriptBody, ScriptIsolationLevel.NoIsolation, TimeSpan.MaxValue, null, Array.Empty<string>(), taskId: Guid.NewGuid().ToString());
 
                 await capabilitiesService.GetCapabilitiesAsync();
 
@@ -151,7 +151,7 @@ namespace Halibut.Tests.Tentacle
 
                 var scriptBody = GetRandomMultiLineString();
                 var scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
-                var startScriptCommand = new StartScriptCommandV2(scriptBody, ScriptIsolationLevel.NoIsolation, TimeSpan.MaxValue, null, null, scriptTicket.TaskId, scriptTicket, TimeSpan.Zero);
+                var startScriptCommand = new StartScriptCommandV2(scriptBody, ScriptIsolationLevel.NoIsolation, TimeSpan.MaxValue, null, Array.Empty<string>(), scriptTicket.TaskId, scriptTicket, TimeSpan.Zero);
 
                 var complete = false;
                 var logs = new List<ProcessOutput>();

--- a/source/Halibut.Tests/TestPortForwarderFixture.cs
+++ b/source/Halibut.Tests/TestPortForwarderFixture.cs
@@ -50,7 +50,7 @@ namespace Halibut.Tests
                                     serviceEndPoint.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
                                 });
 
-                await AssertAsync.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Deploy package A"));
+                await AssertException.Throws<HalibutClientException>(async () => await echo.SayHelloAsync("Deploy package A"));
             }
         }
 

--- a/source/Halibut.Tests/TestServices/AsyncComplexObjectService.cs
+++ b/source/Halibut.Tests/TestServices/AsyncComplexObjectService.cs
@@ -26,15 +26,15 @@ namespace Halibut.Tests.TestServices
             {
                 Child1 = new ComplexChild1
                 {
-                    ChildPayload1 = ReadIntoNewDataStream(request.Child1.ChildPayload1),
-                    ChildPayload2 = ReadIntoNewDataStream(request.Child1.ChildPayload2),
-                    ListOfStreams = request.Child1.ListOfStreams.Select(ReadIntoNewDataStream).ToList(),
-                    DictionaryPayload = request.Child1.DictionaryPayload.ToDictionary(pair => pair.Key, pair => pair.Value),
+                    ChildPayload1 = ReadIntoNewDataStream(request.Child1!.ChildPayload1),
+                    ChildPayload2 = ReadIntoNewDataStream(request.Child1!.ChildPayload2),
+                    ListOfStreams = request.Child1.ListOfStreams!.Select(ReadIntoNewDataStream).ToList(),
+                    DictionaryPayload = request.Child1.DictionaryPayload!.ToDictionary(pair => pair.Key, pair => pair.Value),
                 },
                 Child2 = new ComplexChild2
                 {
-                    EnumPayload = request.Child2.EnumPayload,
-                    ComplexPayloadSet = request.Child2.ComplexPayloadSet.Select(x => new ComplexPair<DataStream>(x.EnumValue, ReadIntoNewDataStream(x.Payload))).ToHashSet()
+                    EnumPayload = request.Child2!.EnumPayload,
+                    ComplexPayloadSet = request.Child2.ComplexPayloadSet!.Select(x => new ComplexPair<DataStream>(x.EnumValue, ReadIntoNewDataStream(x.Payload))).ToHashSet()
                 }
             };
         }
@@ -44,18 +44,18 @@ namespace Halibut.Tests.TestServices
             await Task.CompletedTask;
             return new ComplexObjectWithInheritance
             {
-                Child1 = new ComplexInheritedChild1(request.Child1.Name),
-                Child2 = new ComplexInheritedChild2(request.Child2.Description)
+                Child1 = new ComplexInheritedChild1(request.Child1!.Name),
+                Child2 = new ComplexInheritedChild2(request.Child2!.Description)
             };
         }
 
-        DataStream ReadIntoNewDataStream(DataStream ds)
+        DataStream ReadIntoNewDataStream(DataStream? ds)
         {
             // Read the source DataStream, then write into
             // a new DataStream, to simulate some work.
             // i.e. we don't want to just re-use the exact same
             // DataStream instance
-            return DataStream.FromString(ds.ReadAsString());
+            return DataStream.FromString(ds!.ReadAsString());
         }
     }
 }

--- a/source/Halibut.Tests/TestServices/AsyncMultipleParametersTestService.cs
+++ b/source/Halibut.Tests/TestServices/AsyncMultipleParametersTestService.cs
@@ -14,91 +14,109 @@ namespace Halibut.Tests.TestServices
 
         public async Task<long> AddAsync(long a, long b, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return a + b;
         }
 
         public async Task<double> AddAsync(double a, double b, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return a + b;
         }
 
         public async Task<decimal> AddAsync(decimal a, decimal b, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return a + b;
         }
 
         public async Task<string> HelloAsync(CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello";
         }
 
         public async Task<string> HelloAsync(string a, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + a;
         }
 
         public async Task<string> HelloAsync(string a, string b, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e, f);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e, f, g);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, string i, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h, i);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h, i, j);
         }
 
         public async Task<string> HelloAsync(string a, string b, string c, string d, string e, string f, string g, string h, string i, string j, string k, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello " + string.Join(" ", a, b, c, d, e, f, g, h, i, j, k);
         }
 
         public async Task<string> AmbiguousAsync(string a, string b, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello string";
         }
 
         public async Task<string> AmbiguousAsync(string a, Tuple<string, string> b, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return "Hello tuple";
         }
 
         public async Task<MapLocation> GetLocationAsync(MapLocation loc, CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             // Swap the latitude and longitude for the round trip verification... never know where you will end up! 
             return new MapLocation { Latitude = loc.Longitude, Longitude = loc.Latitude };
         }

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -63,7 +63,7 @@ namespace Halibut.Tests.Timeouts
                 await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000));
                 sw.Stop();
                 Logger.Information("It took: " + sw.Elapsed);
-                sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
+                sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service!.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
                                                                                                                                      // the response to the 'Second last message' is put back into the queue.
                     .And.BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
             }

--- a/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
+++ b/source/Halibut.Tests/Timeouts/PollingQueueTimeouts.cs
@@ -67,7 +67,7 @@ namespace Halibut.Tests.Timeouts
         public async Task WhenThePollingQueueHasNoMessagesAndDoesNotReturnNullResponsesPeriodically_ThePollingServiceStartsANewTcpConnection(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var waitForNullMessagesFromQueueTimeout = TimeSpan.FromSeconds(10);
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            TcpConnectionsCreatedCounter? tcpConnectionsCreatedCounter = null;
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                              .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
                                  .WithCountTcpConnectionsCreated(out tcpConnectionsCreatedCounter)
@@ -88,7 +88,7 @@ namespace Halibut.Tests.Timeouts
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
                 await echo.SayHelloAsync("Check everything is working.");
 
-                tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().Be(1);
+                tcpConnectionsCreatedCounter!.ConnectionsCreatedCount.Should().Be(1);
 
                 Wait.UntilActionSucceeds(() => tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().BeGreaterThan(1),
                     waitForNullMessagesFromQueueTimeout + waitForNullMessagesFromQueueTimeout,

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -44,7 +44,7 @@ namespace Halibut.Tests.Timeouts
                 var pauseConnections = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionService>(IncreasePollingQueueTimeout());
 
                 var sw = Stopwatch.StartNew();
-                var e = (await AssertAsync.Throws<HalibutClientException>(async () => await pauseConnections.ActionAsync())).And;
+                var e = (await AssertException.Throws<HalibutClientException>(async () => await pauseConnections.ActionAsync())).And;
                 sw.Stop();
                 Logger.Error(e, "Received error");
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
@@ -78,7 +78,7 @@ namespace Halibut.Tests.Timeouts
                 var pauseConnections = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionService>(IncreasePollingQueueTimeout());
 
                 var sw = Stopwatch.StartNew();
-                var e = (await AssertAsync.Throws<HalibutClientException>(async () => await pauseConnections.ActionAsync())).And;
+                var e = (await AssertException.Throws<HalibutClientException>(async () => await pauseConnections.ActionAsync())).And;
                 sw.Stop();
                 Logger.Error(e, "Received error");
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
@@ -110,7 +110,7 @@ namespace Halibut.Tests.Timeouts
                 var pauseConnections = clientAndService.CreateAsyncClient<IReturnSomeDataStreamService, IAsyncClientReturnSomeDataStreamService>(IncreasePollingQueueTimeout());
 
                 var sw = Stopwatch.StartNew();
-                var e = (await AssertAsync.Throws<HalibutClientException>(async () => await pauseConnections.SomeDataStreamAsync())).And;
+                var e = (await AssertException.Throws<HalibutClientException>(async () => await pauseConnections.SomeDataStreamAsync())).And;
                 sw.Stop();
                 Logger.Error(e, "Received error");
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
@@ -142,7 +142,7 @@ namespace Halibut.Tests.Timeouts
                 var echoServiceTheErrorWillHappenOn = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(IncreasePollingQueueTimeout());
                 
                 var sw = Stopwatch.StartNew();
-                var e = (await AssertAsync.Throws<HalibutClientException>(() =>
+                var e = (await AssertException.Throws<HalibutClientException>(() =>
                 {
                     var stringToSend = Some.RandomAsciiStringOfLength(numberOfBytesBeforePausingAStream * 20);
                     return echoServiceTheErrorWillHappenOn.SayHelloAsync(stringToSend);
@@ -181,7 +181,7 @@ namespace Halibut.Tests.Timeouts
                 var echoServiceTheErrorWillHappenOn = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>(IncreasePollingQueueTimeout());
                 
                 var sw = Stopwatch.StartNew();
-                var e = (await AssertAsync.Throws<HalibutClientException>(async () => await echoServiceTheErrorWillHappenOn.CountBytesAsync(DataStreamUtil.From(
+                var e = (await AssertException.Throws<HalibutClientException>(async () => await echoServiceTheErrorWillHappenOn.CountBytesAsync(DataStreamUtil.From(
                     firstSend: "hello",
                     andThenRun: portForwarderRef.Value!.PauseExistingConnections,
                     thenSend: "All done" + Some.RandomAsciiStringOfLength(10*1024*1024)

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -55,7 +55,7 @@ namespace Halibut.Tests.Timeouts
                 // The polling tentacle, will not reconnect in time since it has a 133s receive control message timeout.
                 // To move it along we, kill the connection here.
                 // Interestingly this tests does not tests the service times out (the below test does).
-                clientAndService.PortForwarder.CloseExistingConnections();
+                clientAndService.PortForwarder!.CloseExistingConnections();
 
                 await echo.SayHelloAsync("A new request can be made on a new unpaused TCP connection");
             }
@@ -82,7 +82,7 @@ namespace Halibut.Tests.Timeouts
                 sw.Stop();
                 Logger.Error(e, "Received error");
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
-                sw.Elapsed.Should().BeGreaterThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
+                sw.Elapsed.Should().BeGreaterThan(clientAndService.Service!.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
                     .BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout + HalibutTimeoutsAndLimitsForTestsBuilder.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
                 
@@ -114,7 +114,7 @@ namespace Halibut.Tests.Timeouts
                 sw.Stop();
                 Logger.Error(e, "Received error");
                 AssertExceptionMessageLooksLikeAReadTimeout(e);
-                sw.Elapsed.Should().BeGreaterThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
+                sw.Elapsed.Should().BeGreaterThan(clientAndService.Service!.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
                     .BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout + HalibutTimeoutsAndLimitsForTestsBuilder.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
 
@@ -151,7 +151,7 @@ namespace Halibut.Tests.Timeouts
                 sw.Stop();
                 Logger.Error(e, "Received error when making the request (as expected)");
                 
-                var expectedTimeOut = clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.SendTimeout;
+                var expectedTimeOut = clientAndService.Service!.TimeoutsAndLimits.TcpClientTimeout.SendTimeout;
 
                 sw.Elapsed.Should().BeGreaterThan(
                         expectedTimeOut - TimeSpan.FromSeconds(2), 
@@ -192,7 +192,7 @@ namespace Halibut.Tests.Timeouts
                 sw.Stop();
                 Logger.Error(e, "Received error when making the request (as expected)");
                 
-                var expectedTimeout = clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.SendTimeout;
+                var expectedTimeout = clientAndService.Service!.TimeoutsAndLimits.TcpClientTimeout.SendTimeout;
                 sw.Elapsed.Should().BeGreaterThan(expectedTimeout - TimeSpan.FromSeconds(2), "The receive timeout should apply, not the shorter heart beat timeout") // -2s give it a little slack to avoid it timed out slightly too early.
                     .And
                     .BeLessThan(expectedTimeout + HalibutTimeoutsAndLimitsForTestsBuilder.HalfTheTcpReceiveTimeout, "We should be timing out on the tcp receive timeout");
@@ -203,7 +203,7 @@ namespace Halibut.Tests.Timeouts
 
         static void AssertExceptionLooksLikeAWriteTimeout(HalibutClientException? e)
         {
-            e.Message.Should().ContainAny(
+            e!.Message.Should().ContainAny(
                 "Unable to write data to the transport connection: Connection timed out.",
                 " Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
 
@@ -212,7 +212,7 @@ namespace Halibut.Tests.Timeouts
 
         static void AssertExceptionMessageLooksLikeAReadTimeout(HalibutClientException? e)
         {
-            e.Message.Should().ContainAny(
+            e!.Message.Should().ContainAny(
                 "Unable to read data from the transport connection: Connection timed out.",
                 "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
             

--- a/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
+++ b/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
@@ -40,7 +40,7 @@ namespace Halibut.Tests.Timeouts
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build().WithAllTcpTimeoutsTo(TimeSpan.FromMinutes(20));
             halibutTimeoutsAndLimits.TcpClientTimeout = new SendReceiveTimeout(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
             
-            TcpConnectionsCreatedCounter tcpConnectionsCreatedCounter = null;
+            TcpConnectionsCreatedCounter? tcpConnectionsCreatedCounter = null;
             
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                        .As<LatestClientAndLatestServiceBuilder>()
@@ -81,7 +81,7 @@ namespace Halibut.Tests.Timeouts
                     // happy with the service and moves on to getting stuff out of the queue, however the service is still waiting
                     // to authentice the client but can't since the TCP connection is paused. 
                     // So instead lets count created TCP connections.
-                    Wait.UntilActionSucceeds(() => tcpConnectionsCreatedCounter.ConnectionsCreatedCount.Should().BeGreaterThanOrEqualTo(2), TimeSpan.FromSeconds(30), Logger, CancellationToken);
+                    Wait.UntilActionSucceeds(() => tcpConnectionsCreatedCounter!.ConnectionsCreatedCount.Should().BeGreaterThanOrEqualTo(2), TimeSpan.FromSeconds(30), Logger, CancellationToken);
                 }
 
                 sw.Stop();

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -84,7 +84,7 @@ namespace Halibut.Tests
             // Therefore we go up 5 levels to get to the <REPO ROOT> directory,
             // from which point we can navigate to the artifacts directory.
             var currentDirectory = Directory.GetCurrentDirectory();
-            var rootDirectory = new DirectoryInfo(currentDirectory).Parent.Parent.Parent.Parent.Parent;
+            var rootDirectory = new DirectoryInfo(currentDirectory).Parent!.Parent!.Parent!.Parent!.Parent!;
 
             var traceLogsDirectory = rootDirectory.CreateSubdirectory("artifacts").CreateSubdirectory("trace-logs");
             return traceLogsDirectory;

--- a/source/Halibut.Tests/TraceLogFileLogger.cs
+++ b/source/Halibut.Tests/TraceLogFileLogger.cs
@@ -93,7 +93,9 @@ namespace Halibut.Tests
         public void Dispose()
         {
             cancellationTokenSource.Cancel();
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             writeDataToDiskTask.GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             cancellationTokenSource.Dispose();
         }
     }

--- a/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
+++ b/source/Halibut.Tests/Transport/ConnectionManagerFixture.cs
@@ -29,7 +29,7 @@ namespace Halibut.Tests.Transport
             await connectionManager.AcquireConnectionAsync(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             await connectionManager.AcquireConnectionAsync(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
 
-            await connectionManager.DisconnectAsync(serviceEndpoint, null, CancellationToken);
+            await connectionManager.DisconnectAsync(serviceEndpoint, null!, CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
         }
 
@@ -75,7 +75,7 @@ namespace Halibut.Tests.Transport
             var activeConnection = await connectionManager.AcquireConnectionAsync(GetProtocol, connectionFactory, serviceEndpoint, new InMemoryConnectionLog(serviceEndpoint.ToString()), CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().OnlyContain(c => c == activeConnection);
 
-            await connectionManager.DisconnectAsync(serviceEndpoint, null, CancellationToken);
+            await connectionManager.DisconnectAsync(serviceEndpoint, null!, CancellationToken);
             connectionManager.GetActiveConnections(serviceEndpoint).Should().BeNullOrEmpty();
 
             var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
@@ -95,7 +95,7 @@ namespace Halibut.Tests.Transport
 
             await connectionManager.ReleaseConnectionAsync(serviceEndpoint, activeConnection, CancellationToken);
 
-            await connectionManager.DisconnectAsync(serviceEndpoint, null, CancellationToken);
+            await connectionManager.DisconnectAsync(serviceEndpoint, null!, CancellationToken);
 
             var createdTestConnection = createdTestConnections.Should().ContainSingle().Subject;
             createdTestConnection.Disposed.Should().BeTrue();
@@ -217,7 +217,7 @@ namespace Halibut.Tests.Transport
             var returnedConnection = await connectionManager.AcquireConnectionAsync(GetProtocol, connectionFactory, serviceEndpoint, inMemoryConnectionLog, CancellationToken);
             await connectionManager.ReleaseConnectionAsync(serviceEndpoint, returnedConnection, CancellationToken);
             
-            await connectionManager.DisconnectAsync(serviceEndpoint, null, CancellationToken);
+            await connectionManager.DisconnectAsync(serviceEndpoint, null!, CancellationToken);
 
             createdTestConnections.Should().HaveCount(2);
             createdTestConnections.Should().AllSatisfy(c => c.Disposed.Should().BeTrue());

--- a/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
@@ -25,7 +25,7 @@ namespace Halibut.Tests.Transport
 
             var client = new DiscoveryClient(new StreamFactory());
             var discovered = await client.DiscoverAsync(
-                new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, "", clientAndService.Client.TimeoutsAndLimits), 
+                new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, "", clientAndService.Client!.TimeoutsAndLimits), 
                 clientAndService.Client.TimeoutsAndLimits, 
                 CancellationToken);
 
@@ -50,7 +50,7 @@ namespace Halibut.Tests.Transport
                        .AsLatestClientAndLatestServiceBuilder()
                        .Build(CancellationToken))
             {
-                var info = await clientAndService.Client.DiscoverAsync(clientAndService.ServiceUri, CancellationToken);
+                var info = await clientAndService.Client!.DiscoverAsync(clientAndService.ServiceUri, CancellationToken);
                     
                 info.RemoteThumbprint.Should().Be(Certificates.TentacleListeningPublicThumbprint);
             }
@@ -76,13 +76,13 @@ namespace Halibut.Tests.Transport
 
             var sw = Stopwatch.StartNew();
             await AssertionExtensions.Should(() => client.DiscoverAsync(
-                    new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, "", clientAndService.Client.TimeoutsAndLimits), 
-                    clientAndService.Client.TimeoutsAndLimits, 
+                    new ServiceEndPoint(clientAndService.GetServiceEndPoint().BaseUri, "", clientAndService.Client!.TimeoutsAndLimits), 
+                    clientAndService.Client!.TimeoutsAndLimits, 
                     CancellationToken))
                 .ThrowAsync<HalibutClientException>();
 
             sw.Stop();
-            sw.Elapsed.Should().BeCloseTo(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, TimeSpan.FromSeconds(15), "Since a paused connection early on should not hang forever.");
+            sw.Elapsed.Should().BeCloseTo(clientAndService.Service!.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, TimeSpan.FromSeconds(15), "Since a paused connection early on should not hang forever.");
         }
     }
 }

--- a/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
+++ b/source/Halibut.Tests/Transport/DiscoveryClientFixture.cs
@@ -39,7 +39,7 @@ namespace Halibut.Tests.Transport
             var client = new DiscoveryClient(new StreamFactory());
             var fakeEndpoint = new ServiceEndPoint("https://fake-tentacle.example", "", new HalibutTimeoutsAndLimitsForTestsBuilder().Build());
 
-            await AssertAsync.Throws<HalibutClientException>(() => client.DiscoverAsync(fakeEndpoint, new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), CancellationToken), "No such host is known");
+            await AssertException.Throws<HalibutClientException>(() => client.DiscoverAsync(fakeEndpoint, new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), CancellationToken), "No such host is known");
         }
         
         [Test]

--- a/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
+++ b/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
@@ -99,7 +99,7 @@ namespace Halibut.Tests.Transport.Observability
 
                 cts.Cancel();
 
-                await AssertAsync.Throws<Exception>(sayHelloTask);
+                await AssertException.Throws<Exception>(sayHelloTask);
 
                 connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
                 connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);
@@ -132,7 +132,7 @@ namespace Halibut.Tests.Transport.Observability
 
                 cts.Cancel();
 
-                await AssertAsync.Throws<Exception>(sayHelloTask);
+                await AssertException.Throws<Exception>(sayHelloTask);
 
                 connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
                 connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);

--- a/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
+++ b/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
@@ -86,7 +86,7 @@ namespace Halibut.Tests.Transport.Observability
                              .WithConnectionObserverOnTcpServer(connectionsObserver)
                              .Build(CancellationToken))
             {
-                clientAndBuilder.Client.TrustOnly(new List<string>());
+                clientAndBuilder.Client!.TrustOnly(new List<string>());
 
                 using var cts = new CancellationTokenSource();
                 var token = cts.Token;

--- a/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
+++ b/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
@@ -99,7 +99,7 @@ namespace Halibut.Tests.Transport.Observability
 
                 cts.Cancel();
 
-                await AssertionExtensions.Should(() => sayHelloTask).ThrowAsync<Exception>();
+                await AssertAsync.Throws<Exception>(sayHelloTask);
 
                 connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
                 connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);
@@ -132,7 +132,7 @@ namespace Halibut.Tests.Transport.Observability
 
                 cts.Cancel();
 
-                await AssertionExtensions.Should(() => sayHelloTask).ThrowAsync<Exception>();
+                await AssertAsync.Throws<Exception>(sayHelloTask);
 
                 connectionsObserver.ConnectionAcceptedCount.Should().BeGreaterOrEqualTo(1);
                 connectionsObserver.ConnectionClosedCount.Should().BeGreaterOrEqualTo(1);

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -231,13 +231,13 @@ namespace Halibut.Tests.Transport.Protocol
             {
                 await WriteMessage(sut, stream, "Test");
                 var trailingBytes = Encoding.UTF8.GetBytes(trailingData);
-                stream.Write(trailingBytes, 0, trailingBytes.Length);
+                await stream.WriteAsync(trailingBytes, 0, trailingBytes.Length);
                 ms.Position = 0;
 
                 using (var reader = new StreamReader(stream, new UTF8Encoding(false)))
                 {
                     _ = await ReadMessage<string>(sut, stream);
-                    var trailingResult = reader.ReadToEnd();
+                    var trailingResult = await reader.ReadToEndAsync();
                     Assert.AreEqual(trailingData, trailingResult);
                 }
             }
@@ -264,7 +264,7 @@ namespace Halibut.Tests.Transport.Protocol
                 await WriteMessage(writingSerializer, stream, "Repeating phrase that compresses. Repeating phrase that compresses. Repeating phrase that compresses.");
 
                 var trailingBytes = Encoding.UTF8.GetBytes(trailingData);
-                stream.Write(trailingBytes, 0, trailingBytes.Length);
+                await stream.WriteAsync(trailingBytes, 0, trailingBytes.Length);
 
                 stream.Position = 0;
                 await ReadMessage<string>(sut, rewindableStream);

--- a/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/MessageSerializerFixture.cs
@@ -105,7 +105,7 @@ namespace Halibut.Tests.Transport.Protocol
             {
                 var result = await ReadMessage<ResponseMessage>(sut, stream);
                 result.Error.Should().NotBeNull();
-                result.Error.Message = "foo";
+                result.Error!.Message = "foo";
                 result.Error.HalibutErrorType = "MethodNotFoundHalibutClientException";
             }
         }

--- a/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
@@ -261,7 +261,7 @@ namespace Halibut.Tests.Transport.Protocol
         {
             readonly StringBuilder output = new();
             readonly Queue<object> nextReadQueue = new();
-            RemoteIdentity remoteIdentity;
+            RemoteIdentity? remoteIdentity;
             int numberOfReads = 3;
 
             public void NextReadReturns(object o)
@@ -353,7 +353,7 @@ namespace Halibut.Tests.Transport.Protocol
                 await Task.CompletedTask;
 
                 output.AppendLine("<-- MX-CLIENT || MX-SUBSCRIBE subscriptionId");
-                return remoteIdentity;
+                return remoteIdentity!;
             }
             
             public async Task SendAsync<T>(T message, CancellationToken cancellationToken)
@@ -363,22 +363,22 @@ namespace Halibut.Tests.Transport.Protocol
                 output.AppendLine("--> " + typeof(T).Name);
             }
 
-            public Task<RequestMessage> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
+            public Task<RequestMessage?> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
             {
                 return ReceiveAsync<RequestMessage>();
             }
 
-            public Task<ResponseMessage> ReceiveResponseAsync(CancellationToken cancellationToken)
+            public Task<ResponseMessage?> ReceiveResponseAsync(CancellationToken cancellationToken)
             {
                 return ReceiveAsync<ResponseMessage>();
             }
 
-            async Task<T> ReceiveAsync<T>()
+            async Task<T?> ReceiveAsync<T>()
             {
                 await Task.CompletedTask;
 
                 output.AppendLine("<-- " + typeof(T).Name);
-                return (T)(nextReadQueue.Count > 0 ? nextReadQueue.Dequeue() : default(T));
+                return (T?)(nextReadQueue.Count > 0 ? nextReadQueue.Dequeue() : default(T));
             }
 
             public override string ToString()

--- a/source/Halibut.Tests/Transport/Protocol/RegisteredSerializationBinderFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/RegisteredSerializationBinderFixture.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests.Transport.Protocol
             var binder = new RegisteredSerializationBinder(typeRegistry);
             binder.Register(typeof(IExampleService));
             binder.BindToName(typeof(ExampleProperties), out var assemblyName, out var typeName);
-            var t = binder.BindToType(assemblyName, typeName);
+            var t = binder.BindToType(assemblyName, typeName!);
             t.Should().Be(typeof(ExampleProperties));
         }
 
@@ -28,18 +28,18 @@ namespace Halibut.Tests.Transport.Protocol
 
         public class ExampleProperties
         {
-            public string Field;
-            public string PropertyGet { get; set; }
-            public string PropertyGetSet { get; set; }
-            public string[] Arguments { get; set; }
-            public List<int> Ids { get; set; }
-            public Dictionary<int, DictionaryValue> Set { get; set; }
+            public string? Field;
+            public string? PropertyGet { get; set; }
+            public string? PropertyGetSet { get; set; }
+            public string[]? Arguments { get; set; }
+            public List<int>? Ids { get; set; }
+            public Dictionary<int, DictionaryValue>? Set { get; set; }
         }
 
         public class ExampleWithObject
         {
-            public string PropertyGetSet { get; set; }
-            public object ObjectProperty { get; set; }
+            public string? PropertyGetSet { get; set; }
+            public object? ObjectProperty { get; set; }
         }
 
         public interface IHaveBase
@@ -93,22 +93,22 @@ namespace Halibut.Tests.Transport.Protocol
             var binder = new RegisteredSerializationBinder(typeRegistry);
             binder.Register(typeof(IMCircular));
             binder.BindToName(typeof(CircularPart1), out var assemblyName1, out var typeName1);
-            var t1 = binder.BindToType(assemblyName1, typeName1);
+            var t1 = binder.BindToType(assemblyName1, typeName1!);
             t1.Should().Be(typeof(CircularPart1));
 
             binder.BindToName(typeof(CircularPart2), out var assemblyName2, out var typeName2);
-            var t2 = binder.BindToType(assemblyName2, typeName2);
+            var t2 = binder.BindToType(assemblyName2, typeName2!);
             t2.Should().Be(typeof(CircularPart2));
         }
 
         public class CircularPart1
         {
-            public CircularPart2 Circular { get; set; }
+            public CircularPart2? Circular { get; set; }
         }
 
         public class CircularPart2
         {
-            public CircularPart1 Circular { get; set; }
+            public CircularPart1? Circular { get; set; }
         }
 
         public interface IMCircular

--- a/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
@@ -258,7 +258,7 @@ namespace Halibut.Tests.Transport
             await using (var sut =  new RewindableBufferStream(baseStream, 2))
             {
                 var inputBuffer = Encoding.ASCII.GetBytes("Test");
-                baseStream.Write(inputBuffer, 0, inputBuffer.Length);
+                await baseStream.WriteAsync(inputBuffer, 0, inputBuffer.Length);
                 baseStream.Position = 0;
 
                 sut.StartBuffer();
@@ -269,7 +269,7 @@ namespace Halibut.Tests.Transport
                 sut.FinishAndRewind(2);
 
                 var rewoundOutputBuffer = new byte[8];
-                Assert.AreEqual(2, sut.Read(rewoundOutputBuffer, 0, 8));
+                Assert.AreEqual(2, await sut.ReadAsync(rewoundOutputBuffer, 0, 8));
                 var postRewindValue = Encoding.ASCII.GetString(rewoundOutputBuffer.AsSpan(0, 2).ToArray());
                 Assert.AreEqual("st", postRewindValue);
             }

--- a/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/RewindableBufferStreamFixture.cs
@@ -212,7 +212,7 @@ namespace Halibut.Tests.Transport
             await using (var sut = RewindableBufferStreamBuilder.Build(baseStream))
             {
                 var inputBuffer = Encoding.ASCII.GetBytes("Test");
-                baseStream.Write(inputBuffer, 0, inputBuffer.Length);
+                await baseStream.WriteAsync(inputBuffer, 0, inputBuffer.Length);
 
                 baseStream.Position = 0;
 

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -23,9 +23,11 @@ namespace Halibut.Tests.Transport
 {
     public class SecureClientFixture : IAsyncDisposable
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         ServiceEndPoint endpoint;
         HalibutRuntime tentacle;
         ILog log;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [SetUp]
         public void SetUp()

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Runtime.Versioning;
 using System.Threading;
 using FluentAssertions;
 using Halibut.Diagnostics;
@@ -20,12 +21,14 @@ namespace Halibut.Tests.Transport
     {
         PerformanceCounter GetCounterForCurrentProcess(string categoryName, string counterName)
         {
+#pragma warning disable CA1416 // Validate platform compatibility
             var pid = Process.GetCurrentProcess().Id;
 
             var instanceName = new PerformanceCounterCategory("Process")
                 .GetInstanceNames()
                 .FirstOrDefault(instance =>
                 {
+
                     using (var counter = new PerformanceCounter("Process", "ID Process", instance, true))
                     {
                         try
@@ -45,6 +48,7 @@ namespace Halibut.Tests.Transport
             }
 
             return new PerformanceCounter(categoryName, counterName, instanceName, true);
+#pragma warning restore CA1416 // Validate platform compatibility
         }
 
         [Test]
@@ -98,6 +102,10 @@ namespace Halibut.Tests.Transport
 
         IEnumerable<float> CollectCounterValues(PerformanceCounter counter)
         {
+#if !NETFRAMEWORK
+            if (!OperatingSystem.IsWindows()) throw new InvalidOperationException("This is a Windows only operation");
+#endif
+
             var sleepTime = TimeSpan.FromSeconds(1);
 
             while (true)

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -59,8 +59,8 @@ namespace Halibut.Tests.Transport
                 var client = new SecureListener(
                     new IPEndPoint(new IPAddress(new byte[] { 127, 0, 0, 1 }), 0),
                     Certificates.TentacleListening,
-                    null,
-                    null,
+                    null!,
+                    null!,
                     _ => true,
                     new LogFactory(),
                     () => "",

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -102,16 +102,14 @@ namespace Halibut.Tests.Transport
 
         IEnumerable<float> CollectCounterValues(PerformanceCounter counter)
         {
-#if !NETFRAMEWORK
-            if (!OperatingSystem.IsWindows()) throw new InvalidOperationException("This is a Windows only operation");
-#endif
-
             var sleepTime = TimeSpan.FromSeconds(1);
 
             while (true)
             {
                 Thread.Sleep(sleepTime);
+#pragma warning disable CA1416 // Validate platform compatibility
                 yield return counter.NextValue();
+#pragma warning restore CA1416 // Validate platform compatibility
             }
             // ReSharper disable once IteratorNeverReturns : Take is limit
         }

--- a/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
@@ -88,7 +88,6 @@ namespace Halibut.Tests.Transport.Streams
         [Test]
         public void EndOfStreamEncounteredIsRecorded()
         {
-            int counter = 0;
             var errorRecordingStream = new ErrorRecordingStream(new MemoryStream("hello".GetBytesUtf8()), true);
 
             while (errorRecordingStream.Read(new byte[100], 0, 100) != 0)
@@ -102,7 +101,6 @@ namespace Halibut.Tests.Transport.Streams
         [Test]
         public async Task EndOfStreamEncounteredIsRecordedAsync()
         {
-            int counter = 0;
             var errorRecordingStream = new ErrorRecordingStream(new MemoryStream("hello".GetBytesUtf8()), true);
 
             while ((await errorRecordingStream.ReadAsync(new byte[100], 0, 100)) != 0)
@@ -116,7 +114,6 @@ namespace Halibut.Tests.Transport.Streams
         [Test]
         public async Task ReadingIntoAZeroLengthArrayIsNotAEndOfStream()
         {
-            int counter = 0;
             var errorRecordingStream = new ErrorRecordingStream(new MemoryStream("hello".GetBytesUtf8()), true);
 
             await errorRecordingStream.ReadAsync(new byte[0], 0, 0);

--- a/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/ErrorRecordingStreamFixture.cs
@@ -121,8 +121,10 @@ namespace Halibut.Tests.Transport.Streams
 
             await errorRecordingStream.ReadAsync(new byte[0], 0, 0);
             await errorRecordingStream.ReadAsync(new byte[100], 1, 0);
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
             errorRecordingStream.Read(new byte[0], 0, 0);
             errorRecordingStream.Read(new byte[100], 1, 0);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
 
 
             errorRecordingStream.WasTheEndOfStreamEncountered.Should().Be(false);

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -308,7 +308,7 @@ namespace Halibut.Tests.Transport.Streams
                 // NetworkStream implementation of Flush and FlushAsync is a NoOp so pause to make sure our wrapper is working
                 pausingStream.PauseUntilTimeout(CancellationToken, pauseDisposeOrClose: false);
 
-                (await AssertAsync.Throws<IOException>(async () => await sut.FlushAsync(CancellationToken)))
+                (await AssertException.Throws<IOException>(async () => await sut.FlushAsync(CancellationToken)))
                     .And.Message.Should().ContainAny(
                     "Unable to write data to the transport connection: Connection timed out.",
                     "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
@@ -332,8 +332,8 @@ namespace Halibut.Tests.Transport.Streams
 
                 // NetworkStream implementation of Flush and FlushAsync is a NoOp so pause to make sure our wrapper is working
                 pausingStream.PauseUntilTimeout(CancellationToken, pauseDisposeOrClose: false);
-
-                AssertAsync.Throws<IOException>(() => sut.Flush())
+                
+                AssertException.Throws<IOException>(() => sut.Flush())
                     .And.Message.Should().ContainAny(
                         "Unable to write data to the transport connection: Connection timed out.",
                         "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -243,7 +243,9 @@ namespace Halibut.Tests.Transport.Streams
 
             using (disposables)
             {
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                 sut.Dispose();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
 
                 Action read = () => sut.Read(new byte[1], 0, 1);
                 read.Should().Throw<ObjectDisposedException>("Because the stream is closed");
@@ -271,7 +273,9 @@ namespace Halibut.Tests.Transport.Streams
 
             using (disposables)
             {
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                 sut.Flush();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                 callCountingStream.FlushCallCount.Should().Be(1);
             }
         }
@@ -329,7 +333,7 @@ namespace Halibut.Tests.Transport.Streams
                 // NetworkStream implementation of Flush and FlushAsync is a NoOp so pause to make sure our wrapper is working
                 pausingStream.PauseUntilTimeout(CancellationToken, pauseDisposeOrClose: false);
 
-                (await AssertAsync.Throws<IOException>(async () => sut.Flush()))
+                AssertAsync.Throws<IOException>(() => sut.Flush())
                     .And.Message.Should().ContainAny(
                         "Unable to write data to the transport connection: Connection timed out.",
                         "Unable to write data to the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.");
@@ -573,7 +577,9 @@ namespace Halibut.Tests.Transport.Streams
                 // Close and Dispose should not re-throw on timeout as callers do not expect these to throw 
                 // e.g. if using ... throw it makes the stream difficult to use
                 sut.Close();
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                 sut.Dispose();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                 await sut.DisposeAsync();
 
                 callCountingStream.CloseCallCount.Should().Be(2);

--- a/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/NetworkTimeoutStreamFixture.cs
@@ -128,7 +128,7 @@ namespace Halibut.Tests.Transport.Streams
                         await Task.Delay(10, CancellationToken);
                     }
 
-                    Assert.AreEqual("Test"[0], readData.ToCharArray()[0]);
+                    Assert.AreEqual("Test"[0], readData!.ToCharArray()[0]);
                 }
                 else
                 {
@@ -501,12 +501,12 @@ namespace Halibut.Tests.Transport.Streams
                 sut.WriteTimeout = (int)TimeSpan.FromSeconds(1).TotalMilliseconds;
                 sut.ReadTimeout = (int)TimeSpan.FromSeconds(1).TotalMilliseconds;
 
-                var exception = await Try.CatchingError(async () => await sut.ReadFromStream(streamMethod, new byte[19], 0, 19, CancellationToken));
+                var exception = (await Try.CatchingError(async () => await sut.ReadFromStream(streamMethod, new byte[19], 0, 19, CancellationToken)))!;
 
                 callCountingStream.Reset();
 
                 exception.Should().NotBeNull();
-                AssertExceptionsAreEqual(exception!, AssertionExtensions.Should(() => sut.Position).Throw<Exception>().And);
+                AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Position).Throw<Exception>().And);
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.Position = 0).Throw<Exception>().And);
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CanRead).Throw<Exception>().And);
                 AssertExceptionsAreEqual(exception, AssertionExtensions.Should(() => sut.CanSeek).Throw<Exception>().And);

--- a/source/Halibut.Tests/Transport/Streams/PausingStream.cs
+++ b/source/Halibut.Tests/Transport/Streams/PausingStream.cs
@@ -15,8 +15,8 @@ namespace Halibut.Tests.Transport.Streams
     {
         readonly Stream inner;
         bool paused;
-        CancellationTokenSource syncReadPauseCancellationTokenSource;
-        CancellationTokenSource syncWritePauseCancellationTokenSource;
+        CancellationTokenSource? syncReadPauseCancellationTokenSource;
+        CancellationTokenSource? syncWritePauseCancellationTokenSource;
         CancellationToken asyncCancellationToken;
 
         bool pauseDisposeOrClose;

--- a/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
@@ -109,7 +109,7 @@ namespace Halibut.Tests.Transport.Streams
         public async Task WithTemporaryReadTimeoutSetsAndRestoresReadTimeout()
         {
             var currentTimeOut = TimeSpan.FromMilliseconds(42);
-            using var stream = new SupportsTimeoutsStream(new MemoryStream(), currentTimeOut, TimeSpan.FromMilliseconds(13));
+            await using var stream = new SupportsTimeoutsStream(new MemoryStream(), currentTimeOut, TimeSpan.FromMilliseconds(13));
             using (var _ = stream.WithTemporaryReadTimeout(34))
             {
                 stream.ReadTimeout.Should().Be(34);

--- a/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamExtensionMethodsFixture.cs
@@ -102,7 +102,7 @@ namespace Halibut.Tests.Transport.Streams
             memoryStream.WriteString("not enough");
             memoryStream.Position = 0;
             
-            await AssertAsync.Throws<EndOfStreamException>(async () => await memoryStream.ReadBytesAsync(1000, CancellationToken));
+            await AssertException.Throws<EndOfStreamException>(async () => await memoryStream.ReadBytesAsync(1000, CancellationToken));
         }
 
         [Test]

--- a/source/Halibut.Tests/Transport/Streams/StreamWrapperSupportsAsyncIOFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/StreamWrapperSupportsAsyncIOFixture.cs
@@ -89,7 +89,7 @@ namespace Halibut.Tests.Transport.Streams
         public async Task CopyToAsyncUsesAsyncMethods()
         {
             var from = new MemoryStream();
-            from.WriteByteArrayAsync("Hello".GetBytesUtf8(), CancellationToken);
+            await from.WriteByteArrayAsync("Hello".GetBytesUtf8(), CancellationToken);
             from.Position = 0;
 
             var syncIoRecordingStreamFrom = new SyncIoRecordingStream(from);

--- a/source/Halibut.Tests/Transport/Streams/WriteIntoMemoryBufferStreamFixture.cs
+++ b/source/Halibut.Tests/Transport/Streams/WriteIntoMemoryBufferStreamFixture.cs
@@ -174,7 +174,7 @@ namespace Halibut.Tests.Transport.Streams
 
             sut.WriteString("Some");
 
-            await AssertAsync.Throws<Exception>(async () => await sut.WriteBufferToUnderlyingStream(CancellationToken));
+            await AssertException.Throws<Exception>(async () => await sut.WriteBufferToUnderlyingStream(CancellationToken));
             
             memoryStream.Length.Should().Be(0);
 
@@ -194,7 +194,7 @@ namespace Halibut.Tests.Transport.Streams
             var bytes = "Some".GetBytesUtf8();
             await sut.WriteToStream(streamMethod, bytes, 0, bytes.Length, CancellationToken);
 
-            await AssertAsync.Throws<Exception>(async () => await sut.WriteToStream(streamMethod, bytes, 0, bytes.Length, CancellationToken));
+            await AssertException.Throws<Exception>(async () => await sut.WriteToStream(streamMethod, bytes, 0, bytes.Length, CancellationToken));
             
             memoryStream.Length.Should().Be(0);
 

--- a/source/Halibut.Tests/TrustFixture.cs
+++ b/source/Halibut.Tests/TrustFixture.cs
@@ -28,7 +28,7 @@ namespace Halibut.Tests
             // Trust no one
             clientAndService.Service!.TrustOnly(Array.Empty<string>());
 
-            await AssertAsync.Throws<Exception>(async () => await echoService.SayHelloAsync("Hello again"));
+            await AssertException.Throws<Exception>(async () => await echoService.SayHelloAsync("Hello again"));
         }
     }
 }

--- a/source/Halibut.Tests/TypeRegistryFixture.cs
+++ b/source/Halibut.Tests/TypeRegistryFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using FluentAssertions;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
@@ -151,7 +152,7 @@ namespace Halibut.Tests
 
         public bool TryGetValue(string key, out string value)
         {
-            return _dictionaryImplementation.TryGetValue(key, out value);
+            return _dictionaryImplementation.TryGetValue(key, out value!);
         }
 
         public string this[string key]

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -128,7 +128,7 @@ namespace Halibut.Tests
                 (await echo.AmbiguousAsync("a", "b")).Should().Be("Hello string");
                 (await echo.AmbiguousAsync("a", new Tuple<string, string>("a", "b"))).Should().Be("Hello tuple");
 
-                var ex = (await AssertionExtensions.Should(() => echo.AmbiguousAsync("a", (string)null)).ThrowAsync<AmbiguousMethodMatchHalibutClientException>()).And;
+                var ex = (await AssertionExtensions.Should(() => echo.AmbiguousAsync("a", (string)null!)).ThrowAsync<AmbiguousMethodMatchHalibutClientException>()).And;
                 ex.Message.Should().Contain("Ambiguous");
 
                 (await echo.GetLocationAsync(new MapLocation { Latitude = -27, Longitude = 153 })).Should().Match<MapLocation>(x => x.Latitude == 153 && x.Longitude == -27);
@@ -189,10 +189,10 @@ namespace Halibut.Tests
                     var response = await service.ProcessAsync(request);
 
                     response.Payload1.Should().NotBeSameAs(request.Payload1);
-                    response.Payload1.ReadAsString().Should().Be(payload1);
+                    response.Payload1!.ReadAsString().Should().Be(payload1);
 
                     response.Payload2.Should().NotBeSameAs(request.Payload2);
-                    response.Payload2.ReadAsString().Should().Be(payload2);
+                    response.Payload2!.ReadAsString().Should().Be(payload2);
                 }
             }
         }
@@ -245,19 +245,19 @@ namespace Halibut.Tests
                 var response = await service.ProcessAsync(request);
 
                 response.Child1.Should().NotBeSameAs(request.Child1);
-                response.Child1.ChildPayload1.Should().NotBeSameAs(request.Child1.ChildPayload1);
-                response.Child1.ChildPayload1.ReadAsString().Should().Be(childPayload1);
+                response.Child1!.ChildPayload1.Should().NotBeSameAs(request.Child1.ChildPayload1);
+                response.Child1.ChildPayload1!.ReadAsString().Should().Be(childPayload1);
                 response.Child1.ChildPayload2.Should().NotBeSameAs(request.Child1.ChildPayload2);
-                response.Child1.ChildPayload2.ReadAsString().Should().Be(childPayload2);
+                response.Child1.ChildPayload2!.ReadAsString().Should().Be(childPayload2);
                 response.Child1.ListOfStreams.Should().NotBeSameAs(request.Child1.ListOfStreams);
-                response.Child1.ListOfStreams.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list);
+                response.Child1.ListOfStreams!.Select(x => x.ReadAsString()).ToList().Should().BeEquivalentTo(list);
                 response.Child1.DictionaryPayload.Should().NotBeSameAs(request.Child1.DictionaryPayload);
                 response.Child1.DictionaryPayload.Should().BeEquivalentTo(dictionary);
 
                 response.Child2.Should().NotBeSameAs(request.Child2);
-                response.Child2.EnumPayload.Should().Be(enumValue);
+                response.Child2!.EnumPayload.Should().Be(enumValue);
                 response.Child2.ComplexPayloadSet.Should().NotBeSameAs(request.Child2.ComplexPayloadSet);
-                response.Child2.ComplexPayloadSet.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set);
+                response.Child2.ComplexPayloadSet!.Select(x => new ComplexPair<string>(x.EnumValue, x.Payload.ReadAsString())).ToHashSet().Should().BeEquivalentTo(set);
             }
         }
 
@@ -284,11 +284,11 @@ namespace Halibut.Tests
             var response = await service.ProcessAsync(request);
 
             response.Child1.Should().NotBeSameAs(request.Child1);
-            response.Child1.Name.Should().Be(childPayload1);
+            response.Child1!.Name.Should().Be(childPayload1);
             response.Child1.Name.Should().Be(request.Child1.Name);
 
             response.Child2.Should().NotBeSameAs(request.Child2);
-            response.Child2.Description.Should().Be(childPayload2);
+            response.Child2!.Description.Should().Be(childPayload2);
             response.Child2.Description.Should().Be(request.Child2.Description);
         }
     }

--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -144,7 +144,7 @@ namespace Halibut.Tests.Util.AsyncEx
         {
             //inspired by https://stackoverflow.com/a/21269145/779192
             var mre = new ManualResetEvent(initialState: false);
-            void Subscription(object s, UnobservedTaskExceptionEventArgs args)
+            void Subscription(object? s, UnobservedTaskExceptionEventArgs args)
             {
                 if (exceptionThrown(args.Exception) || args.Exception.InnerExceptions.Any(exceptionThrown))
                 {
@@ -167,7 +167,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 }
 
                 //unobserved task exceptions are thrown from the finalizer
-                createTaskToHaveTimeoutAfterCallInvokedOn = null; // Allow the task to be GC'ed
+                createTaskToHaveTimeoutAfterCallInvokedOn = null!; // Allow the task to be GC'ed
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 if (mre.WaitOne(2000))

--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Tests.Support;
 using Halibut.Util.AsyncEx;
 using NUnit.Framework;
 
@@ -44,8 +45,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 triggered = true;
             });
             var timeWaiting = Stopwatch.StartNew();
-            Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromMilliseconds(1), CancellationToken.None);
-            await act.Should().ThrowAsync<TimeoutException>();
+            await AssertAsync.Throws<TimeoutException>(task.TimeoutAfter(TimeSpan.FromMilliseconds(1), CancellationToken.None));
             timeWaiting.Stop();
             timeWaiting.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), "we should have stopped waiting on the task when timeout happened");
             
@@ -78,8 +78,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 triggered = true;
             });
 
-            Func<Task> act = async () => await task.TimeoutAfter(TimeSpan.FromDays(1), ctsForTimeoutAfter.Token);
-            await act.Should().ThrowAsync<OperationCanceledException>();
+            await AssertAsync.Throws<OperationCanceledException>(task.TimeoutAfter(TimeSpan.FromDays(1), ctsForTimeoutAfter.Token));
             triggered.Should().Be(false, "we should have stopped waiting on the task when cancellation happened");
             taskWillRunUntilThisIsCancelled.Cancel();
             await task;
@@ -92,6 +91,7 @@ namespace Halibut.Tests.Util.AsyncEx
             var msg = "this task threw an exception after timeout " + Guid.NewGuid().ToString();
 
             using var cts = new CancellationTokenSource();
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
             await VerifyNoUnobservedExceptions<TimeoutException>(
                 () => Task.Run(async () =>
                         {
@@ -107,6 +107,7 @@ namespace Halibut.Tests.Util.AsyncEx
                     task => task.TimeoutAfter(TimeSpan.FromMilliseconds(1), CancellationToken.None),
                     () => cts.Cancel(),
                     e => e.Message.Equals(msg));
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
         
         [Test]
@@ -115,6 +116,7 @@ namespace Halibut.Tests.Util.AsyncEx
             using var timeoutAfterCts = new CancellationTokenSource();
             using var taskWaitsOnThis = new CancellationTokenSource();
             var msg = "this task threw an exception after timeout " + Guid.NewGuid().ToString();
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
             await VerifyNoUnobservedExceptions<OperationCanceledException>(
                 () => Task.Run(async () =>
                 {
@@ -134,6 +136,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 () => taskWaitsOnThis.Cancel(),
                 e => e.Message.Equals(msg)
                 );
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
 
         static async Task VerifyNoUnobservedExceptions<T>(Func<Task> createTaskToHaveTimeoutAfterCallInvokedOn,
@@ -156,8 +159,7 @@ namespace Halibut.Tests.Util.AsyncEx
             try
             {
                 var backgroundTask = createTaskToHaveTimeoutAfterCallInvokedOn.Invoke();
-                Func<Task> act = async () => await timeoutAfterCall(backgroundTask);
-                await act.Should().ThrowAsync<T>();
+                await AssertAsync.Throws<T>(timeoutAfterCall(backgroundTask));
 
                 timeoutAfterCallHasFinished();
                 //delay long enough to ensure the task throws its exception

--- a/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
+++ b/source/Halibut.Tests/Util/AsyncEx/TaskExtensionsFixture.cs
@@ -45,7 +45,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 triggered = true;
             });
             var timeWaiting = Stopwatch.StartNew();
-            await AssertAsync.Throws<TimeoutException>(task.TimeoutAfter(TimeSpan.FromMilliseconds(1), CancellationToken.None));
+            await AssertException.Throws<TimeoutException>(task.TimeoutAfter(TimeSpan.FromMilliseconds(1), CancellationToken.None));
             timeWaiting.Stop();
             timeWaiting.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(10), "we should have stopped waiting on the task when timeout happened");
             
@@ -78,7 +78,7 @@ namespace Halibut.Tests.Util.AsyncEx
                 triggered = true;
             });
 
-            await AssertAsync.Throws<OperationCanceledException>(task.TimeoutAfter(TimeSpan.FromDays(1), ctsForTimeoutAfter.Token));
+            await AssertException.Throws<OperationCanceledException>(task.TimeoutAfter(TimeSpan.FromDays(1), ctsForTimeoutAfter.Token));
             triggered.Should().Be(false, "we should have stopped waiting on the task when cancellation happened");
             taskWillRunUntilThisIsCancelled.Cancel();
             await task;
@@ -159,7 +159,7 @@ namespace Halibut.Tests.Util.AsyncEx
             try
             {
                 var backgroundTask = createTaskToHaveTimeoutAfterCallInvokedOn.Invoke();
-                await AssertAsync.Throws<T>(timeoutAfterCall(backgroundTask));
+                await AssertException.Throws<T>(timeoutAfterCall(backgroundTask));
 
                 timeoutAfterCallHasFinished();
                 //delay long enough to ensure the task throws its exception

--- a/source/Halibut.Tests/Util/DataStreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/DataStreamExtensionMethods.cs
@@ -11,9 +11,9 @@ namespace Halibut.Tests.Util
         public static string ReadAsString(this DataStream stream)
         {
             var result = string.Empty;
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             stream.Receiver().ReadAsync(async (s, ct) =>
                     {
-                        await Task.CompletedTask;
                         using (var reader = new StreamReader(s))
                         {
                             result = await reader.ReadToEndAsync();
@@ -21,6 +21,7 @@ namespace Halibut.Tests.Util
                     },
                     CancellationToken.None)
                 .GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             return result;
         }
     }

--- a/source/Halibut.Tests/Util/DataStreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/DataStreamExtensionMethods.cs
@@ -10,7 +10,7 @@ namespace Halibut.Tests.Util
         // TODO: This could be async
         public static string ReadAsString(this DataStream stream)
         {
-            string result = null;
+            var result = string.Empty;
             stream.Receiver().ReadAsync(async (s, ct) =>
                     {
                         await Task.CompletedTask;

--- a/source/Halibut.Tests/Util/NoSanityCheckingDelegateServiceFactory.cs
+++ b/source/Halibut.Tests/Util/NoSanityCheckingDelegateServiceFactory.cs
@@ -16,7 +16,7 @@ namespace Halibut.Tests.Util
         public NoSanityCheckingDelegateServiceFactory Register<TContract, TAsyncContract>(Func<TAsyncContract> implementation)
         {
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.Name, () => implementation()!);
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);

--- a/source/Halibut.Tests/Util/NonPublicPropertyAccessorExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/NonPublicPropertyAccessorExtensionMethods.cs
@@ -30,7 +30,7 @@ namespace Halibut.Tests.Util
             if (field is null) throw new InvalidOperationException($"Failed to find field {fieldName} on type {type.FullName}");
 
             var value = field.GetValue(getFrom);
-            return value;
+            return value!;
         }
     }
 }

--- a/source/Halibut.Tests/Util/StreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/StreamExtensionMethods.cs
@@ -19,7 +19,9 @@ namespace Halibut.Tests.Util
             switch (streamMethod)
             {
                 case StreamReadMethod.Read:
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     return sut.Read(readBuffer, offset, count);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                 case StreamReadMethod.ReadByte:
                     return sut.ReadByte();
                 case StreamReadMethod.BeginReadEndWithinCallback:
@@ -44,7 +46,9 @@ namespace Halibut.Tests.Util
                 case StreamMethod.Async:
                     return await sut.ReadAsync(readBuffer, offset, count, cancellationToken);
                 case StreamMethod.Sync:
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     return sut.Read(readBuffer, offset, count);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                 case StreamMethod.LegacyAsyncCallEndWithinCallback:
                     return await sut.ReadFromStreamLegacyAsyncCallEndWithinCallback(readBuffer, offset, count, cancellationToken);
                 case StreamMethod.LegacyAsyncCallEndOutsideCallback:

--- a/source/Halibut.Tests/Util/StreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/StreamExtensionMethods.cs
@@ -108,7 +108,9 @@ namespace Halibut.Tests.Util
                     await sut.WriteAsync(buffer, offset, count, cancellationToken);
                     return;
                 case StreamMethod.Sync:
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     sut.Write(buffer, offset, count);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                     return;
                 case StreamMethod.LegacyAsyncCallEndWithinCallback:
                     await WriteToStreamLegacyAsyncCallEndWithinCallback(sut, buffer, offset, count, cancellationToken);
@@ -126,7 +128,9 @@ namespace Halibut.Tests.Util
             switch (streamWriteMethod)
             {
                 case StreamWriteMethod.Write:
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     sut.Write(buffer, offset, count);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                     return;
                 case StreamWriteMethod.WriteByte:
                     sut.WriteByte(buffer[0]);
@@ -194,10 +198,14 @@ namespace Halibut.Tests.Util
             switch (streamCopyToMethod)
             {
                 case StreamCopyToMethod.CopyTo:
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     sut.CopyTo(destination);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                     return;
                 case StreamCopyToMethod.CopyToWithBufferSize:
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
                     sut.CopyTo(destination, bufferSize);
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
                     return;
                 case StreamCopyToMethod.CopyToAsync:
 #if NETFRAMEWORK

--- a/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
+++ b/source/Halibut.Tests/WhenCallingAMethodThatDoesNotExist.cs
@@ -30,7 +30,7 @@ namespace Halibut.Tests
             {
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
                 
-                await AssertAsync.Throws<MethodNotFoundHalibutClientException>(() => echo.SayHelloAsync("Say hello to a service that does not exist."));
+                await AssertException.Throws<MethodNotFoundHalibutClientException>(() => echo.SayHelloAsync("Say hello to a service that does not exist."));
             }
         }
 

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -179,7 +179,7 @@ namespace Halibut.Tests
                 public bool IsEmpty => inner.IsEmpty;
                 public int Count => inner.Count;
                 public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
-                public async Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken) => await inner.DequeueAsync(cancellationToken);
+                public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken) => await inner.DequeueAsync(cancellationToken);
 
                 public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
                 {
@@ -239,7 +239,7 @@ namespace Halibut.Tests
                 public int Count => inner.Count;
                 public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
                 
-                public async Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken)
+                public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken)
                 {
                     var response = await inner.DequeueAsync(cancellationToken);
                     

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -39,7 +39,7 @@ namespace Halibut.Tests
                 {
                     var doSomeActionService = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
 
-                    await AssertAsync.Throws<OperationCanceledException>(() => doSomeActionService.ActionAsync(halibutProxyRequestOptions));
+                    await AssertException.Throws<OperationCanceledException>(() => doSomeActionService.ActionAsync(halibutProxyRequestOptions));
                 }
             }
         }
@@ -109,7 +109,7 @@ namespace Halibut.Tests
                 {
                     var doSomeActionService = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
 
-                    await AssertAsync.Throws<OperationCanceledException>(() => doSomeActionService.ActionAsync(halibutProxyRequestOptions));
+                    await AssertException.Throws<OperationCanceledException>(() => doSomeActionService.ActionAsync(halibutProxyRequestOptions));
                 }
 
                 calls.Should().HaveCount(1);

--- a/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
+++ b/source/Halibut.Tests/WhenTheTcpConnectionStopsSendingData.cs
@@ -37,7 +37,7 @@ namespace Halibut.Tests
                 await echo.SayHelloAsync("Bob");
                 sw.Stop();
 
-                sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(1), // Allow for some slack, don't care if it actually waited just under.  
+                sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service!.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(1), // Allow for some slack, don't care if it actually waited just under.  
                     "Since we should test connections in the pool using using the heart beat timeout.")
                     .And.BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, "Since we should test connections in the pool using using the shorter timeout.");
             }

--- a/source/Halibut.sln
+++ b/source/Halibut.sln
@@ -38,6 +38,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halibut.TestUtils.CompatBinary.v4_4_8", "Halibut.TestUtils.CompatBinary.v4_4_8\Halibut.TestUtils.CompatBinary.v4_4_8.csproj", "{80042E24-9461-47D1-9AC5-E414E4DBF821}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F3E5130E-C600-45F3-BA7C-CBFABC1291CA}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/source/Halibut/DataStream.cs
+++ b/source/Halibut/DataStream.cs
@@ -11,10 +11,12 @@ namespace Halibut
     public class DataStream : IEquatable<DataStream>, IDataStreamInternal
     {
         readonly Func<Stream, CancellationToken, Task> writerAsync;
-        IDataStreamReceiver receiver;
+        IDataStreamReceiver? receiver;
 
         [JsonConstructor]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public DataStream()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
         }
         
@@ -49,14 +51,14 @@ namespace Halibut
             return new InMemoryDataStreamReceiver(writerAsync);
         }
 
-        public bool Equals(DataStream other)
+        public bool Equals(DataStream? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return Id.Equals(other.Id);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -42,9 +42,9 @@ namespace Halibut.Diagnostics
                 return HalibutNetworkExceptionType.IsNetworkError;
             }
 
-            if (exception is ProxyException)
+            if (exception is ProxyException proxyException)
             {
-                if ((exception as ProxyException).CausedByNetworkError) return HalibutNetworkExceptionType.IsNetworkError;
+                if (proxyException.CausedByNetworkError) return HalibutNetworkExceptionType.IsNetworkError;
                 return HalibutNetworkExceptionType.NotANetworkError;
             }
 

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -24,12 +24,12 @@ namespace Halibut.Diagnostics
             this.logger = logger;
         }
 
-        public void Write(EventType type, string message, params object[] args)
+        public void Write(EventType type, string message, params object?[] args)
         {
-            WriteInternal(new LogEvent(type, message, null, args));
+            WriteInternal(new LogEvent(type, message, null!, args));
         }
 
-        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        public void WriteException(EventType type, string message, Exception ex, params object?[] args)
         {
             WriteInternal(new LogEvent(type, message, ex, args));
         }

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -26,7 +26,7 @@ namespace Halibut.Diagnostics
 
         public void Write(EventType type, string message, params object?[] args)
         {
-            WriteInternal(new LogEvent(type, message, null!, args));
+            WriteInternal(new LogEvent(type, message, null, args));
         }
 
         public void WriteException(EventType type, string message, Exception ex, params object?[] args)

--- a/source/Halibut/Diagnostics/LibLog.cs
+++ b/source/Halibut/Diagnostics/LibLog.cs
@@ -71,7 +71,7 @@ namespace Halibut.Logging
 #else
     public
 #endif
-    delegate bool Logger(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters);
+    delegate bool Logger(LogLevel logLevel, Func<string>? messageFunc, Exception? exception = null, params object[] formatParameters);
 
 #if !LIBLOG_PROVIDERS_ONLY
     /// <summary>
@@ -98,7 +98,7 @@ namespace Halibut.Logging
         /// 
         /// To check IsEnabled call Log with only LogLevel and check the return value, no event will be written.
         /// </remarks>
-        bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters);
+        bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception = null, params object[] formatParameters);
     }
 #endif
 
@@ -429,8 +429,8 @@ namespace Halibut.Logging
         public const string DisableLoggingEnvironmentVariable = "$rootnamespace$_LIBLOG_DISABLE";
         private const string NullLogProvider = "Current Log Provider is not set. Call SetCurrentLogProvider " +
                                                "with a non-null value first.";
-        private static dynamic s_currentLogProvider;
-        private static Action<ILogProvider> s_onCurrentLogProviderSet;
+        private static dynamic? s_currentLogProvider;
+        private static Action<ILogProvider>? s_onCurrentLogProviderSet;
 
         [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
         static LogProvider()
@@ -472,7 +472,7 @@ namespace Halibut.Logging
             }
         }
 
-        internal static ILogProvider CurrentLogProvider
+        internal static ILogProvider? CurrentLogProvider
         {
             get
             {
@@ -525,7 +525,7 @@ namespace Halibut.Logging
 #endif
         static ILog GetLogger(Type type)
         {
-            return GetLogger(type.FullName);
+            return GetLogger(type.FullName!);
         }
 
         /// <summary>
@@ -540,7 +540,7 @@ namespace Halibut.Logging
 #endif
         static ILog GetLogger(string name)
         {
-            ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
+            ILogProvider? logProvider = CurrentLogProvider ?? ResolveLogProvider();
             return logProvider == null
                 ? NoOpLogger.Instance
                 : (ILog)new LoggerExecutionWrapper(logProvider.GetLogger(name), () => IsDisabled);
@@ -559,7 +559,7 @@ namespace Halibut.Logging
 #endif
         static IDisposable OpenNestedContext(string message)
         {
-            ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
+            ILogProvider? logProvider = CurrentLogProvider ?? ResolveLogProvider();
 
             return logProvider == null
                 ? new DisposableAction(() => { })
@@ -580,7 +580,7 @@ namespace Halibut.Logging
 #endif
         static IDisposable OpenMappedContext(string key, string value)
         {
-            ILogProvider logProvider = CurrentLogProvider ?? ResolveLogProvider();
+            ILogProvider? logProvider = CurrentLogProvider ?? ResolveLogProvider();
 
             return logProvider == null
                 ? new DisposableAction(() => { })
@@ -629,7 +629,7 @@ namespace Halibut.Logging
 
         [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "System.Console.WriteLine(System.String,System.Object,System.Object)")]
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        internal static ILogProvider ResolveLogProvider()
+        internal static ILogProvider? ResolveLogProvider()
         {
             try
             {
@@ -660,7 +660,7 @@ namespace Halibut.Logging
         {
             internal static readonly NoOpLogger Instance = new NoOpLogger();
 
-            public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+            public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception, params object[] formatParameters)
             {
                 return false;
             }
@@ -675,7 +675,7 @@ namespace Halibut.Logging
         private readonly Func<bool> _getIsDisabled;
         internal const string FailedToGenerateLogMessage = "Failed to generate log message";
 
-        internal LoggerExecutionWrapper(Logger logger, Func<bool> getIsDisabled = null)
+        internal LoggerExecutionWrapper(Logger logger, Func<bool>? getIsDisabled = null)
         {
             _logger = logger;
             _getIsDisabled = getIsDisabled ?? (() => false);
@@ -687,7 +687,7 @@ namespace Halibut.Logging
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters)
+        public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception = null, params object[] formatParameters)
         {
             if (_getIsDisabled())
             {
@@ -717,7 +717,7 @@ namespace Halibut.Logging
                 {
                     Log(LogLevel.Error, () => FailedToGenerateLogMessage, ex);
                 }
-                return null;
+                return null!;
             };
             return _logger(logLevel, wrappedMessageFunc, exception, formatParameters);
         }
@@ -820,7 +820,7 @@ namespace Halibut.Logging.LogProviders
 
         protected override OpenNdc GetOpenNdcMethod()
         {
-            Type ndcContextType = Type.GetType("NLog.NestedDiagnosticsContext, NLog");
+            Type ndcContextType = Type.GetType("NLog.NestedDiagnosticsContext, NLog")!;
             MethodInfo pushMethod = ndcContextType.GetMethodPortable("Push", typeof(string));
             ParameterExpression messageParam = Expression.Parameter(typeof(string), "message");
             MethodCallExpression pushMethodCall = Expression.Call(null, pushMethod, messageParam);
@@ -829,7 +829,7 @@ namespace Halibut.Logging.LogProviders
 
         protected override OpenMdc GetOpenMdcMethod()
         {
-            Type mdcContextType = Type.GetType("NLog.MappedDiagnosticsContext, NLog");
+            Type mdcContextType = Type.GetType("NLog.MappedDiagnosticsContext, NLog")!;
 
             MethodInfo setMethod = mdcContextType.GetMethodPortable("Set", typeof(string), typeof(string));
             MethodInfo removeMethod = mdcContextType.GetMethodPortable("Remove", typeof(string));
@@ -855,7 +855,7 @@ namespace Halibut.Logging.LogProviders
 
         private static Type GetLogManagerType()
         {
-            return Type.GetType("NLog.LogManager, NLog");
+            return Type.GetType("NLog.LogManager, NLog")!;
         }
 
         private static Func<string, object> GetGetLoggerMethodCall()
@@ -877,7 +877,7 @@ namespace Halibut.Logging.LogProviders
             }
 
             [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
-            public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+            public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception, params object[] formatParameters)
             {
                 if (messageFunc == null)
                 {
@@ -1042,7 +1042,7 @@ namespace Halibut.Logging.LogProviders
 
         protected override OpenNdc GetOpenNdcMethod()
         {
-            Type logicalThreadContextType = Type.GetType("log4net.LogicalThreadContext, log4net");
+            Type logicalThreadContextType = Type.GetType("log4net.LogicalThreadContext, log4net")!;
             PropertyInfo stacksProperty = logicalThreadContextType.GetPropertyPortable("Stacks");
             Type logicalThreadContextStacksType = stacksProperty.PropertyType;
             PropertyInfo stacksIndexerProperty = logicalThreadContextStacksType.GetPropertyPortable("Item");
@@ -1070,7 +1070,7 @@ namespace Halibut.Logging.LogProviders
 
         protected override OpenMdc GetOpenMdcMethod()
         {
-            Type logicalThreadContextType = Type.GetType("log4net.LogicalThreadContext, log4net");
+            Type logicalThreadContextType = Type.GetType("log4net.LogicalThreadContext, log4net")!;
             PropertyInfo propertiesProperty = logicalThreadContextType.GetPropertyPortable("Properties");
             Type logicalThreadContextPropertiesType = propertiesProperty.PropertyType;
             PropertyInfo propertiesIndexerProperty = logicalThreadContextPropertiesType.GetPropertyPortable("Item");
@@ -1105,7 +1105,7 @@ namespace Halibut.Logging.LogProviders
 
         private static Type GetLogManagerType()
         {
-            return Type.GetType("log4net.LogManager, log4net");
+            return Type.GetType("log4net.LogManager, log4net")!;
         }
 
         private static Func<string, object> GetGetLoggerMethodCall()
@@ -1120,7 +1120,7 @@ namespace Halibut.Logging.LogProviders
         internal class Log4NetLogger
         {
             private readonly dynamic _logger;
-            private static Type s_callerStackBoundaryType;
+            private static Type? s_callerStackBoundaryType;
             private static readonly object CallerStackBoundaryTypeSync = new object();
 
             private readonly object _levelDebug;
@@ -1143,11 +1143,11 @@ namespace Halibut.Logging.LogProviders
                 }
 
                 var levelFields = logEventLevelType.GetFieldsPortable().ToList();
-                _levelDebug = levelFields.First(x => x.Name == "Debug").GetValue(null);
-                _levelInfo = levelFields.First(x => x.Name == "Info").GetValue(null);
-                _levelWarn = levelFields.First(x => x.Name == "Warn").GetValue(null);
-                _levelError = levelFields.First(x => x.Name == "Error").GetValue(null);
-                _levelFatal = levelFields.First(x => x.Name == "Fatal").GetValue(null);
+                _levelDebug = levelFields.First(x => x.Name == "Debug").GetValue(null)!;
+                _levelInfo = levelFields.First(x => x.Name == "Info").GetValue(null)!;
+                _levelWarn = levelFields.First(x => x.Name == "Warn").GetValue(null)!;
+                _levelError = levelFields.First(x => x.Name == "Error").GetValue(null)!;
+                _levelFatal = levelFields.First(x => x.Name == "Fatal").GetValue(null)!;
 
                 // Func<object, object, bool> isEnabledFor = (logger, level) => { return ((log4net.Core.ILogger)logger).IsEnabled(level); }
                 var loggerType = Type.GetType("log4net.Core.ILogger, log4net");
@@ -1189,7 +1189,7 @@ namespace Halibut.Logging.LogProviders
                     exceptionParam).Compile();
             }
 
-            public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+            public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception, params object[] formatParameters)
             {
                 if (messageFunc == null)
                 {
@@ -1282,11 +1282,12 @@ namespace Halibut.Logging.LogProviders
         private static readonly Action<string, string, int> WriteLogEntry;
         private static readonly Func<string, int, bool> ShouldLogEntry;
 
-        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         static EntLibLogProvider()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
-            LogEntryType = Type.GetType(string.Format(CultureInfo.InvariantCulture, TypeTemplate, "LogEntry"));
-            LoggerType = Type.GetType(string.Format(CultureInfo.InvariantCulture, TypeTemplate, "Logger"));
+            LogEntryType = Type.GetType(string.Format(CultureInfo.InvariantCulture, TypeTemplate, "LogEntry"))!;
+            LoggerType = Type.GetType(string.Format(CultureInfo.InvariantCulture, TypeTemplate, "Logger"))!;
             TraceEventTypeType = TraceEventTypeValues.Type;
             if (LogEntryType == null
                  || TraceEventTypeType == null
@@ -1401,7 +1402,7 @@ namespace Halibut.Logging.LogProviders
                 _shouldLog = shouldLog;
             }
 
-            public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+            public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception, params object[] formatParameters)
             {
                 var severity = MapSeverity(logLevel);
                 if (messageFunc == null)
@@ -1489,7 +1490,7 @@ namespace Halibut.Logging.LogProviders
 
         private static Func<string, string, IDisposable> GetPushProperty()
         {
-            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx");
+            Type ndcContextType = Type.GetType("Serilog.Context.LogContext, Serilog.FullNetFx")!;
             MethodInfo pushPropertyMethod = ndcContextType.GetMethodPortable(
                 "PushProperty",
                 typeof(string),
@@ -1513,7 +1514,7 @@ namespace Halibut.Logging.LogProviders
 
         private static Type GetLogManagerType()
         {
-            return Type.GetType("Serilog.Log, Serilog");
+            return Type.GetType("Serilog.Log, Serilog")!;
         }
 
         private static Func<string, object> GetForContextMethodCall()
@@ -1632,7 +1633,7 @@ namespace Halibut.Logging.LogProviders
                 _logger = logger;
             }
 
-            public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+            public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception, params object[] formatParameters)
             {
                 var translatedLevel = TranslateLevel(logLevel);
                 if (messageFunc == null)
@@ -1697,12 +1698,12 @@ namespace Halibut.Logging.LogProviders
             int severity,
             string logSystem,
             int skipFrames,
-            Exception exception,
+            Exception? exception,
             bool attributeToException,
             int writeMode,
-            string detailsXml,
+            string? detailsXml,
             string category,
-            string caption,
+            string? caption,
             string description,
             params object[] args
             );
@@ -1744,14 +1745,14 @@ namespace Halibut.Logging.LogProviders
 
         private static Type GetLogManagerType()
         {
-            return Type.GetType("Gibraltar.Agent.Log, Gibraltar.Agent");
+            return Type.GetType("Gibraltar.Agent.Log, Gibraltar.Agent")!;
         }
 
         private static WriteDelegate GetLogWriteDelegate()
         {
             Type logManagerType = GetLogManagerType();
-            Type logMessageSeverityType = Type.GetType("Gibraltar.Agent.LogMessageSeverity, Gibraltar.Agent");
-            Type logWriteModeType = Type.GetType("Gibraltar.Agent.LogWriteMode, Gibraltar.Agent");
+            Type logMessageSeverityType = Type.GetType("Gibraltar.Agent.LogMessageSeverity, Gibraltar.Agent")!;
+            Type logWriteModeType = Type.GetType("Gibraltar.Agent.LogWriteMode, Gibraltar.Agent")!;
 
             MethodInfo method = logManagerType.GetMethodPortable(
                 "Write",
@@ -1781,7 +1782,7 @@ namespace Halibut.Logging.LogProviders
 #endif
             }
 
-            public bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+            public bool Log(LogLevel logLevel, Func<string>? messageFunc, Exception? exception, params object[] formatParameters)
             {
                 if (messageFunc == null)
                 {
@@ -1829,15 +1830,16 @@ namespace Halibut.Logging.LogProviders
         internal static readonly int Error;
         internal static readonly int Critical;
 
-        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         static TraceEventTypeValues()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             var assembly = typeof(Uri).GetAssemblyPortable(); // This is to get to the System.dll assembly in a PCL compatible way.
             if (assembly == null)
             {
                 return;
             }
-            Type = assembly.GetType("System.Diagnostics.TraceEventType");
+            Type = assembly.GetType("System.Diagnostics.TraceEventType")!;
             if (Type == null) return;
             Verbose = (int)Enum.Parse(Type, "Verbose", false);
             Information = (int)Enum.Parse(Type, "Information", false);
@@ -1908,27 +1910,27 @@ namespace Halibut.Logging.LogProviders
         internal static MethodInfo GetMethodPortable(this Type type, string name)
         {
 #if LIBLOG_PORTABLE
-            return type.GetRuntimeMethods().SingleOrDefault(m => m.Name == name);
+            return type.GetRuntimeMethods().SingleOrDefault(m => m.Name == name)!;
 #else
-            return type.GetMethod(name);
+            return type.GetMethod(name)!;
 #endif
         }
 
         internal static MethodInfo GetMethodPortable(this Type type, string name, params Type[] types)
         {
 #if LIBLOG_PORTABLE
-            return type.GetRuntimeMethod(name, types);
+            return type.GetRuntimeMethod(name, types)!;
 #else
-            return type.GetMethod(name, types);
+            return type.GetMethod(name, types)!;
 #endif
         }
 
         internal static PropertyInfo GetPropertyPortable(this Type type, string name)
         {
 #if LIBLOG_PORTABLE
-            return type.GetRuntimeProperty(name);
+            return type.GetRuntimeProperty(name)!;
 #else
-            return type.GetProperty(name);
+            return type.GetProperty(name)!;
 #endif
         }
 
@@ -1944,21 +1946,21 @@ namespace Halibut.Logging.LogProviders
         internal static Type GetBaseTypePortable(this Type type)
         {
 #if LIBLOG_PORTABLE
-            return type.GetTypeInfo().BaseType;
+            return type.GetTypeInfo().BaseType!;
 #else
-            return type.BaseType;
+            return type.BaseType!;
 #endif
         }
 
 #if LIBLOG_PORTABLE
         internal static MethodInfo GetGetMethod(this PropertyInfo propertyInfo)
         {
-            return propertyInfo.GetMethod;
+            return propertyInfo.GetMethod!;
         }
 
         internal static MethodInfo GetSetMethod(this PropertyInfo propertyInfo)
         {
-            return propertyInfo.SetMethod;
+            return propertyInfo.SetMethod!;
         }
 #endif
 
@@ -1981,9 +1983,9 @@ namespace Halibut.Logging.LogProviders
 
     internal class DisposableAction : IDisposable
     {
-        private readonly Action _onDispose;
+        private readonly Action? _onDispose;
 
-        public DisposableAction(Action onDispose = null)
+        public DisposableAction(Action? onDispose = null)
         {
             _onDispose = onDispose;
         }

--- a/source/Halibut/Diagnostics/LogEvent.cs
+++ b/source/Halibut/Diagnostics/LogEvent.cs
@@ -4,7 +4,7 @@ namespace Halibut.Diagnostics
 {
     public class LogEvent
     {
-        public LogEvent(EventType type, string message, Exception error, object?[] formatArguments)
+        public LogEvent(EventType type, string message, Exception? error, object?[] formatArguments)
         {
             Type = type;
             Error = error;
@@ -18,7 +18,7 @@ namespace Halibut.Diagnostics
         
         public string FormattedMessage { get; }
 
-        public Exception Error { get; }
+        public Exception? Error { get; }
 
         public DateTimeOffset Time { get; }
 

--- a/source/Halibut/Diagnostics/LogEvent.cs
+++ b/source/Halibut/Diagnostics/LogEvent.cs
@@ -4,7 +4,7 @@ namespace Halibut.Diagnostics
 {
     public class LogEvent
     {
-        public LogEvent(EventType type, string message, Exception error, object[] formatArguments)
+        public LogEvent(EventType type, string message, Exception error, object?[] formatArguments)
         {
             Type = type;
             Error = error;

--- a/source/Halibut/Diagnostics/LogWriters/AggregateLogWriter.cs
+++ b/source/Halibut/Diagnostics/LogWriters/AggregateLogWriter.cs
@@ -17,7 +17,7 @@ namespace Halibut.Diagnostics.LogWriters
             this.logWriter = logWriter;
         }
 
-        public void Write(EventType type, string message, params object[] args)
+        public void Write(EventType type, string message, params object?[] args)
         {
             foreach (var writer in logWriter)
             {
@@ -26,7 +26,7 @@ namespace Halibut.Diagnostics.LogWriters
             log.Write(type, message, args);
         }
 
-        public void WriteException(EventType type, string message, Exception ex, params object[] args)
+        public void WriteException(EventType type, string message, Exception ex, params object?[] args)
         {
             foreach (var writer in logWriter)
             {

--- a/source/Halibut/Diagnostics/LogWriters/ILogWriter.cs
+++ b/source/Halibut/Diagnostics/LogWriters/ILogWriter.cs
@@ -4,7 +4,7 @@ namespace Halibut.Diagnostics.LogWriters
 {
     public interface ILogWriter
     {
-        void Write(EventType type, string message, params object[] args);
-        void WriteException(EventType type, string message, Exception ex, params object[] args);
+        void Write(EventType type, string message, params object?[] args);
+        void WriteException(EventType type, string message, Exception ex, params object?[] args);
     }
 }

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Halibut is a secure, RPC-based communication framework. Like WCF and similar frameworks, Halibut uses a simple request/response based programming model. However, unlike other request/response frameworks, the transport layer can be configured to allow either party to be a TCP listener or TCP client.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.0.0</VersionPrefix>
@@ -13,9 +12,9 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <PackageIcon>icon.png</PackageIcon>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>9.0</LangVersion>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -17,6 +17,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <LangVersion>9.0</LangVersion>
+	  <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net48;net6.0</TargetFrameworks>

--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -59,6 +59,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
     <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -77,8 +77,8 @@ namespace Halibut
 
         public ILogFactory Logs => logs;
 
-        public Func<string, string, UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
-        public OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
+        public Func<string, string, UnauthorizedClientConnectResponse>? OnUnauthorizedClientConnect { get; set; }
+        public OverrideErrorResponseMessageCachingAction? OverrideErrorResponseMessageCaching { get; set; }
 
         IPendingRequestQueue GetQueue(Uri target)
         {
@@ -229,7 +229,7 @@ namespace Halibut
         {
             var client = new SecureListeningClient(ExchangeProtocolBuilder(), request.Destination, serverCertificate, logs.ForEndpoint(request.Destination.BaseUri), connectionManager, tcpConnectionFactory);
 
-            ResponseMessage response = null;
+            ResponseMessage response = null!;
 
             await client.ExecuteTransactionAsync(
                 async (protocol, cts) =>

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -12,20 +12,20 @@ namespace Halibut
 {
     public class HalibutRuntimeBuilder
     {
-        ILogFactory logFactory;
-        IPendingRequestQueueFactory queueFactory;
-        X509Certificate2 serverCertificate;
-        IServiceFactory serviceFactory;
-        ITrustProvider trustProvider;
-        Action<MessageSerializerBuilder> configureMessageSerializerBuilder;
-        ITypeRegistry typeRegistry;
-        Action<TypeRegistryBuilder> configureTypeRegisterBuilder;
+        ILogFactory? logFactory;
+        IPendingRequestQueueFactory? queueFactory;
+        X509Certificate2? serverCertificate;
+        IServiceFactory? serviceFactory;
+        ITrustProvider? trustProvider;
+        Action<MessageSerializerBuilder>? configureMessageSerializerBuilder;
+        ITypeRegistry? typeRegistry;
+        Action<TypeRegistryBuilder>? configureTypeRegisterBuilder;
         Func<RetryPolicy> pollingReconnectRetryPolicy = RetryPolicy.Create;
-        Func<string, string, UnauthorizedClientConnectResponse> onUnauthorizedClientConnect;
-        HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
-        IStreamFactory streamFactory;
-        IRpcObserver rpcObserver;
-        IConnectionsObserver connectionsObserver;
+        Func<string, string, UnauthorizedClientConnectResponse>? onUnauthorizedClientConnect;
+        HalibutTimeoutsAndLimits? halibutTimeoutsAndLimits;
+        IStreamFactory? streamFactory;
+        IRpcObserver? rpcObserver;
+        IConnectionsObserver? connectionsObserver;
 
         public HalibutRuntimeBuilder WithConnectionsObserver(IConnectionsObserver connectionsObserver)
         {

--- a/source/Halibut/IHalibutRuntime.cs
+++ b/source/Halibut/IHalibutRuntime.cs
@@ -46,8 +46,8 @@ namespace Halibut
 
         Task DisconnectAsync(ServiceEndPoint endpoint, CancellationToken cancellationToken);
 
-        Func<string, string, UnauthorizedClientConnectResponse> OnUnauthorizedClientConnect { get; set; }
-        OverrideErrorResponseMessageCachingAction OverrideErrorResponseMessageCaching { get; set; }
+        Func<string, string, UnauthorizedClientConnectResponse>? OnUnauthorizedClientConnect { get; set; }
+        OverrideErrorResponseMessageCachingAction? OverrideErrorResponseMessageCaching { get; set; }
         public HalibutTimeoutsAndLimits TimeoutsAndLimits { get; }
     }
 }

--- a/source/Halibut/ProxyDetails.cs
+++ b/source/Halibut/ProxyDetails.cs
@@ -14,7 +14,7 @@ namespace Halibut
         }
 
         [JsonConstructor]
-        public ProxyDetails(string host, int port, ProxyType type, string userName, string password)
+        public ProxyDetails(string host, int port, ProxyType type, string? userName, string? password)
             : this(host, port, type)
         {
             this.UserName = userName;
@@ -25,20 +25,20 @@ namespace Halibut
 
         public int Port { get; }
 
-        public string UserName { get; }
+        public string? UserName { get; }
 
-        public string Password { get; }
+        public string? Password { get; }
 
         public ProxyType Type { get; }
 
-        public bool Equals(ProxyDetails other)
+        public bool Equals(ProxyDetails? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return string.Equals(Host, other.Host) && Port == other.Port && string.Equals(UserName, other.UserName) && string.Equals(Password, other.Password) && Type == other.Type;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;

--- a/source/Halibut/ServiceEndPoint.cs
+++ b/source/Halibut/ServiceEndPoint.cs
@@ -8,18 +8,18 @@ namespace Halibut
     {
         readonly string baseUriString;
 
-        public ServiceEndPoint(string baseUri, string remoteThumbprint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        public ServiceEndPoint(string baseUri, string? remoteThumbprint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
             : this(new Uri(baseUri), remoteThumbprint, null, halibutTimeoutsAndLimits)
         {
         }
 
-        public ServiceEndPoint(Uri baseUri, string remoteThumbprint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        public ServiceEndPoint(Uri baseUri, string? remoteThumbprint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
             : this(baseUri, remoteThumbprint, null, halibutTimeoutsAndLimits)
         {
         }
 
         [JsonConstructor]
-        public ServiceEndPoint(Uri baseUri, string remoteThumbprint, ProxyDetails proxy, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        public ServiceEndPoint(Uri baseUri, string? remoteThumbprint, ProxyDetails? proxy, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             if (IsWebSocketAddress(baseUri))
             {
@@ -80,9 +80,9 @@ namespace Halibut
 
         public Uri BaseUri { get; }
 
-        public string RemoteThumbprint { get; }
+        public string? RemoteThumbprint { get; }
 
-        public ProxyDetails Proxy { get; }
+        public ProxyDetails? Proxy { get; }
 
         public bool IsWebSocketEndpoint => IsWebSocketAddress(BaseUri);
 
@@ -90,14 +90,14 @@ namespace Halibut
 
         public static bool IsWebSocketAddress(Uri baseUri) => baseUri.Scheme.Equals("wss", StringComparison.OrdinalIgnoreCase);
 
-        public bool Equals(ServiceEndPoint other)
+        public bool Equals(ServiceEndPoint? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
             return string.Equals(RemoteThumbprint, other.RemoteThumbprint) && string.Equals(baseUriString, other.baseUriString) && Equals(Proxy, other.Proxy);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
@@ -111,7 +111,7 @@ namespace Halibut
             {
                 var hashCode = (RemoteThumbprint != null ? RemoteThumbprint.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ (baseUriString != null ? baseUriString.GetHashCode() : 0);
-                hashCode = (hashCode*397) ^ (Proxy != null ? Proxy.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (Proxy is not null ? Proxy.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/source/Halibut/ServiceModel/DelegateServiceFactory.cs
+++ b/source/Halibut/ServiceModel/DelegateServiceFactory.cs
@@ -16,7 +16,7 @@ namespace Halibut.ServiceModel
             AsyncServiceVerifier.VerifyAsyncSurfaceAreaFollowsConventions<TContract, TAsyncContract>();
             
             var serviceType = typeof(TContract);
-            services.Add(serviceType.Name, () => implementation());
+            services.Add(serviceType.Name, () => implementation()!);
             lock (serviceTypes)
             {
                 serviceTypes.Add(serviceType);

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -13,6 +13,7 @@ namespace Halibut.ServiceModel
 
     public class HalibutProxyWithAsync : DispatchProxyAsync
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         MessageRouter messageRouter;
         Type contractType;
         ServiceEndPoint endPoint;
@@ -20,6 +21,7 @@ namespace Halibut.ServiceModel
         bool configured;
         CancellationToken globalCancellationToken;
         ILog logger;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         public void Configure(
             MessageRouter messageRouter, 
@@ -56,7 +58,7 @@ namespace Halibut.ServiceModel
                 result = (T)Convert.ChangeType(result, returnType);
             }
 
-            return (T)result;
+            return (T)result!;
         }
 
         async Task<(MethodInfo, object)> MakeRpcCall(MethodInfo asyncMethod, object[] args)
@@ -78,7 +80,7 @@ namespace Halibut.ServiceModel
 
             EnsureNotError(response);
             
-            return (serviceMethod, response.Result);
+            return (serviceMethod, response.Result!);
         }
 
         /// <summary>
@@ -104,7 +106,7 @@ namespace Halibut.ServiceModel
             return request;
         }
 
-        RequestCancellationTokens RequestCancellationTokens(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        RequestCancellationTokens RequestCancellationTokens(HalibutProxyRequestOptions? halibutProxyRequestOptions)
         {
             if (halibutProxyRequestOptions == null)
             {
@@ -129,7 +131,7 @@ namespace Halibut.ServiceModel
 
         internal static void ThrowExceptionFromReceivedError(ServerError error, ILog logger)
         {
-            var realException = error.Details as string;
+            var realException = error.Details!;
 
             try
             {
@@ -139,7 +141,7 @@ namespace Halibut.ServiceModel
                     if (theType != null && theType != typeof(HalibutClientException))
                     {
                         var ctor = theType.GetConstructor(new[] { typeof(string), typeof(string) });
-                        Exception e = (Exception)ctor.Invoke(new object[] { error.Message, realException });
+                        Exception e = (Exception)ctor!.Invoke(new object?[] { error.Message, realException });
                         throw e;
                     }
                 }
@@ -154,7 +156,7 @@ namespace Halibut.ServiceModel
                     throw new MethodNotFoundHalibutClientException(error.Message, realException);
                 }
 
-                if (error.Details.StartsWith("System.Reflection.AmbiguousMatchException: "))
+                if (error.Details!.StartsWith("System.Reflection.AmbiguousMatchException: "))
                 {
                     throw new AmbiguousMethodMatchHalibutClientException(error.Message, realException);
                 }
@@ -176,7 +178,7 @@ namespace Halibut.ServiceModel
 
         }
 
-        internal static (object[] args, HalibutProxyRequestOptions halibutProxyRequestOptions) TrimOffHalibutProxyRequestOptions(object[] args)
+        internal static (object[] args, HalibutProxyRequestOptions? halibutProxyRequestOptions) TrimOffHalibutProxyRequestOptions(object[] args)
         {
             if (args.Length == 0) return (args, null);
             object last = args.Last();

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -10,7 +10,7 @@ namespace Halibut.ServiceModel
         bool IsEmpty { get; }
         int Count { get; }
         Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination);
-        Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken);
+        Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken);
         Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens);
     }
 }

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -80,7 +80,7 @@ namespace Halibut.ServiceModel
             }
         }
 
-        public async Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken)
+        public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken)
         {
             var timer = Stopwatch.StartNew();
 
@@ -101,7 +101,7 @@ namespace Halibut.ServiceModel
             }
         }
 
-        async Task<PendingRequest> DequeueNextAsync(TimeSpan timeout, CancellationToken cancellationToken)
+        async Task<PendingRequest?> DequeueNextAsync(TimeSpan timeout, CancellationToken cancellationToken)
         {
             var first = await TakeFirst(cancellationToken);
             if (first != null || timeout <= TimeSpan.Zero)
@@ -124,7 +124,7 @@ namespace Halibut.ServiceModel
             return await TakeFirst(cancellationToken);
         }
 
-        async Task<PendingRequest> TakeFirst(CancellationToken cancellationToken)
+        async Task<PendingRequest?> TakeFirst(CancellationToken cancellationToken)
         {
             using (await queueLock.LockAsync(cancellationToken))
             {
@@ -169,6 +169,7 @@ namespace Halibut.ServiceModel
             readonly SemaphoreSlim transferLock = new(1, 1);
             bool transferBegun;
             bool completed;
+            ResponseMessage? response;
 
             public PendingRequest(RequestMessage request, ILog log)
             {
@@ -311,11 +312,11 @@ namespace Halibut.ServiceModel
                 }
             }
 
-            public ResponseMessage Response { get; private set; }
+            public ResponseMessage Response => response ?? throw new InvalidOperationException("Response has not been set.");
 
             public void SetResponse(ResponseMessage response)
             {
-                Response = response;
+                this.response = response;
                 responseWaiter.Set();
             }
 

--- a/source/Halibut/ServiceModel/RequestCancellationTokens.cs
+++ b/source/Halibut/ServiceModel/RequestCancellationTokens.cs
@@ -5,7 +5,7 @@ namespace Halibut.ServiceModel
 {
     public class RequestCancellationTokens : IDisposable
     {
-        CancellationTokenSource linkedCancellationTokenSource;
+        CancellationTokenSource? linkedCancellationTokenSource;
 
         public RequestCancellationTokens(CancellationToken connectingCancellationToken, CancellationToken inProgressRequestCancellationToken)
         {

--- a/source/Halibut/ServiceModel/ServiceInvoker.cs
+++ b/source/Halibut/ServiceModel/ServiceInvoker.cs
@@ -42,7 +42,7 @@ namespace Halibut.ServiceModel
 
         static MethodInfo SelectAsyncMethod(IList<MethodInfo> methods, RequestMessage requestMessage)
         {
-            var argumentTypes = requestMessage.Params?.Select(s => s == null ? null : s.GetType()).ToList() ?? new List<Type>();
+            var argumentTypes = requestMessage.Params?.Select(s => s?.GetType()).ToList() ?? new List<Type?>();
 
             var matches = new List<MethodInfo>();
 
@@ -116,7 +116,7 @@ namespace Halibut.ServiceModel
             throw new AmbiguousMethodMatchHalibutClientException(message.ToString(), new AmbiguousMatchException(message.ToString()));
         }
 
-        async Task<object> InvokeAsyncMethod(MethodInfo method, object obj, params object[] parameters)
+        async Task<object?> InvokeAsyncMethod(MethodInfo method, object obj, params object[] parameters)
         {
             var returnType = method.ReturnType;
 
@@ -126,7 +126,7 @@ namespace Halibut.ServiceModel
                 throw new InvalidOperationException($"InvokeAsyncMethod cannot be called on a method that does not return Task or Task<T> ({returnType.Name})");
             }
 
-            var task = (Task)method.Invoke(obj, parameters);
+            var task = (Task)method.Invoke(obj, parameters)!;
             try
             {
                 await task.ConfigureAwait(false);
@@ -145,7 +145,7 @@ namespace Halibut.ServiceModel
 
             // If the return type is not Task, we assume it is Task<T>
             var resultType = returnType.GetGenericArguments().First();
-            var resultProperty = typeof(Task<>).MakeGenericType(resultType).GetProperty("Result");
+            var resultProperty = typeof(Task<>).MakeGenericType(resultType).GetProperty("Result")!;
             return resultProperty.GetValue(task);
         }
 

--- a/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
+++ b/source/Halibut/Transport/Caching/CachingKeyGenerator.cs
@@ -10,7 +10,7 @@ namespace Halibut.Transport.Caching
     {
         const char LinkChar = ':';
 
-        internal string GetCacheKey(MethodInfo methodInfo, object[] args, string prefix)
+        internal string GetCacheKey(MethodInfo methodInfo, object[] args, string? prefix)
         {
             var methodArguments = args?.Any() == true
                 ? args.Select(ParameterCacheKeys.GenerateCacheKey)
@@ -18,7 +18,7 @@ namespace Halibut.Transport.Caching
             return GenerateCacheKey(methodInfo, prefix, methodArguments);
         }
 
-        string GetCacheKeyPrefix(MethodInfo methodInfo, string prefix)
+        string GetCacheKeyPrefix(MethodInfo methodInfo, string? prefix)
         {
             if (!string.IsNullOrWhiteSpace(prefix)) return $"{prefix}{LinkChar}";
 
@@ -28,7 +28,7 @@ namespace Halibut.Transport.Caching
             return $"{typeName}{LinkChar}{methodName}{LinkChar}";
         }
 
-        string GenerateCacheKey(MethodInfo methodInfo, string prefix, IEnumerable<string> parameters)
+        string GenerateCacheKey(MethodInfo methodInfo, string? prefix, IEnumerable<string> parameters)
         {
             var cacheKeyPrefix = GetCacheKeyPrefix(methodInfo, prefix);
 

--- a/source/Halibut/Transport/ClientCertificateValidator.cs
+++ b/source/Halibut/Transport/ClientCertificateValidator.cs
@@ -13,9 +13,9 @@ namespace Halibut.Transport
             this.endPoint = endPoint;
         }
 
-        public bool Validate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
+        public bool Validate(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslpolicyerrors)
         {
-            var providedCert = new X509Certificate2(certificate.Export(X509ContentType.Cert), (string)null!); // Copy the cert so that we can reference it later
+            var providedCert = new X509Certificate2(certificate!.Export(X509ContentType.Cert), (string)null!); // Copy the cert so that we can reference it later
             var providedThumbprint = providedCert.Thumbprint;
 
             if (providedThumbprint == endPoint.RemoteThumbprint)

--- a/source/Halibut/Transport/ConnectionManagerAsync.cs
+++ b/source/Halibut/Transport/ConnectionManagerAsync.cs
@@ -187,7 +187,7 @@ namespace Halibut.Transport
             }
         }
 
-        static async Task SafelyDisposeConnectionAsync(IConnection connection, ILog log)
+        static async Task SafelyDisposeConnectionAsync(IConnection connection, ILog? log)
         {
             try
             {

--- a/source/Halibut/Transport/ConnectionPoolAsync.cs
+++ b/source/Halibut/Transport/ConnectionPoolAsync.cs
@@ -8,13 +8,14 @@ using Nito.AsyncEx;
 
 namespace Halibut.Transport
 {
-    public class ConnectionPoolAsync<TKey, TPooledResource> : IConnectionPool<TKey, TPooledResource> 
+    public class ConnectionPoolAsync<TKey, TPooledResource> : IConnectionPool<TKey, TPooledResource>
+        where TKey : notnull
         where TPooledResource : class, IPooledResource
     {
         readonly Dictionary<TKey, HashSet<TPooledResource>> pool = new();
         readonly SemaphoreSlim poolLock = new(1, 1);
         
-        public async Task<TPooledResource> TakeAsync(TKey endPoint, CancellationToken cancellationToken)
+        public async Task<TPooledResource?> TakeAsync(TKey endPoint, CancellationToken cancellationToken)
         {
             using (await poolLock.LockAsync(cancellationToken))
             {
@@ -78,7 +79,7 @@ namespace Halibut.Transport
             }
         }
 
-        TPooledResource Take(HashSet<TPooledResource> connections)
+        TPooledResource? Take(HashSet<TPooledResource> connections)
         {
             if (connections.Count == 0)
                 return null;
@@ -99,7 +100,7 @@ namespace Halibut.Transport
             return connections;
         }
         
-        static async Task DestroyConnectionAsync(TPooledResource connection, ILog log)
+        static async Task DestroyConnectionAsync(TPooledResource? connection, ILog? log)
         {
             try
             {

--- a/source/Halibut/Transport/DiscoveryClient.cs
+++ b/source/Halibut/Transport/DiscoveryClient.cs
@@ -65,7 +65,7 @@ namespace Halibut.Transport
             }
         }
 
-        bool ValidateCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
+        bool ValidateCertificate(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslpolicyerrors)
         {
             return true;
         }

--- a/source/Halibut/Transport/IConnectionPool.cs
+++ b/source/Halibut/Transport/IConnectionPool.cs
@@ -8,7 +8,7 @@ namespace Halibut.Transport
     public interface IConnectionPool<TKey, TPooledResource> : IAsyncDisposable
         where TPooledResource : class, IPooledResource
     {
-        Task<TPooledResource> TakeAsync(TKey endPoint, CancellationToken cancellationToken);
+        Task<TPooledResource?> TakeAsync(TKey endPoint, CancellationToken cancellationToken);
 
         Task ReturnAsync(TKey endPoint, TPooledResource resource, CancellationToken cancellationToken);
 

--- a/source/Halibut/Transport/Observability/NoOpConnectionsObserver.cs
+++ b/source/Halibut/Transport/Observability/NoOpConnectionsObserver.cs
@@ -2,7 +2,7 @@ namespace Halibut.Transport.Observability
 {
     public class NoOpConnectionsObserver : IConnectionsObserver
     {
-        static NoOpConnectionsObserver singleInstance;
+        static NoOpConnectionsObserver? singleInstance;
 
         public static NoOpConnectionsObserver Instance => singleInstance ??= new NoOpConnectionsObserver();
 

--- a/source/Halibut/Transport/PollingClient.cs
+++ b/source/Halibut/Transport/PollingClient.cs
@@ -11,8 +11,7 @@ namespace Halibut.Transport
 {
     public class PollingClient : IPollingClient
     {
-        readonly Func<RequestMessage, ResponseMessage>? handleIncomingRequest;
-        readonly Func<RequestMessage, Task<ResponseMessage>>? handleIncomingRequestAsync;
+        readonly Func<RequestMessage, Task<ResponseMessage>> handleIncomingRequestAsync;
         readonly ILog log;
         readonly ISecureClient secureClient;
         readonly Uri subscription;
@@ -23,17 +22,6 @@ namespace Halibut.Transport
         
         readonly Func<RetryPolicy> createRetryPolicy;
         RequestCancellationTokens? requestCancellationTokens;
-
-        public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, ResponseMessage> handleIncomingRequest, ILog log, CancellationToken cancellationToken, Func<RetryPolicy> createRetryPolicy)
-        {
-            this.subscription = subscription;
-            this.secureClient = secureClient;
-            this.handleIncomingRequest = handleIncomingRequest;
-            this.log = log;
-            this.cancellationToken = cancellationToken;
-            workingCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            this.createRetryPolicy = createRetryPolicy;
-        }
         
         public PollingClient(Uri subscription, ISecureClient secureClient, Func<RequestMessage, Task<ResponseMessage>> handleIncomingRequestAsync, ILog log, CancellationToken cancellationToken, Func<RetryPolicy> createRetryPolicy)
         {

--- a/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/IMessageExchangeStream.cs
@@ -35,7 +35,7 @@ namespace Halibut.Transport.Protocol
 
         Task SendAsync<T>(T message, CancellationToken cancellationToken);
 
-        Task<RequestMessage> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken);
-        Task<ResponseMessage> ReceiveResponseAsync(CancellationToken cancellationToken);
+        Task<RequestMessage?> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken);
+        Task<ResponseMessage?> ReceiveResponseAsync(CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeProtocol.cs
@@ -40,7 +40,7 @@ namespace Halibut.Transport.Protocol
                 await PrepareExchangeAsClientAsync(cancellationToken);
                 
                 await stream.SendAsync(request, cancellationToken);
-                return await stream.ReceiveResponseAsync(cancellationToken);
+                return (await stream.ReceiveResponseAsync(cancellationToken))!;
             }
             finally
             {
@@ -214,7 +214,7 @@ namespace Halibut.Transport.Protocol
             }
         }
         
-        async Task<bool> ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage nextRequest, CancellationToken cancellationToken)
+        async Task<bool> ProcessReceiverInternalAsync(IPendingRequestQueue pendingRequests, RequestMessage? nextRequest, CancellationToken cancellationToken)
         {
             try
             {
@@ -276,7 +276,7 @@ namespace Halibut.Transport.Protocol
             try
             {
                 await stream.SendAsync(nextRequest, cancellationToken);
-                return await stream.ReceiveResponseAsync(cancellationToken);
+                return (await stream.ReceiveResponseAsync(cancellationToken))!;
             }
             finally
             {

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -185,7 +185,7 @@ namespace Halibut.Transport.Protocol
             log.Write(EventType.Diagnostic, "Sent: {0}", message);
         }
 
-        public async Task<RequestMessage> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
+        public async Task<RequestMessage?> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
         {
             await stream.WithReadTimeout(
                 timeoutForReceivingTheFirstByte,
@@ -194,7 +194,7 @@ namespace Halibut.Transport.Protocol
             return await ReceiveAsync<RequestMessage>(cancellationToken);
         }
 
-        public async Task<ResponseMessage> ReceiveResponseAsync(CancellationToken cancellationToken)
+        public async Task<ResponseMessage?> ReceiveResponseAsync(CancellationToken cancellationToken)
         {
             // Wait for data to become available using existing timeouts, then once we have data streaming in, use the smaller timeout (so we do not wait as long if an error happens here).
             await stream.WithReadTimeout(
@@ -204,7 +204,7 @@ namespace Halibut.Transport.Protocol
             return await ReceiveAsync<ResponseMessage>(cancellationToken);
         }
 
-        async Task<T> ReceiveAsync<T>(CancellationToken cancellationToken)
+        async Task<T?> ReceiveAsync<T>(CancellationToken cancellationToken)
         {
             var (result, dataStreams) = await serializer.ReadMessageAsync<T>(stream, cancellationToken);
             await ReadStreamsAsync(dataStreams, cancellationToken);
@@ -212,14 +212,9 @@ namespace Halibut.Transport.Protocol
             return result;
         }
 
-        async Task WithTimeout(SendReceiveTimeout timeout, Func<Task> func)
+        async Task WithTimeout(SendReceiveTimeout? timeout, Func<Task> func)
         {
             await stream.WithTimeout(timeout, func);
-        }
-
-        async Task<T> WithTimeout<T>(SendReceiveTimeout timeout, Func<Task<T>> func)
-        {
-            return await stream.WithTimeout(timeout, func);
         }
 
         void SetReadAndWriteTimeouts(SendReceiveTimeout timeout)
@@ -303,7 +298,7 @@ namespace Halibut.Transport.Protocol
         {
             var dataStream = deserializedStreams.FirstOrDefault(d => d.Id == id);
             
-            if (dataStream == null)
+            if (dataStream is null)
             {
                 throw new Exception("Unexpected stream!");
             }

--- a/source/Halibut/Transport/Protocol/MessageSerializer.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializer.cs
@@ -59,7 +59,7 @@ namespace Halibut.Transport.Protocol
                 // If it is not, then an old receiver (eg, old tentacle) will not be able to understand messages from a new sender (server)
                 // Once ALL sources and targets are deserializing to MessageEnvelope<T>, (ReadBsonMessage) then this can be changed to T
                 var streamCapturingSerializer = createStreamCapturingSerializer();
-                streamCapturingSerializer.Serializer.Serialize(bson, new MessageEnvelope<object> { Message = message });
+                streamCapturingSerializer.Serializer.Serialize(bson, new MessageEnvelope<object> { Message = message! });
 
                 serializedStreams = streamCapturingSerializer.DataStreams;
             }
@@ -75,7 +75,7 @@ namespace Halibut.Transport.Protocol
         {
             await using (var errorRecordingStream = new ErrorRecordingStream(stream, closeInner: false))
             {
-                Exception exceptionFromDeserialisation = null;
+                Exception? exceptionFromDeserialisation = null;
                 try
                 {
                     return await ReadCompressedMessageAsync<T>(errorRecordingStream, stream, cancellationToken);
@@ -174,7 +174,9 @@ namespace Halibut.Transport.Protocol
         // And it is impossible to deserialize the wrong type - any mismatched type will refuse to deserialize
         class MessageEnvelope<T>
         {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             public T Message { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -8,9 +8,9 @@ namespace Halibut.Transport.Protocol
     public class MessageSerializerBuilder
     {
         readonly ILogFactory logFactory;
-        ITypeRegistry typeRegistry;
-        Action<JsonSerializerSettings> configureSerializer;
-        IMessageSerializerObserver messageSerializerObserver;
+        ITypeRegistry? typeRegistry;
+        Action<JsonSerializerSettings>? configureSerializer;
+        IMessageSerializerObserver? messageSerializerObserver;
         // Initial prod telemetry showed quite large read values (> 17M). But a decent number were below 64K.
         // This number is also below what .NET uses to put objects on the LOH (threshold is 85K)
         long readIntoMemoryLimitBytes = 1024L * 64L;

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -19,13 +19,13 @@ namespace Halibut.Transport.Protocol
             foreach (var protocolType in protocolTypes) typeRegistry.RegisterType(protocolType, protocolType.Name, true);
         }
 
-        public Type BindToType(string assemblyName, string typeName)
+        public Type BindToType(string? assemblyName, string typeName)
         {
             var type = baseBinder.BindToType(assemblyName, typeName);
-            return typeRegistry.IsInAllowedTypes(type) ? type : null;
+            return typeRegistry.IsInAllowedTypes(type) ? type : null!;
         }
 
-        public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        public void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
         {
             baseBinder.BindToName(serializedType, out assemblyName, out typeName);
         }

--- a/source/Halibut/Transport/Protocol/RemoteIdentity.cs
+++ b/source/Halibut/Transport/Protocol/RemoteIdentity.cs
@@ -13,7 +13,9 @@ namespace Halibut.Transport.Protocol
             this.subscriptionId = subscriptionId;
         }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public RemoteIdentity(RemoteIdentityType identityType)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             this.identityType = identityType;
         }

--- a/source/Halibut/Transport/Protocol/RequestMessage.cs
+++ b/source/Halibut/Transport/Protocol/RequestMessage.cs
@@ -6,6 +6,7 @@ namespace Halibut.Transport.Protocol
 {
     public class RequestMessage
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         [JsonProperty("id")]
         public string Id { get; set; }
 
@@ -23,6 +24,7 @@ namespace Halibut.Transport.Protocol
 
         [JsonProperty("params")]
         public object[] Params { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         public override string ToString()
         {

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -7,15 +7,17 @@ namespace Halibut.Transport.Protocol
     public class ResponseMessage
     {
         [JsonProperty("id")]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public string Id { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [JsonProperty("error")]
-        public ServerError Error { get; set; }
+        public ServerError? Error { get; set; }
 
         [JsonProperty("result")]
-        public object Result { get; set; }
+        public object? Result { get; set; }
 
-        public static ResponseMessage FromResult(RequestMessage request, object result)
+        public static ResponseMessage FromResult(RequestMessage request, object? result)
         {
             return new ResponseMessage { Id = request.Id, Result = result };
         }
@@ -32,12 +34,12 @@ namespace Halibut.Transport.Protocol
 
         internal static ServerError ServerErrorFromException(Exception ex)
         {
-            string ErrorType = null;
+            string? errorType = null;
             if (ex is HalibutClientException)
             {
-                ErrorType = ex.GetType().FullName;
+                errorType = ex.GetType().FullName;
             }
-            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), HalibutErrorType = ErrorType };
+            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), HalibutErrorType = errorType };
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ServerError.cs
+++ b/source/Halibut/Transport/Protocol/ServerError.cs
@@ -6,11 +6,13 @@ namespace Halibut.Transport.Protocol
     public class ServerError
     {
         [JsonProperty("message")]
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public string Message { get; set; }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         [JsonProperty("details")]
-        public string Details { get; set; }
+        public string? Details { get; set; }
         
-        public string HalibutErrorType { get; set; }
+        public string? HalibutErrorType { get; set; }
     }
 }

--- a/source/Halibut/Transport/Protocol/StreamTimeoutExtensionMethods.cs
+++ b/source/Halibut/Transport/Protocol/StreamTimeoutExtensionMethods.cs
@@ -7,7 +7,7 @@ namespace Halibut.Transport.Protocol
 {
     public static class StreamTimeoutExtensionMethods
     {
-        public static async Task WithTimeout(this Stream stream, SendReceiveTimeout timeout, Func<Task> func)
+        public static async Task WithTimeout(this Stream stream, SendReceiveTimeout? timeout, Func<Task> func)
         {
             if (!stream.CanTimeout)
             {
@@ -95,9 +95,9 @@ namespace Halibut.Transport.Protocol
             }
         }
 
-        public static void SetReadAndWriteTimeouts(this Stream stream, SendReceiveTimeout timeout)
+        public static void SetReadAndWriteTimeouts(this Stream stream, SendReceiveTimeout? timeout)
         {
-            if(timeout == null) return;
+            if (timeout == null) return;
             
             if (!stream.CanTimeout)
             {
@@ -108,7 +108,7 @@ namespace Halibut.Transport.Protocol
             stream.ReadTimeout = (int)timeout.ReceiveTimeout.TotalMilliseconds;
         }
         
-        public static SendReceiveTimeout GetReadAndWriteTimeouts(this Stream stream)
+        public static SendReceiveTimeout? GetReadAndWriteTimeouts(this Stream stream)
         {
             if (!stream.CanTimeout)
             {

--- a/source/Halibut/Transport/Protocol/TypeRegistry.cs
+++ b/source/Halibut/Transport/Protocol/TypeRegistry.cs
@@ -12,7 +12,7 @@ namespace Halibut.Transport.Protocol
         readonly HashSet<Type> messageContractTypes = new HashSet<Type>();
         readonly HashSet<Type> allowedTypes = new HashSet<Type>();
 
-        public TypeRegistry(IEnumerable<Assembly> typeAssemblies = null)
+        public TypeRegistry(IEnumerable<Assembly>? typeAssemblies = null)
         {
             this.typeAssemblies = typeAssemblies ?? Array.Empty<Assembly>();
         }
@@ -77,7 +77,7 @@ namespace Halibut.Transport.Protocol
         {
             if (type.HasElementType)
             {
-                yield return type.GetElementType();
+                yield return type.GetElementType()!;
             }
 
             if (type.IsGenericType)

--- a/source/Halibut/Transport/Protocol/TypeRegistryBuilder.cs
+++ b/source/Halibut/Transport/Protocol/TypeRegistryBuilder.cs
@@ -4,7 +4,7 @@ namespace Halibut.Transport.Protocol
 {
     public class TypeRegistryBuilder
     {
-        Assembly[] typeAssemblies;
+        Assembly[]? typeAssemblies;
 
         /// <summary>
         /// Adds a list of assemblies to the <see cref="ITypeRegistry"/>. Used to search for contract types for derived types.

--- a/source/Halibut/Transport/Protocol/WebSocketStream.cs
+++ b/source/Halibut/Transport/Protocol/WebSocketStream.cs
@@ -60,7 +60,7 @@ namespace Halibut.Transport.Protocol
             return receiveResult.Count;
         }
 
-        public async Task<string> ReadTextMessage(TimeSpan timeout, CancellationToken cancellationToken)
+        public async Task<string?> ReadTextMessage(TimeSpan timeout, CancellationToken cancellationToken)
         {
             AssertCanReadOrWrite();
             var sb = new StringBuilder();

--- a/source/Halibut/Transport/Proxy/HttpProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/HttpProxyClient.cs
@@ -51,7 +51,7 @@ namespace Halibut.Transport.Proxy
     public class HttpProxyClient : IProxyClient
     {
         private HttpResponseCodes _respCode;
-        private string _respText;
+        private string? _respText;
         readonly ILog log;
 
         private const string HTTP_PROXY_CONNECT_CMD = "CONNECT {0}:{1} HTTP/1.0\r\nHost: {0}:{1}\r\n\r\n";
@@ -112,7 +112,7 @@ namespace Halibut.Transport.Proxy
         /// <param name="proxyPort">Port number for the proxy server.</param>
         /// <param name="proxyUserName">Proxy authentication user name.</param>
         /// <param name="proxyPassword">Proxy authentication password.</param>
-        public HttpProxyClient(ILog logger, string proxyHost, int proxyPort, string proxyUserName, string proxyPassword, IStreamFactory streamFactory)
+        public HttpProxyClient(ILog logger, string proxyHost, int proxyPort, string? proxyUserName, string? proxyPassword, IStreamFactory streamFactory)
         {
             log = logger;
             if (string.IsNullOrEmpty(proxyHost))
@@ -150,18 +150,18 @@ namespace Halibut.Transport.Proxy
         /// <summary>
         /// Gets or sets proxy authentication user name.
         /// </summary>
-        public string ProxyUserName { get; set; }
+        public string? ProxyUserName { get; set; }
 
         /// <summary>
         /// Gets or sets proxy authentication password.
         /// </summary>
-        public string ProxyPassword { get; set; }
+        public string? ProxyPassword { get; set; }
 
         /// <summary>
         /// Gets or sets the TcpClient object. 
         /// This property can be set prior to executing CreateConnection to use an existing TcpClient connection.
         /// </summary>
-        public TcpClient TcpClient { get; set; }
+        public TcpClient? TcpClient { get; set; }
         
         readonly IStreamFactory streamFactory;
 
@@ -221,7 +221,7 @@ namespace Halibut.Transport.Proxy
         
         async Task SendConnectionCommandAsync(string host, int port, CancellationToken cancellationToken)
         {
-            var stream = streamFactory.CreateStream(TcpClient);
+            var stream = streamFactory.CreateStream(TcpClient!);
             var connectCmd = GetConnectCmd(host, port);
             var request = Encoding.ASCII.GetBytes(connectCmd);
 
@@ -281,16 +281,16 @@ namespace Halibut.Transport.Proxy
             switch (_respCode)
             {
                 case HttpResponseCodes.None:
-                    msg = string.Format(CultureInfo.InvariantCulture, "Proxy destination {0} on port {1} failed to return a recognized HTTP response code.  Server response: {2}", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient), _respText);
+                    msg = string.Format(CultureInfo.InvariantCulture, "Proxy destination {0} on port {1} failed to return a recognized HTTP response code.  Server response: {2}", Utils.GetHost(TcpClient!), Utils.GetPort(TcpClient!), _respText);
                     break;
 
                 case HttpResponseCodes.BadGateway:
                     //HTTP/1.1 502 Proxy Error (The specified Secure Sockets Layer (SSL) port is not allowed. ISA Server is not configured to allow SSL requests from this port. Most Web browsers use port 443 for SSL requests.)
-                    msg = string.Format(CultureInfo.InvariantCulture, "Proxy destination {0} on port {1} responded with a 502 code - Bad Gateway.  If you are connecting to a Microsoft ISA destination please refer to knowledge based article Q283284 for more information.  Server response: {2}", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient), _respText);
+                    msg = string.Format(CultureInfo.InvariantCulture, "Proxy destination {0} on port {1} responded with a 502 code - Bad Gateway.  If you are connecting to a Microsoft ISA destination please refer to knowledge based article Q283284 for more information.  Server response: {2}", Utils.GetHost(TcpClient!), Utils.GetPort(TcpClient!), _respText);
                     break;
 
                 default:
-                    msg = string.Format(CultureInfo.InvariantCulture, "Proxy destination {0} on port {1} responded with a {2} code - {3}", Utils.GetHost(TcpClient), Utils.GetPort(TcpClient), ((int)_respCode).ToString(CultureInfo.InvariantCulture), _respText);
+                    msg = string.Format(CultureInfo.InvariantCulture, "Proxy destination {0} on port {1} responded with a {2} code - {3}", Utils.GetHost(TcpClient!), Utils.GetPort(TcpClient!), ((int)_respCode).ToString(CultureInfo.InvariantCulture), _respText);
                     break;
             }
 

--- a/source/Halibut/Transport/Proxy/IProxyClient.cs
+++ b/source/Halibut/Transport/Proxy/IProxyClient.cs
@@ -53,7 +53,7 @@ namespace Halibut.Transport.Proxy
         /// <summary>
         /// Gets or set the TcpClient object if one was specified in the constructor.
         /// </summary>
-        TcpClient TcpClient { get; }
+        TcpClient? TcpClient { get; }
 
         IProxyClient WithTcpClientFactory(Func<TcpClient> tcpClientfactory);
 

--- a/source/Halibut/Transport/Proxy/ProxyClientFactory.cs
+++ b/source/Halibut/Transport/Proxy/ProxyClientFactory.cs
@@ -93,7 +93,7 @@ namespace Halibut.Transport.Proxy
         /// <param name="proxyUsername">The proxy username.  This parameter is only used by Socks4 and Socks5 proxy objects.</param>
         /// <param name="proxyPassword">The proxy user password.  This parameter is only used Socks5 proxy objects.</param>
         /// <returns>Proxy client object.</returns>
-        public IProxyClient CreateProxyClient(ILog logger, ProxyType type, string proxyHost, int proxyPort, string proxyUsername, string proxyPassword)
+        public IProxyClient CreateProxyClient(ILog logger, ProxyType type, string proxyHost, int proxyPort, string? proxyUsername, string? proxyPassword)
         {
             if (type == ProxyType.None)
                 throw new ArgumentOutOfRangeException(nameof(type));

--- a/source/Halibut/Transport/Proxy/Utils.cs
+++ b/source/Halibut/Transport/Proxy/Utils.cs
@@ -14,7 +14,9 @@ namespace Halibut.Transport.Proxy
             var host = "";
             try
             {
-                host = ((System.Net.IPEndPoint)client.Client.RemoteEndPoint).Address.ToString();
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                host = ((System.Net.IPEndPoint)client.Client.RemoteEndPoint)!.Address.ToString();
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             }
             catch
             {   };
@@ -30,7 +32,9 @@ namespace Halibut.Transport.Proxy
             var port = "";
             try
             {
-                port = ((System.Net.IPEndPoint)client.Client.RemoteEndPoint).Port.ToString(CultureInfo.InvariantCulture);
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+                port = ((System.Net.IPEndPoint)client.Client.RemoteEndPoint)!.Port.ToString(CultureInfo.InvariantCulture);
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             }
             catch
             { };

--- a/source/Halibut/Transport/SecureClient.cs
+++ b/source/Halibut/Transport/SecureClient.cs
@@ -44,7 +44,7 @@ namespace Halibut.Transport
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 
-            Exception lastError = null;
+            Exception? lastError = null;
 
             // retryAllowed is also used to indicate if the error occurred before or after the connection was made
             var retryAllowed = true;
@@ -61,7 +61,7 @@ namespace Halibut.Transport
                 {
                     lastError = null;
 
-                    IConnection connection = null;
+                    IConnection? connection = null;
                     try
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
@@ -149,7 +149,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        void HandleError(Exception lastError, bool retryAllowed)
+        void HandleError(Exception? lastError, bool retryAllowed)
         {
             if (lastError == null)
                 return;

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -48,9 +48,11 @@ namespace Halibut.Transport
         readonly IConnectionsObserver connectionsObserver;
         ILog log;
         TcpListener listener;
-        Thread backgroundThread;
+        Thread? backgroundThread;
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public SecureListener(
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             IPEndPoint endPoint, 
             X509Certificate2 serverCertificate, 
             ExchangeProtocolBuilder exchangeProtocolBuilder, 
@@ -129,12 +131,12 @@ namespace Halibut.Transport
 
             const int errorThreshold = 3;
 
-            using (IsWindows() ? cancellationToken.Register(listener.Stop) : (IDisposable) null)
+            using (IsWindows() ? cancellationToken.Register(listener.Stop) : (IDisposable) null!)
             {
                 var numberOfFailedAttemptsInRow = 0;
                 while (!cts.IsCancellationRequested)
                 {
-                    TcpClient client = null;
+                    TcpClient? client = null;
                     try
                     {
                         if (!IsWindows())
@@ -162,7 +164,7 @@ namespace Halibut.Transport
                     catch (Exception ex)
                     {
                         numberOfFailedAttemptsInRow++;
-                        log.WriteException(EventType.ErrorInInitialisation, "Error accepting TCP client: {0}", ex, client.GetRemoteEndpointString());
+                        log.WriteException(EventType.ErrorInInitialisation, "Error accepting TCP client: {0}", ex, client!.GetRemoteEndpointString());
                         // Slow down the logs in case an exception is immediately encountered after X failed AcceptTcpClient calls
                         if (numberOfFailedAttemptsInRow >= errorThreshold)
                         {
@@ -338,7 +340,7 @@ namespace Halibut.Transport
             await stream.FlushAsync();
         }
 
-        static string GetThumbprint(SslStream stream)
+        static string? GetThumbprint(SslStream stream)
         {
             if (stream.RemoteCertificate == null)
             {
@@ -374,7 +376,7 @@ namespace Halibut.Transport
             return exchangeAction(exchangeProtocolBuilder(stream, log), cancellationToken);
         }
 
-        static bool AcceptAnySslCertificate(object sender, X509Certificate clientCertificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
+        static bool AcceptAnySslCertificate(object sender, X509Certificate? clientCertificate, X509Chain? chain, SslPolicyErrors sslpolicyerrors)
         {
             return true;
         }

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -42,7 +42,7 @@ namespace Halibut.Transport
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 
-            Exception lastError = null;
+            Exception? lastError = null;
 
             // retryAllowed is also used to indicate if the error occurred before or after the connection was made
             var retryAllowed = true;
@@ -59,7 +59,7 @@ namespace Halibut.Transport
                 {
                     lastError = null;
 
-                    IConnection connection = null;
+                    IConnection? connection = null;
                     try
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
@@ -158,7 +158,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        void HandleError(Exception lastError, bool retryAllowed)
+        void HandleError(Exception? lastError, bool retryAllowed)
         {
             if (lastError == null)
                 return;

--- a/source/Halibut/Transport/SecureWebSocketClient.cs
+++ b/source/Halibut/Transport/SecureWebSocketClient.cs
@@ -54,7 +54,7 @@ namespace Halibut.Transport
         {
             var retryInterval = ServiceEndpoint.RetryListeningSleepInterval;
 
-            Exception lastError = null;
+            Exception? lastError = null;
 
             // retryAllowed is also used to indicate if the error occurred before or after the connection was made
             var retryAllowed = true;
@@ -71,7 +71,7 @@ namespace Halibut.Transport
                 {
                     lastError = null;
 
-                    IConnection connection = null;
+                    IConnection? connection = null;
                     try
                     {
                         connection = await connectionManager.AcquireConnectionAsync(
@@ -150,7 +150,7 @@ namespace Halibut.Transport
             HandleError(lastError, retryAllowed);
         }
 
-        void HandleError(Exception lastError, bool retryAllowed)
+        void HandleError(Exception? lastError, bool retryAllowed)
         {
             if (lastError == null)
                 return;

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -36,7 +36,9 @@ namespace Halibut.Transport
         {
         }
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public SecureWebSocketListener(string endPoint, X509Certificate2 serverCertificate, ExchangeProtocolBuilder exchangeProtocolBuilder, ExchangeActionAsync exchangeAction, Predicate<string> verifyClientThumbprint, ILogFactory logFactory, Func<string> getFriendlyHtmlPageContent, Func<Dictionary<string, string>> getFriendlyHtmlPageHeaders, Func<string, string, UnauthorizedClientConnectResponse> unauthorizedClientConnect, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, IStreamFactory streamFactory, IConnectionsObserver connectionsObserver)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             if (!endPoint.EndsWith("/"))
                 endPoint += "/";
@@ -80,7 +82,7 @@ namespace Halibut.Transport
                 while (!cts.IsCancellationRequested)
                 {
 
-                    HttpListenerContext context = null;
+                    HttpListenerContext? context = null;
                     try
                     {
                         context = await listener.GetContextAsync().ConfigureAwait(false);
@@ -137,7 +139,7 @@ namespace Halibut.Transport
             var connectionAuthorizedAndObserved = false;
             var clientName = listenerContext.Request.RemoteEndPoint.ToString();
 
-            WebSocketStream webSocketStream = null;
+            WebSocketStream? webSocketStream = null;
             var errorEventType = EventType.ErrorInInitialisation;
             try
             {
@@ -152,7 +154,7 @@ namespace Halibut.Transport
                     return;
                 }
 
-                if (req.Substring(0, 2) != "MX")
+                if (req!.Substring(0, 2) != "MX")
                 {
                     log.Write(EventType.Diagnostic, "Appears to be a web browser, sending friendly HTML response");
                     return;

--- a/source/Halibut/Transport/ServerCertificateInterceptor.cs
+++ b/source/Halibut/Transport/ServerCertificateInterceptor.cs
@@ -10,7 +10,7 @@ namespace Halibut.Transport
     {
         public const string Header = "X-Octopus-RequestId";
 
-        static readonly Dictionary<string, X509Certificate2> certificates = new();
+        static readonly Dictionary<string, X509Certificate2?> certificates = new();
         static bool initialized;
 
 
@@ -58,14 +58,14 @@ namespace Halibut.Transport
 
         public static void Validate(string connectionId, ServiceEndPoint endPoint)
         {
-            X509Certificate2 providedCertificate;
+            X509Certificate2? providedCertificate;
 
             lock (certificates)
                 if (!certificates.TryGetValue(connectionId, out providedCertificate))
                     throw new Exception("Did not recieve a certificate from the server");
 
-            if (providedCertificate.Thumbprint != endPoint.RemoteThumbprint)
-                throw new UnexpectedCertificateException(providedCertificate, endPoint);
+            if (providedCertificate?.Thumbprint != endPoint.RemoteThumbprint)
+                throw new UnexpectedCertificateException(providedCertificate!, endPoint);
         }
     }
 }

--- a/source/Halibut/Transport/TcpClientManager.cs
+++ b/source/Halibut/Transport/TcpClientManager.cs
@@ -87,7 +87,7 @@ namespace Halibut.Transport
             lock (syncLock)
             {
                 var clients = activeClients?.ToArray();
-                activeClients = null;
+                activeClients = null!;
 
                 if (clients == null || !clients.Any())
                 {

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -63,7 +63,7 @@ namespace Halibut.Transport
         internal static async Task<TcpClient> CreateConnectedTcpClientAsync(ServiceEndPoint endPoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, IStreamFactory streamFactory, ILog log, CancellationToken cancellationToken)
         {
             TcpClient client;
-            if (endPoint.Proxy == null)
+            if (endPoint.Proxy is null)
             {
                 client = CreateTcpClientAsync(halibutTimeoutsAndLimits);
                 await client.ConnectWithTimeoutAsync(endPoint.BaseUri, endPoint.TcpClientConnectTimeout, cancellationToken);
@@ -104,7 +104,7 @@ namespace Halibut.Transport
             return client;
         }
 
-        X509Certificate UserCertificateSelectionCallback(object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate remoteCertificate, string[] acceptableIssuers)
+        X509Certificate UserCertificateSelectionCallback(object sender, string targetHost, X509CertificateCollection localCertificates, X509Certificate? remoteCertificate, string[] acceptableIssuers)
         {
             return clientCertificate;
         }

--- a/source/Halibut/Transport/UnexpectedCertificateException.cs
+++ b/source/Halibut/Transport/UnexpectedCertificateException.cs
@@ -7,7 +7,7 @@ namespace Halibut.Transport
     class UnexpectedCertificateException : AuthenticationException
     {
         public X509Certificate2 ProvidedCert { get; }
-        public string ExpectedThumbprint { get; }
+        public string? ExpectedThumbprint { get; }
         public Uri ServerUrl { get; }
 
         const string Text = "The server at {0} presented an unexpected security certificate. We expected the server to " +

--- a/source/Halibut/Transport/WebSocketConnectionFactory.cs
+++ b/source/Halibut/Transport/WebSocketConnectionFactory.cs
@@ -57,7 +57,7 @@ namespace Halibut.Transport
             client.Options.ClientCertificates = new X509Certificate2Collection(new X509Certificate2Collection(clientCertificate));
             client.Options.AddSubProtocol("Octopus");
             client.Options.SetRequestHeader(ServerCertificateInterceptor.Header, connectionId);
-            if (serviceEndpoint.Proxy != null)
+            if (serviceEndpoint.Proxy is not null)
                 client.Options.Proxy = new WebSocketProxy(serviceEndpoint.Proxy);
 
             try
@@ -112,7 +112,7 @@ namespace Halibut.Transport
 
         public bool IsBypassed(Uri host) => false;
 
-        public ICredentials Credentials { get; set; }
+        public ICredentials? Credentials { get; set; }
     }
 }
 #endif

--- a/source/Halibut/Util/ActionDisposable.cs
+++ b/source/Halibut/Util/ActionDisposable.cs
@@ -4,9 +4,9 @@ namespace Halibut.Util
 {
     public class ActionDisposable : IDisposable
     {
-        Action action;
+        Action? action;
 
-        public ActionDisposable(Action action)
+        public ActionDisposable(Action? action)
         {
             this.action = action;
         }

--- a/source/Octopus.TestPortForwarder/Octopus.TestPortForwarder.csproj
+++ b/source/Octopus.TestPortForwarder/Octopus.TestPortForwarder.csproj
@@ -4,6 +4,7 @@
         <LangVersion>9.0</LangVersion>
         <RootNamespace>Octopus.TestPortForwarder</RootNamespace>
         <Nullable>enable</Nullable>
+	    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">


### PR DESCRIPTION
# Background

For years, no one has dealt with the warnings that have been accumulating as .NET code analysis have matured.

# Results

## Before

There were hundreds of warnings that were being ignored.

## After

These have all been addressed, and each project has had "Treat warnings as errors" turned on.

There was a lot to get through, so in many cases, the simplest solution was often taken (e.g. using "!" or "?" etc.)

But this is **more about helping future developers**, and **less about fixing all the issues that already exist**.

Some places it was easier to suppress the warning than solve it, as the difference between .NET4.8 and .NET6.0 made it harder to solve.

With models, I tried to reflect whether a property was legitimately nullable or not.



### AssertAsync
We had to add an overload that was not async (i.e. sync), which made this class name not make sense anymore. So we renamed to `AssertException`.

Also, whenever we used the async version, and gave it a task from a `Task.Run`, it would warn about this. So we made the overload that just takes the task itself, and suppress the warning in that overload.

### .editorconfig
This was added so we could disable VSTHRD200. This was a nightmare in the test project, as it wanted all our async tests to end with the word 'Async'. But this isn't a rule we are respecting in Halibut itself, so it was disabled.

# How to review this PR
There is a lot here.

To help break it up, each commit attempts to achieve something specific towards the final goal.

Please review each commit (or the whole thing if that works better for you).

As you review, please try to see if I have converted something incorrectly.

Otherwise, Quality :heavy_check_mark:


# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
