### PR TITLE
Stop throwing an exception in the finally of WithTimeouts

### DIFF
--- a/source/Halibut/Transport/Protocol/StreamTimeoutExtensionMethods.cs
+++ b/source/Halibut/Transport/Protocol/StreamTimeoutExtensionMethods.cs
@@ -18,6 +18,7 @@ namespace Halibut.Transport.Protocol
 
             var currentReadTimeout = stream.ReadTimeout;
             var currentWriteTimeout = stream.WriteTimeout;
+            var timeoutsReverted = false;
 
             try
             {
@@ -26,8 +27,20 @@ namespace Halibut.Transport.Protocol
             }
             finally
             {
-                stream.ReadTimeout = currentReadTimeout;
-                stream.WriteTimeout = currentWriteTimeout;
+                try
+                {
+                    stream.ReadTimeout = currentReadTimeout;
+                    stream.WriteTimeout = currentWriteTimeout;
+                    timeoutsReverted = true;
+                }
+                catch
+                {
+                }
+            }
+
+            if (!timeoutsReverted)
+            {
+                throw new InvalidOperationException("Could not revert the Timeouts. This should not happen.");
             }
         }
 
@@ -40,17 +53,33 @@ namespace Halibut.Transport.Protocol
 
             var currentReadTimeout = stream.ReadTimeout;
             var currentWriteTimeout = stream.WriteTimeout;
+            var timeoutsReverted = false;
+            T result;
 
             try
             {
                 stream.SetReadAndWriteTimeouts(timeout);
-                return await func();
+                result = await func();
             }
             finally
             {
-                stream.ReadTimeout = currentReadTimeout;
-                stream.WriteTimeout = currentWriteTimeout;
+                try
+                {
+                    stream.ReadTimeout = currentReadTimeout;
+                    stream.WriteTimeout = currentWriteTimeout;
+                    timeoutsReverted = true;
+                }
+                catch
+                {
+                }
             }
+
+            if (!timeoutsReverted)
+            {
+                throw new InvalidOperationException("Could not revert the Timeouts. This should not happen.");
+            }
+
+            return result;
         }
 
         public static async Task WithReadTimeout(this Stream stream, TimeSpan timeout, Func<Task> func)
@@ -63,6 +92,7 @@ namespace Halibut.Transport.Protocol
             }
 
             var currentReadTimeout = stream.ReadTimeout;
+            var timeoutsReverted = false;
 
             try
             {
@@ -71,7 +101,19 @@ namespace Halibut.Transport.Protocol
             }
             finally
             {
-                stream.ReadTimeout = currentReadTimeout;
+                try
+                {
+                    stream.ReadTimeout = currentReadTimeout;
+                    timeoutsReverted = true;
+                }
+                catch
+                {
+                }
+            }
+
+            if (!timeoutsReverted)
+            {
+                throw new InvalidOperationException("Could not revert the Timeouts. This should not happen.");
             }
         }
 
@@ -83,16 +125,32 @@ namespace Halibut.Transport.Protocol
             }
 
             var currentReadTimeout = stream.ReadTimeout;
+            var timeoutsReverted = false;
+            T result;
 
             try
             {
                 stream.SetReadTimeouts(timeout);
-                return await func();
+                result = await func();
             }
             finally
             {
-                stream.ReadTimeout = currentReadTimeout;
+                try
+                {
+                    stream.ReadTimeout = currentReadTimeout;
+                    timeoutsReverted = true;
+                }
+                catch
+                {
+                }
             }
+
+            if (!timeoutsReverted)
+            {
+                throw new InvalidOperationException("Could not revert the Timeouts. This should not happen.");
+            }
+
+            return result;
         }
 
         public static void SetReadAndWriteTimeouts(this Stream stream, SendReceiveTimeout? timeout)


### PR DESCRIPTION
# Background

Stop throwing an exception in the finally of WithTimeouts when the Stream is in an error state.

[sc-65700]

This has been run through a Tentacle build here https://github.com/OctopusDeploy/OctopusTentacle/pull/711

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
