### PR TITLE
Add PollingRequestQueueTimeout and PollingRequestMaximumMessageProcessingTimeout tests

### DIFF
--- a/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
+++ b/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
@@ -64,8 +64,7 @@ namespace Halibut.Tests
                 stopwatch.Stop();
 
                 stopwatch.Elapsed.Should()
-                    .BeGreaterThan(halibutTimeoutsAndLimits.PollingRequestQueueTimeout, "Should have waited longer than the PollingRequestQueueTimeout").And
-                    .BeLessThan(responseDelay + TimeSpan.FromSeconds(5), "Should have received the response after the 10 second delay + 5 second buffer");
+                    .BeGreaterThan(halibutTimeoutsAndLimits.PollingRequestQueueTimeout, "Should have waited longer than the PollingRequestQueueTimeout");
             }
         }
 

--- a/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
+++ b/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.TestServices.Async;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class PollingServiceTimeoutsFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestQueueTimeoutIsReached_TheRequestShouldTimeout(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                       .As<LatestClientAndLatestServiceBuilder>()
+                       .NoService()
+                       .WithStandardServices()
+                       .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                       .Build(CancellationToken))
+            {
+                var client = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoServiceWithOptions>();
+
+                var stopwatch = Stopwatch.StartNew();
+                (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken, CancellationToken.None))))
+                    .And.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out.");
+                stopwatch.Stop();
+
+                stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(8), "Should have timed out quickly");
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestQueueTimeoutIsReached_ButTheResponseIsReceivedBeforeThePollingRequestMaximumMessageProcessingTimeoutIsReached_TheRequestShouldSucceed(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+            halibutTimeoutsAndLimits.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(100);
+
+            var responseDelay = TimeSpan.FromSeconds(10);
+
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .As<LatestClientAndLatestServiceBuilder>()
+                             .WithDoSomeActionService(() => Thread.Sleep(responseDelay))
+                             .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                             .WithInstantReconnectPollingRetryPolicy()
+                             .Build(CancellationToken))
+            {
+                var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+                var stopwatch = Stopwatch.StartNew();
+                await doSomeActionClient.ActionAsync(new(CancellationToken, CancellationToken.None));
+                stopwatch.Stop();
+
+                stopwatch.Elapsed.Should()
+                    .BeGreaterThan(halibutTimeoutsAndLimits.PollingRequestQueueTimeout, "Should have waited longer than the PollingRequestQueueTimeout").And
+                    .BeLessThan(responseDelay + TimeSpan.FromSeconds(5), "Should have received the response after the 10 second delay + 5 second buffer");
+            }
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestMaximumMessageProcessingTimeoutIsReached_TheRequestShouldTimeout_AndTheTransferringPendingRequestCancelled(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+            halibutTimeoutsAndLimits.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(6);
+
+            var waitSemaphore = new SemaphoreSlim(0, 1);
+            var connectionsObserver = new TestConnectionsObserver();
+
+            await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                             .As<LatestClientAndLatestServiceBuilder>()
+                             .WithDoSomeActionService(() => waitSemaphore.Wait(CancellationToken))
+                             .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                             .WithInstantReconnectPollingRetryPolicy()
+                             .WithConnectionObserverOnTcpServer(connectionsObserver)
+                             .Build(CancellationToken))
+            {
+                var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+                var stopwatch = Stopwatch.StartNew();
+                (await AssertException.Throws<HalibutClientException>(async () => await doSomeActionClient.ActionAsync(new(CancellationToken, CancellationToken.None))))
+                    .And.Message.Should().Contain("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:06), so the request timed out.");
+                stopwatch.Stop();
+
+                stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(15), "Should have timed out quickly");
+
+                connectionsObserver.ConnectionAcceptedCount.Should().Be(1, "A single TCP connection should have been created");
+
+                waitSemaphore.Release();
+
+                Wait.UntilActionSucceeds(() =>
+                {
+                    // Leaving these asserts as when cooperative cancellation is supported it should cause them to fail at which point they can be fixed to assert cancellation to the socket works as expected.
+                    connectionsObserver.ConnectionClosedCount.Should().Be(0, "Cancelling the PendingRequest does not cause the TCP Connection to be cancelled to stop the in-flight request");
+                    connectionsObserver.ConnectionAcceptedCount.Should().Be(1, "The Service won't have reconnected after the request was cancelled");
+                }, TimeSpan.FromSeconds(30), Logger, CancellationToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

Add PollingRequestQueueTimeout and PollingRequestMaximumMessageProcessingTimeout tests

Cherry-picked from this reverted PR https://github.com/OctopusDeploy/Halibut/pull/558 

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
