### PR TITLE
Remove a .GetAwaiter().GetResult() from tests.

### DIFF
--- a/source/Halibut.Tests/AsyncClientAndServiceMustNotUseSyncNetworkIO.cs
+++ b/source/Halibut.Tests/AsyncClientAndServiceMustNotUseSyncNetworkIO.cs
@@ -45,10 +45,10 @@ namespace Halibut.Tests
                     var response = await service.ProcessAsync(request);
 
                     response.Payload1.Should().NotBeSameAs(request.Payload1);
-                    response.Payload1!.ReadAsString().Should().Be(payload1);
+                    (await response.Payload1!.ReadAsString(CancellationToken)).Should().Be(payload1);
 
                     response.Payload2.Should().NotBeSameAs(request.Payload2);
-                    response.Payload2!.ReadAsString().Should().Be(payload2);
+                    (await response.Payload2!.ReadAsString(CancellationToken)).Should().Be(payload2);
                 }
             }
 

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
+    <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />

--- a/source/Halibut.Tests/TestServices/AsyncComplexObjectService.cs
+++ b/source/Halibut.Tests/TestServices/AsyncComplexObjectService.cs
@@ -28,13 +28,13 @@ namespace Halibut.Tests.TestServices
                 {
                     ChildPayload1 = await ReadIntoNewDataStream(request.Child1!.ChildPayload1, cancellationToken),
                     ChildPayload2 = await ReadIntoNewDataStream(request.Child1!.ChildPayload2, cancellationToken),
-                    ListOfStreams = await request.Child1.ListOfStreams!.ToAsyncEnumerable().Do(ReadIntoNewDataStream).ToListAsync(cancellationToken),
+                    ListOfStreams = await request.Child1.ListOfStreams!.ToAsyncEnumerable().SelectAwait(async ds => await ReadIntoNewDataStream(ds, cancellationToken)).ToListAsync(cancellationToken),
                     DictionaryPayload = request.Child1.DictionaryPayload!.ToDictionary(pair => pair.Key, pair => pair.Value),
                 },
                 Child2 = new ComplexChild2
                 {
                     EnumPayload = request.Child2!.EnumPayload,
-                    ComplexPayloadSet = await request.Child2.ComplexPayloadSet!.ToAsyncEnumerable().Do(async x => new ComplexPair<DataStream>(x.EnumValue, await ReadIntoNewDataStream(x.Payload, cancellationToken))).ToHashSetAsync(cancellationToken)
+                    ComplexPayloadSet = await request.Child2.ComplexPayloadSet!.ToAsyncEnumerable().SelectAwait(async x => new ComplexPair<DataStream>(x.EnumValue, await ReadIntoNewDataStream(x.Payload, cancellationToken))).ToHashSetAsync(cancellationToken)
                 }
             };
         }

--- a/source/Halibut.Tests/TestServices/AsyncComplexObjectService.cs
+++ b/source/Halibut.Tests/TestServices/AsyncComplexObjectService.cs
@@ -14,8 +14,8 @@ namespace Halibut.Tests.TestServices
             await Task.CompletedTask;
             return new ComplexObjectMultipleDataStreams
             {
-                Payload1 = ReadIntoNewDataStream(request.Payload1),
-                Payload2 = ReadIntoNewDataStream(request.Payload2)
+                Payload1 = await ReadIntoNewDataStream(request.Payload1, cancellationToken),
+                Payload2 = await ReadIntoNewDataStream(request.Payload2, cancellationToken)
             };
         }
 
@@ -26,15 +26,15 @@ namespace Halibut.Tests.TestServices
             {
                 Child1 = new ComplexChild1
                 {
-                    ChildPayload1 = ReadIntoNewDataStream(request.Child1!.ChildPayload1),
-                    ChildPayload2 = ReadIntoNewDataStream(request.Child1!.ChildPayload2),
-                    ListOfStreams = request.Child1.ListOfStreams!.Select(ReadIntoNewDataStream).ToList(),
+                    ChildPayload1 = await ReadIntoNewDataStream(request.Child1!.ChildPayload1, cancellationToken),
+                    ChildPayload2 = await ReadIntoNewDataStream(request.Child1!.ChildPayload2, cancellationToken),
+                    ListOfStreams = await request.Child1.ListOfStreams!.ToAsyncEnumerable().Do(ReadIntoNewDataStream).ToListAsync(cancellationToken),
                     DictionaryPayload = request.Child1.DictionaryPayload!.ToDictionary(pair => pair.Key, pair => pair.Value),
                 },
                 Child2 = new ComplexChild2
                 {
                     EnumPayload = request.Child2!.EnumPayload,
-                    ComplexPayloadSet = request.Child2.ComplexPayloadSet!.Select(x => new ComplexPair<DataStream>(x.EnumValue, ReadIntoNewDataStream(x.Payload))).ToHashSet()
+                    ComplexPayloadSet = await request.Child2.ComplexPayloadSet!.ToAsyncEnumerable().Do(async x => new ComplexPair<DataStream>(x.EnumValue, await ReadIntoNewDataStream(x.Payload, cancellationToken))).ToHashSetAsync(cancellationToken)
                 }
             };
         }
@@ -49,13 +49,13 @@ namespace Halibut.Tests.TestServices
             };
         }
 
-        DataStream ReadIntoNewDataStream(DataStream? ds)
+        async Task<DataStream> ReadIntoNewDataStream(DataStream? ds, CancellationToken cancellationToken)
         {
             // Read the source DataStream, then write into
             // a new DataStream, to simulate some work.
             // i.e. we don't want to just re-use the exact same
             // DataStream instance
-            return DataStream.FromString(ds!.ReadAsString());
+            return DataStream.FromString(await ds!.ReadAsString(cancellationToken));
         }
     }
 }

--- a/source/Halibut.Tests/UsageFixture.cs
+++ b/source/Halibut.Tests/UsageFixture.cs
@@ -251,7 +251,7 @@ namespace Halibut.Tests
                 (await response.Child1.ChildPayload2!.ReadAsString(CancellationToken)).Should().Be(childPayload2);
                 response.Child1.ListOfStreams.Should().NotBeSameAs(request.Child1.ListOfStreams);
                 (await response.Child1.ListOfStreams!.ToAsyncEnumerable()
-                    .Do(async x => await x.ReadAsString(CancellationToken))
+                    .SelectAwait(async x => await x.ReadAsString(CancellationToken))
                     .ToListAsync(CancellationToken))
                     .Should().BeEquivalentTo(list);
                 response.Child1.DictionaryPayload.Should().NotBeSameAs(request.Child1.DictionaryPayload);
@@ -261,7 +261,7 @@ namespace Halibut.Tests
                 response.Child2!.EnumPayload.Should().Be(enumValue);
                 response.Child2.ComplexPayloadSet.Should().NotBeSameAs(request.Child2.ComplexPayloadSet);
                 (await response.Child2.ComplexPayloadSet!.ToAsyncEnumerable()
-                    .Do(async x => new ComplexPair<string>(x.EnumValue, await x.Payload.ReadAsString(CancellationToken)))
+                    .SelectAwait(async x => new ComplexPair<string>(x.EnumValue, await x.Payload.ReadAsString(CancellationToken)))
                     .ToArrayAsync())
                     .ToHashSet()
                     .Should()

--- a/source/Halibut.Tests/Util/DataStreamExtensionMethods.cs
+++ b/source/Halibut.Tests/Util/DataStreamExtensionMethods.cs
@@ -7,21 +7,17 @@ namespace Halibut.Tests.Util
 {
     public static class DataStreamExtensionMethods
     {
-        // TODO: This could be async
-        public static string ReadAsString(this DataStream stream)
+        public static async Task<string> ReadAsString(this DataStream stream, CancellationToken cancellationToken)
         {
             var result = string.Empty;
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            stream.Receiver().ReadAsync(async (s, ct) =>
+            await stream.Receiver().ReadAsync(async (s, ct) =>
                     {
                         using (var reader = new StreamReader(s))
                         {
                             result = await reader.ReadToEndAsync();
                         }
                     },
-                    CancellationToken.None)
-                .GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+                    cancellationToken);
             return result;
         }
     }


### PR DESCRIPTION
# Background

Cleans up a TODO in which we called .GetAwaiter().GetResult()

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
