### PR TITLE
Tests to ensure the type of exceptions thrown during RPC calls for connecting, timeouts and cancellations errors do not change

### DIFF
--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Tests.Support;
+using Halibut.Tests.Support.PendingRequestQueueFactories;
+using Halibut.Tests.Support.TestAttributes;
+using Halibut.Tests.Support.TestCases;
+using Halibut.Tests.TestServices;
+using Halibut.Tests.TestServices.Async;
+using Halibut.TestUtils.Contracts;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    /// <summary>
+    /// The type of exception that is throw by Halibut is important for the caller to be able to determine what went wrong and how to handle it.
+    /// These tests ensure the contract is maintained in Halibut and that the exception does not change and have un-intended consequences for the caller.
+    /// </summary>
+    public class ExceptionContractFixture : BaseTest
+    {
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestQueueTimeoutIsReached_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+
+            await using var clientOnly = await clientAndServiceTestCase.CreateClientOnlyTestCaseBuilder()
+                .AsLatestClientBuilder()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .Build(CancellationToken);
+
+            var client = clientOnly.CreateClientWithoutService<IEchoService, IAsyncClientEchoServiceWithOptions>();
+
+            (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken, CancellationToken.None))))
+                .And.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out.");
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestMaximumMessageProcessingTimeoutIsReached_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+            halibutTimeoutsAndLimits.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(6);
+
+            var waitSemaphore = new SemaphoreSlim(0, 1);
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithDoSomeActionService(() => waitSemaphore.Wait(CancellationToken))
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .Build(CancellationToken);
+
+            var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+            (await AssertException.Throws<HalibutClientException>(async () => await doSomeActionClient.ActionAsync(new(CancellationToken, CancellationToken.None))))
+                .And.Message.Should().Contain("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:06), so the request timed out.");
+
+            waitSemaphore.Release();
+        }
+
+        [Test] [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestIsCancelledWhileQueued_AnOperationCanceledExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            
+            await using var clientOnly = await clientAndServiceTestCase.CreateClientOnlyTestCaseBuilder()
+                .AsLatestClientBuilder()
+                .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestQueuedPendingRequestQueueFactory(inner, cancellationTokenSource)))
+                .Build(CancellationToken);
+
+            var client = clientOnly.CreateClientWithoutService<IEchoService, IAsyncClientEchoServiceWithOptions>();
+
+            await AssertException.Throws<OperationCanceledException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token, CancellationToken.None)));
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestIsCancelledWhileDequeued_AnOperationCanceledExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            var waitSemaphore = new SemaphoreSlim(0, 1);
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithDoSomeActionService(() => waitSemaphore.Wait(CancellationToken))
+                .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, cancellationTokenSource)))
+                .Build(CancellationToken);
+
+            var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+            await AssertException.Throws<OperationCanceledException>(async () => await doSomeActionClient.ActionAsync(new(CancellationToken.None, cancellationTokenSource.Token)));
+
+            waitSemaphore.Release();
+        }
+        
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestFailsToBeSent_AsTheServiceDoesNotAcceptTheConnection_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .WithPortForwarding(out var portForwarder)
+                .Build(CancellationToken);
+
+            portForwarder.Value.Dispose();
+
+            var client = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoServiceWithOptions>();
+
+            (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken, CancellationToken.None))))
+                .And.Message.Should().ContainAny(
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: No connection could be made because the target machine actively refused it",
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Connection refused");
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestFailsToBeSent_AsTheServiceRejectsTheConnection_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithStandardServices()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .WithPortForwarding(out var portForwarder)
+                .Build(CancellationToken);
+
+            portForwarder.Value.EnterKillNewAndExistingConnectionsMode();
+
+            var client = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoServiceWithOptions>();
+
+            (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken, CancellationToken.None))))
+                .And.Message.Should().ContainAny(
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Unable to read data from the transport connection:",
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Unable to write data to the transport connection:");
+        }
+        
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestFailsToBeSent_AsTheConnectionAttemptToTheServiceTimesOut_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+
+            halibutTimeoutsAndLimits.TcpClientConnectTimeout = TimeSpan.FromSeconds(1);
+
+            await using var clientOnly = await clientAndServiceTestCase.CreateClientOnlyTestCaseBuilder()
+                .AsLatestClientBuilder()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .Build(CancellationToken);
+
+            // We need to use a non localhost address to get a timeout
+            var client = clientOnly.CreateClient<IEchoService, IAsyncClientEchoServiceWithOptions>(new Uri("https://20.5.79.31:10933/"));
+
+            (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken, CancellationToken.None))))
+                .And.Message.Should().Contain(
+                    $"An error occurred when sending a request to 'https://20.5.79.31:10933/', before the request could begin: The client was unable to establish the initial connection within the timeout 00:00:01.");
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestIsCancelledImmediatelyWhileTryingToConnect_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.TcpClientConnectTimeout = TimeSpan.FromSeconds(5);
+            halibutTimeoutsAndLimits.ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(600);
+            halibutTimeoutsAndLimits.RetryCountLimit = int.MaxValue;
+
+            var connectionsObserver = new TestConnectionsObserver();
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateClientOnlyTestCaseBuilder()
+                .AsLatestClientBuilder()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .WithClientConnectionsObserver(connectionsObserver)
+                .Build(CancellationToken);
+
+            var client = clientAndService.CreateClient<IEchoService, IAsyncClientEchoServiceWithOptions>(new Uri("https://20.5.79.31:10933/"));
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            
+            (await AssertException.Throws<HalibutClientException>(async () =>
+            {
+                var task = client.SayHelloAsync("Hello", new(cancellationTokenSource.Token, CancellationToken.None));
+                cancellationTokenSource.Cancel();
+                await task;
+            })).And.Message.Should().Contain($"An error occurred when sending a request to 'https://20.5.79.31:10933/', after the request began: The operation was canceled.");
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestIsCancelledWhileConnecting_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.TcpClientConnectTimeout = TimeSpan.FromSeconds(60);
+            halibutTimeoutsAndLimits.ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(600);
+            halibutTimeoutsAndLimits.RetryCountLimit = int.MaxValue;
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithStandardServices()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .Build(CancellationToken);
+            
+            var client = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoServiceWithOptions>(point =>
+            {
+                // We need to use a non localhost address to get the correct exception
+                return new ServiceEndPoint(new Uri("https://20.5.79.31:10933/"), point.RemoteThumbprint, point.Proxy, clientAndService.Client!.TimeoutsAndLimits);
+            });
+
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token, CancellationToken.None))))
+                .And.Message.Should().Contain("An error occurred when sending a request to 'https://20.5.79.31:10933/', after the request began: The operation was canceled.");
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestIsCancelledWhileConnecting_AndTheConnectionIsEstablishedButPaused_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.TcpClientConnectTimeout = TimeSpan.FromSeconds(60);
+            halibutTimeoutsAndLimits.ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(600);
+            halibutTimeoutsAndLimits.RetryCountLimit = int.MaxValue;
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithStandardServices()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .WithPortForwarding(out var portForwarder)
+                .Build(CancellationToken);
+            
+            portForwarder.Value.EnterPauseNewAndExistingConnectionsMode();
+            var client = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoServiceWithOptions>();
+
+            var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+#if NETFRAMEWORK
+            // net48 does not support cancellation of the request as the DeflateStream ends up using Begin and End methods which don't get passed the cancellation token
+            // This results in a different exception message / a different code path executing. This highlights an inconsistency in the response from 
+            // Halibut due to the way the code is written, so leaving this here as it should really be consistent.
+            await AssertException.Throws<OperationCanceledException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token, CancellationToken.None)));
+#else
+            var exception = (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token, CancellationToken.None)))).And;
+            exception.Message.Should().Be($"An error occurred when sending a request to '{clientAndService.ServiceUri}', after the request began: The ReadAsync operation was cancelled.");
+#endif
+        }
+        
+// net48 does not support cancellation of the request as the DeflateStream ends up using Begin and End methods which don't get passed the cancellation token
+#if !NETFRAMEWORK
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
+        public async Task WhenTheListeningRequestIsCancelledWhileInProgress_AnOperationCanceledExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var executingSemaphore = new SemaphoreSlim(0, 1);
+            var waitSemaphore = new SemaphoreSlim(0, 1);
+            
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithDoSomeActionService(() =>
+                {
+                    executingSemaphore.Release();
+                    waitSemaphore.Wait(CancellationToken);
+                })
+                .Build(CancellationToken);
+
+            var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            
+            var cancellationTask = Task.Run(async () =>
+            {
+                await executingSemaphore.WaitAsync(CancellationToken);
+                cancellationTokenSource.Cancel();
+            });
+
+            (await AssertException.Throws<HalibutClientException>(async () => await doSomeActionClient.ActionAsync(new(cancellationTokenSource.Token, cancellationTokenSource.Token))))
+                .And.Message.Should().Contain($"An error occurred when sending a request to '{clientAndService.ServiceUri}', after the request began: The ReadAsync operation was cancelled.");
+
+            waitSemaphore.Release();
+            await cancellationTask;
+        }
+#endif
+    }
+}

--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -171,13 +171,10 @@ namespace Halibut.Tests
             halibutTimeoutsAndLimits.TcpClientConnectTimeout = TimeSpan.FromSeconds(5);
             halibutTimeoutsAndLimits.ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(600);
             halibutTimeoutsAndLimits.RetryCountLimit = int.MaxValue;
-
-            var connectionsObserver = new TestConnectionsObserver();
-
+            
             await using var clientAndService = await clientAndServiceTestCase.CreateClientOnlyTestCaseBuilder()
                 .AsLatestClientBuilder()
                 .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
-                .WithClientConnectionsObserver(connectionsObserver)
                 .Build(CancellationToken);
 
             var client = clientAndService.CreateClient<IEchoService, IAsyncClientEchoServiceWithOptions>(new Uri("https://20.5.79.31:10933/"));

--- a/source/Halibut.Tests/Support/LatestClient.cs
+++ b/source/Halibut.Tests/Support/LatestClient.cs
@@ -50,6 +50,13 @@ namespace Halibut.Tests.Support
             return Client.CreateAsyncClient<TService, TAsyncClientService>(serviceEndPoint);
         }
 
+        public TAsyncClientService CreateClient<TService, TAsyncClientService>(Uri serviceUri, Func<ServiceEndPoint, ServiceEndPoint> modifyServiceEndpoint)
+        {
+            var serviceEndPoint = GetServiceEndPoint(serviceUri);
+            serviceEndPoint = modifyServiceEndpoint(serviceEndPoint);
+            return Client.CreateAsyncClient<TService, TAsyncClientService>(serviceEndPoint);
+        }
+
         public TAsyncClientService CreateClientWithoutService<TService, TAsyncClientService>()
         {
             var serviceThatDoesNotExistUri = GetServiceUriThatDoesNotExist();
@@ -61,6 +68,14 @@ namespace Halibut.Tests.Support
             var serviceThatDoesNotExistUri = GetServiceUriThatDoesNotExist();
             var serviceEndPoint = GetServiceEndPoint(serviceThatDoesNotExistUri);
             modifyServiceEndpoint(serviceEndPoint);
+            return Client.CreateAsyncClient<TService, TAsyncClientService>(serviceEndPoint);
+        }
+
+        public TAsyncClientService CreateClientWithoutService<TService, TAsyncClientService>(Func<ServiceEndPoint, ServiceEndPoint> modifyServiceEndpoint)
+        {
+            var serviceThatDoesNotExistUri = GetServiceUriThatDoesNotExist();
+            var serviceEndPoint = GetServiceEndPoint(serviceThatDoesNotExistUri);
+            serviceEndPoint = modifyServiceEndpoint(serviceEndPoint);
             return Client.CreateAsyncClient<TService, TAsyncClientService>(serviceEndPoint);
         }
 

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -344,6 +344,11 @@ namespace Halibut.Tests.Support
                 return client.CreateClient<TService, TAsyncClientService>(ServiceUri, modifyServiceEndpoint);
             }
 
+            public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>(Func<ServiceEndPoint, ServiceEndPoint> modifyServiceEndpoint)
+            {
+                return client.CreateClient<TService, TAsyncClientService>(ServiceUri, modifyServiceEndpoint);
+            }
+
             public TAsyncClientService CreateAsyncClient<TService, TAsyncClientService>()
             {
                 return client.CreateClient<TService, TAsyncClientService>(ServiceUri);

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestDequeuedPendingRequestQueueFactory.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestDequeuedPendingRequestQueueFactory.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Tests.Support.PendingRequestQueueFactories
+{
+    /// <summary>
+    /// CancelWhenRequestDequeuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
+    /// </summary>
+    public class CancelWhenRequestDequeuedPendingRequestQueueFactory : IPendingRequestQueueFactory
+        {
+            readonly CancellationTokenSource[] cancellationTokenSources;
+            readonly IPendingRequestQueueFactory inner;
+
+            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource[] cancellationTokenSources)
+            {
+                this.cancellationTokenSources = cancellationTokenSources;
+                this.inner = inner;
+            }
+
+            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource): this(inner, new []{ cancellationTokenSource })
+            {
+            }
+
+            public IPendingRequestQueue CreateQueue(Uri endpoint)
+            {
+                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSources);
+            }
+
+            class Decorator : IPendingRequestQueue
+            {
+                readonly CancellationTokenSource[] cancellationTokenSources;
+                readonly IPendingRequestQueue inner;
+
+                public Decorator(IPendingRequestQueue inner, CancellationTokenSource[] cancellationTokenSources)
+                {
+                    this.inner = inner;
+                    this.cancellationTokenSources = cancellationTokenSources;
+                }
+
+                public bool IsEmpty => inner.IsEmpty;
+                public int Count => inner.Count;
+                public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
+                
+                public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken)
+                {
+                    var response = await inner.DequeueAsync(cancellationToken);
+                    
+                    Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2)));
+
+                    return response;
+                }
+
+                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
+                    => await inner.QueueAndWaitAsync(request, requestCancellationTokens);
+            }
+        }
+}

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+
+namespace Halibut.Tests.Support.PendingRequestQueueFactories
+{
+    /// <summary>
+    /// CancelWhenRequestQueuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
+    /// </summary>
+    public class CancelWhenRequestQueuedPendingRequestQueueFactory : IPendingRequestQueueFactory
+        {
+            readonly CancellationTokenSource[] cancellationTokenSources;
+            readonly IPendingRequestQueueFactory inner;
+
+            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource[] cancellationTokenSources)
+            {
+                this.cancellationTokenSources = cancellationTokenSources;
+                this.inner = inner;
+            }
+
+            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource) : this(inner, new[]{ cancellationTokenSource }) {
+            }
+
+            public IPendingRequestQueue CreateQueue(Uri endpoint)
+            {
+                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSources);
+            }
+
+            class Decorator : IPendingRequestQueue
+            {
+                readonly CancellationTokenSource[] cancellationTokenSources;
+                readonly IPendingRequestQueue inner;
+
+                public Decorator(IPendingRequestQueue inner, CancellationTokenSource[] cancellationTokenSources)
+                {
+                    this.inner = inner;
+                    this.cancellationTokenSources = cancellationTokenSources;
+                }
+
+                public bool IsEmpty => inner.IsEmpty;
+                public int Count => inner.Count;
+                public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
+                public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken) => await inner.DequeueAsync(cancellationToken);
+
+                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
+                {
+                    var task = Task.Run(async () =>
+                        {
+                            while (inner.IsEmpty)
+                            {
+                                await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
+                            }
+
+                            Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.Cancel());
+                        },
+                        CancellationToken.None);
+
+                    var result = await inner.QueueAndWaitAsync(request, requestCancellationTokens);
+                    await task;
+                    return result;
+                }
+            }
+        }
+}

--- a/source/Halibut.Tests/Timeouts/ReceiveResponseTimeoutTests.cs
+++ b/source/Halibut.Tests/Timeouts/ReceiveResponseTimeoutTests.cs
@@ -85,7 +85,8 @@ namespace Halibut.Tests.Timeouts
                 (await AssertionExtensions.Should(() => lastServiceClient.GetListAsync()).ThrowAsync<HalibutClientException>())
                     .And.Message.Should().ContainAny(
                         "Connection timed out.",
-                        "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
+                        "A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond",
+                        "Unable to read data from the transport connection: Connection reset by peer");
             }
         }
         

--- a/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
+++ b/source/Halibut.Tests/WhenCancellingARequestForAPollingTentacle.cs
@@ -7,11 +7,11 @@ using FluentAssertions;
 using Halibut.Logging;
 using Halibut.ServiceModel;
 using Halibut.Tests.Support;
+using Halibut.Tests.Support.PendingRequestQueueFactories;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices;
 using Halibut.Tests.TestServices.Async;
-using Halibut.Transport.Protocol;
 using NUnit.Framework;
 
 namespace Halibut.Tests
@@ -140,116 +140,6 @@ namespace Halibut.Tests
             var halibutProxyRequestOptions = new HalibutProxyRequestOptions(connectingCancellationTokenSource.Token, inProgressCancellationTokenSource.Token);
                 
             return (tokenSourcesToCancel, halibutProxyRequestOptions);
-        }
-
-        /// <summary>
-        /// CancelWhenRequestQueuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
-        /// </summary>
-        class CancelWhenRequestQueuedPendingRequestQueueFactory : IPendingRequestQueueFactory
-        {
-            readonly CancellationTokenSource[] cancellationTokenSources;
-            readonly IPendingRequestQueueFactory inner;
-
-            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource[] cancellationTokenSources)
-            {
-                this.cancellationTokenSources = cancellationTokenSources;
-                this.inner = inner;
-            }
-
-            public CancelWhenRequestQueuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource) : this(inner, new[]{ cancellationTokenSource }) {
-            }
-
-            public IPendingRequestQueue CreateQueue(Uri endpoint)
-            {
-                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSources);
-            }
-
-            class Decorator : IPendingRequestQueue
-            {
-                readonly CancellationTokenSource[] cancellationTokenSources;
-                readonly IPendingRequestQueue inner;
-
-                public Decorator(IPendingRequestQueue inner, CancellationTokenSource[] cancellationTokenSources)
-                {
-                    this.inner = inner;
-                    this.cancellationTokenSources = cancellationTokenSources;
-                }
-
-                public bool IsEmpty => inner.IsEmpty;
-                public int Count => inner.Count;
-                public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
-                public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken) => await inner.DequeueAsync(cancellationToken);
-
-                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
-                {
-                    var task = Task.Run(async () =>
-                        {
-                            while (inner.IsEmpty)
-                            {
-                                await Task.Delay(TimeSpan.FromMilliseconds(10), CancellationToken.None);
-                            }
-
-                            Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.Cancel());
-                        },
-                        CancellationToken.None);
-
-                    var result = await inner.QueueAndWaitAsync(request, requestCancellationTokens);
-                    await task;
-                    return result;
-                }
-            }
-        }
-
-        /// <summary>
-        /// CancelWhenRequestDequeuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
-        /// </summary>
-        class CancelWhenRequestDequeuedPendingRequestQueueFactory : IPendingRequestQueueFactory
-        {
-            readonly CancellationTokenSource[] cancellationTokenSources;
-            readonly IPendingRequestQueueFactory inner;
-
-            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource[] cancellationTokenSources)
-            {
-                this.cancellationTokenSources = cancellationTokenSources;
-                this.inner = inner;
-            }
-
-            public CancelWhenRequestDequeuedPendingRequestQueueFactory(IPendingRequestQueueFactory inner, CancellationTokenSource cancellationTokenSource): this(inner, new []{ cancellationTokenSource })
-            {
-            }
-
-            public IPendingRequestQueue CreateQueue(Uri endpoint)
-            {
-                return new Decorator(inner.CreateQueue(endpoint), cancellationTokenSources);
-            }
-
-            class Decorator : IPendingRequestQueue
-            {
-                readonly CancellationTokenSource[] cancellationTokenSources;
-                readonly IPendingRequestQueue inner;
-
-                public Decorator(IPendingRequestQueue inner, CancellationTokenSource[] cancellationTokenSources)
-                {
-                    this.inner = inner;
-                    this.cancellationTokenSources = cancellationTokenSources;
-                }
-
-                public bool IsEmpty => inner.IsEmpty;
-                public int Count => inner.Count;
-                public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
-                
-                public async Task<RequestMessage?> DequeueAsync(CancellationToken cancellationToken)
-                {
-                    var response = await inner.DequeueAsync(cancellationToken);
-                    
-                    Parallel.ForEach(cancellationTokenSources, cancellationTokenSource => cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(2)));
-
-                    return response;
-                }
-
-                public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)
-                    => await inner.QueueAndWaitAsync(request, requestCancellationTokens);
-            }
         }
     }
 }

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -128,7 +128,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, requestCancellationTokens.LinkedCancellationToken);
+                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, requestCancellationTokens.InProgressRequestCancellationToken);
                     }
                 }
                 catch (IOException ex) when (ex.IsSocketConnectionReset())

--- a/source/Halibut/Transport/SecureListeningClient.cs
+++ b/source/Halibut/Transport/SecureListeningClient.cs
@@ -128,7 +128,7 @@ namespace Halibut.Transport
                     // against all connections in the pool being bad
                     if (i == 1)
                     {
-                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, requestCancellationTokens.InProgressRequestCancellationToken);
+                        await connectionManager.ClearPooledConnectionsAsync(ServiceEndpoint, log, requestCancellationTokens.LinkedCancellationToken);
                     }
                 }
                 catch (IOException ex) when (ex.IsSocketConnectionReset())


### PR DESCRIPTION
# Background

Tests to cover the type of exception that occurs during an RPC call for connecting, timeout and cancellation scenarios.

The behaviour and the type of exception thrown are important to the caller.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
