### PR TITLE
Downgrade System.Runtime.Caching to 6.0.0

### DIFF
--- a/source/Halibut/Halibut.csproj
+++ b/source/Halibut/Halibut.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-    <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
     <PackageReference Include="NetCoreStack.DispatchProxyAsync" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
[`System.Runtime.Caching` was upgraded to `8.0.0` in this PR,](https://github.com/OctopusDeploy/Halibut/pull/554) as part of addressing [CVE-2021-24112](https://msrc.microsoft.com/update-aguide/vulnerability/CVE-2021-24112).

The upgrade caused dependency conflicts in Octopus Server, which have been difficult to resolve.

This PR downgrades `System.Runtime.Caching` to `6.0.0`, which should resolve the downstream dependency conflicts. 

# Background

## What happened?

The upgrade of `System.Runtime.Caching` from `6.0.0` -> `8.0.0` caused no problems when upgrading Halibut in Tentacle, but caused conflicts when upgrading Tentacle in Octopus Server. This .

The conflict was was due to multiple referenced versions (`6.0.0` and `8.0.0`) of the `System.Security.Cryptography.ProtectedData` library, which is a dependency of the `System.Runtime.Caching`.

`Caching 8.0.0` depends on `ProtectedData 8.0.0`, but other existing dependencies in Server require `ProtectedData 6.0.0`.

## Why downgrade?

Attempts to upgrade existing references to `ProtectedData 8.0.0` failed for unknown reasons, as dotnet itself gave some unhelpful error messages like this:

```
96>Microsoft.Common.CurrentVersion.targets(2382,5): Error MSB3277 : Found conflicts between different versions of "System.Security.Cryptography.ProtectedData" that could not be resolved.
There was a conflict between "System.Security.Cryptography.ProtectedData, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
    "System.Security.Cryptography.ProtectedData, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not.
    References which depend on "System.Security.Cryptography.ProtectedData, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll].
        C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll
          Project file item includes which caused reference "C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll".
            C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll
    References which depend on "System.Security.Cryptography.ProtectedData, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [].
        C:\dev\OctopusDeploy\source\Octopus.Core\bin\net8.0\Octopus.Shared.dll
          Project file item includes which caused reference "C:\dev\OctopusDeploy\source\Octopus.Core\bin\net8.0\Octopus.Shared.dll".
            C:\dev\OctopusDeploy\source\Octopus.Core\bin\net8.0\Octopus.Core.dll
            C:\dev\OctopusDeploy\source\Octopus.Aws\bin\net8.0\Octopus.Aws.dll
            C:\dev\OctopusDeploy\source\Octopus.Upgraders\bin\net8.0\Octopus.Upgraders.dll
``` 

**NB: the error message says that v6 depends on... itself?**
```
References which depend on "System.Security.Cryptography.ProtectedData, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll].
        C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll
          Project file item includes which caused reference "C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll".
            C:\Users\AdrianCodrington\.nuget\packages\system.security.cryptography.protecteddata\6.0.0\lib\net6.0\System.Security.Cryptography.ProtectedData.dll
```

Downgrading `Caching` fixes the CVE by still removing references to `System.Drawing.Common 5.0.0` from production code whilst not breaking downstream dependencies in Octopus Server.

<!-- Why does this PR exist? -->

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
