### PR TITLE
Add renovate github action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "nuget"
-    directory: "/source/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/approve-renovate-pull-request.yml
+++ b/.github/workflows/approve-renovate-pull-request.yml
@@ -1,0 +1,26 @@
+name: "Approve Renovate Pull Request"
+
+on:
+  pull_request:
+    branches: [main]
+
+# Increase the access for the GITHUB_TOKEN
+permissions:
+  # This Allows the GITHUB_TOKEN to approve pull requests
+  pull-requests: write
+  # This Allows the GITHUB_TOKEN to auto merge pull requests
+  contents: write
+
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  # By default, GitHub Actions workflows triggered by renovate get a GITHUB_TOKEN with read-only permissions.
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  approve_renovate_pull_requests:
+    runs-on: ubuntu-latest
+    name: Approve renovate pull request
+    if: ${{ (github.actor == 'Octobob') && (contains(github.head_ref, 'renovate')) }}
+    steps:
+      - name: Approve a renovate created PR
+        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,28 @@
+name: Renovate update dependencies
+on:
+  schedule:
+    # UTC 10:00 PM (8AM AEST, Monday - Thursday)
+    - cron: '0 22 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  renovate-backend:
+    name: Self-hosted Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v39.0.1
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || null }}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,42 @@
+const excludeList = [
+    "dotnet-sdk", // The dotnet SDK update is a non-trivial piece of work.
+];
+
+module.exports = {
+
+    timezone: "Australia/Brisbane",
+    requireConfig: "optional",
+    onboarding: false,
+
+    ignoreDeps: excludeList,
+    enabledManagers: ["nuget"],
+
+    // Full list of built-in presets: https://docs.renovatebot.com/presets-default/
+    extends: [
+        "config:base",
+        "group:monorepos",
+        "group:recommended",
+		":rebaseStalePrs",
+        ":automergeRequireAllStatusChecks",
+    ],
+
+    // Renovate will create a new issue in the repository.
+    // This issue has a "dashboard" where you can get an overview of the status of all updates.
+    // https://docs.renovatebot.com/key-concepts/dashboard/
+    dependencyDashboard: true,
+    dependencyDashboardTitle: "Halibut Dependency Dashboard",
+
+    platform: "github",
+    repositories: ["OctopusDeploy/Halibut"],
+    reviewers: ["OctopusDeploy/team-server-at-scale"],
+    labels: ["dependencies", "Halibut"],
+    branchPrefix: "renovate-dotnet/",
+
+    // Limit the amount of PRs created
+    prConcurrentLimit: 2,
+    prHourlyLimit: 1,
+
+    // If set to false, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.
+    // https://docs.renovatebot.com/configuration-options/#separatemajorminor
+    separateMajorMinor: false,
+};


### PR DESCRIPTION
# Background

As part of [Sensible Default](https://docs.google.com/document/d/13RkZtQc4wgyUAcdzhVG9XCl-qJJBZazqA4ZZG0ado0U/edit#heading=h.5l19v0q8dv5o) work, we'd like to add renovate to enable automatically dependency update in this repository.

Both Renovate and Dependabot are working well with GitHub. We chose Renovate because it is easier to configure for grouped PR than Dependabot. Additionally, Renovate has been used in many Octopus repositories (including Server) and has proved it is integrated well with OctoBob to approve/merge dependency update PRs automatically.

This PR adds Renovate GitHub action to the repo.
- Run at 8AM, Mon-Fri
- Auto-merge is not yet enabled.
- Auto-approval by OctoBob is enabled.

[sc-65919]

# How to review this PR

Quality :heavy_check_mark: