### PR TITLE
Stop Timeout While Waiting for Response

### DIFF
--- a/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
+++ b/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
@@ -9,6 +9,7 @@ namespace Halibut.Tests.Builders
         ILog? log;
         string? endpoint;
         TimeSpan? pollingQueueWaitTimeout;
+        bool? relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout;
 
         public PendingRequestQueueBuilder WithEndpoint(string endpoint)
         {
@@ -27,14 +28,23 @@ namespace Halibut.Tests.Builders
             this.pollingQueueWaitTimeout = pollingQueueWaitTimeout;
             return this;
         }
-        
+
+        public PendingRequestQueueBuilder WithRelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout(bool relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout)
+        {
+            this.relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout;
+            return this;
+        }
+
         public IPendingRequestQueue Build()
         {
             var endpoint = this.endpoint ?? "poll://endpoint001";
-            var pollingQueueWaitTimeout = this.pollingQueueWaitTimeout ?? new HalibutTimeoutsAndLimitsForTestsBuilder().Build().PollingQueueWaitTimeout;
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
             var log = this.log ?? new InMemoryConnectionLog(endpoint);
 
-            return new PendingRequestQueueAsync(log, pollingQueueWaitTimeout);
+            halibutTimeoutsAndLimits.PollingQueueWaitTimeout = pollingQueueWaitTimeout ?? halibutTimeoutsAndLimits.PollingQueueWaitTimeout;
+            halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout ?? halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout;
+
+            return new PendingRequestQueueAsync(log, halibutTimeoutsAndLimits);
         }
     }
 }

--- a/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
+++ b/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
@@ -41,10 +41,10 @@ namespace Halibut.Tests.Builders
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
             var log = this.log ?? new InMemoryConnectionLog(endpoint);
 
-            halibutTimeoutsAndLimits.PollingQueueWaitTimeout = pollingQueueWaitTimeout ?? halibutTimeoutsAndLimits.PollingQueueWaitTimeout;
-            halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout ?? halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout;
+            var pollingQueueWaitTimeout = this.pollingQueueWaitTimeout ?? halibutTimeoutsAndLimits.PollingQueueWaitTimeout;
+            var relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = this.relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout ?? halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout;
 
-            return new PendingRequestQueueAsync(log, halibutTimeoutsAndLimits);
+            return new PendingRequestQueueAsync(log, pollingQueueWaitTimeout, relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout);
         }
     }
 }

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -19,6 +19,12 @@ namespace Halibut.Diagnostics
         public TimeSpan PollingRequestMaximumMessageProcessingTimeout { get; set; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
+        ///     We believe that PollingRequestMaximumMessageProcessingTimeout is redundant.
+        ///     This setting allows us to feature toggle turning off PollingRequestMaximumMessageProcessingTimeout
+        /// </summary>
+        public bool RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout { get; set; }
+
+        /// <summary>
         ///     The amount of time to wait between connection requests to the remote endpoint (applies
         ///     to both polling and listening connections). Can be overridden via the ServiceEndPoint.
         /// </summary>
@@ -159,7 +165,6 @@ namespace Halibut.Diagnostics
         /// The duration a TCP connection will wait for a keepalive response before sending another keepalive probe.
         /// </summary>
         public TimeSpan TcpKeepAliveInterval { get; set; } = TimeSpan.FromSeconds(5);
-
         
         /// <summary>
         /// In the future these will become the default

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -20,7 +20,11 @@ namespace Halibut.Diagnostics
 
         /// <summary>
         ///     We believe that PollingRequestMaximumMessageProcessingTimeout is redundant.
-        ///     This setting allows us to feature toggle turning off PollingRequestMaximumMessageProcessingTimeout
+        ///     This makes clients talking to polling services have similar behaviour to talking to listening services.
+        ///     In listening we wait for the request to finish or for an error.
+        ///     Enabling this results in the same behaviour as listening.
+        /// 
+        ///     This setting allows us to feature toggle turning off PollingRequestMaximumMessageProcessingTimeout.
         /// </summary>
         public bool RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout { get; set; }
 


### PR DESCRIPTION
[sc-59506]

# Background

It was noticed that `PollingRequestMaximumMessageProcessingTimeout` was redundant. 

`PollingRequestMaximumMessageProcessingTimeout` is the amount of time we will wait for a response to be given from a request that has already been dequeued. 

The **down side** of keeping `PollingRequestMaximumMessageProcessingTimeout` is that it will also timeout an operation that is successful, but taking a long time (e.g. downloading a large package to a Tentacle, or over a slow network, complex script/action for Tentacle to run etc.).

We think it was added years ago as a way to ensure we do not wait forever if communications with the Tentacle dies.

But we believe this won't be an issue because:
- We always make sure a response is set, regardless of success or failure. Applying a response stops us waiting
- We have timeouts and keep alives applied to the TCP connection. So if we loose communications with the Tentacle, these mechanisms will be what fail and stop us from waiting forever.
- Web sockets recently was enhanced to time out. So there should be no other types of polling tentacle that wait forever.


# Results

Related to OctopusDeploy/Issues#8229

## Before

No matter why it took a long time to complete a task, we would always timeout after `PollingRequestMaximumMessageProcessingTimeout`

## After

We now simply wait until a response is applied, and rely on the communication timeouts and response applying to break the waiting.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
