### PR TITLE
Turning on RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout by default

### DIFF
--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -16,6 +16,7 @@ namespace Halibut.Tests
                 // Also set to a "weird value" to make it more obvious which timeout is at play in tests.
                 PollingRequestQueueTimeout = TimeSpan.FromSeconds(66),
                 PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(66),
+                RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = true,
                 RetryListeningSleepInterval = TimeSpan.FromSeconds(1),
                 ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(66), // Must always be greater than the heartbeat timeout.
             

--- a/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
+++ b/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
@@ -45,6 +45,7 @@ namespace Halibut.Tests
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
             halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
             halibutTimeoutsAndLimits.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(100);
+            halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = false;
 
             var responseDelay = TimeSpan.FromSeconds(10);
 
@@ -73,6 +74,7 @@ namespace Halibut.Tests
             var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
             halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
             halibutTimeoutsAndLimits.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(6);
+            halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = false;
 
             var waitSemaphore = new SemaphoreSlim(0, 1);
             var connectionsObserver = new TestConnectionsObserver();

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -110,6 +110,7 @@ namespace Halibut.Tests.ServiceModel
             var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
+                .WithRelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout(false)
                 .Build();
             var request = new RequestMessageBuilder(endpoint)
                 .WithServiceEndpoint(seb => seb.WithPollingRequestQueueTimeout(TimeSpan.FromMilliseconds(1000)))
@@ -435,7 +436,10 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            var sut = new PendingRequestQueueBuilder()
+                .WithEndpoint(endpoint)
+                .WithRelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout(false)
+                .Build();
             var request = new RequestMessageBuilder(endpoint)
                 .WithServiceEndpoint(seb => seb.WithPollingRequestMaximumMessageProcessingTimeout(TimeSpan.FromMilliseconds(1000)))
                 .Build();

--- a/source/Halibut.Tests/Support/LatestClientBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientBuilder.cs
@@ -236,7 +236,7 @@ namespace Halibut.Tests.Support
                 return pendingRequestQueueFactory(octopusLogFactory);
             }
 
-            var pendingRequestQueueFactoryBuilder = new PendingRequestQueueFactoryBuilder(octopusLogFactory);
+            var pendingRequestQueueFactoryBuilder = new PendingRequestQueueFactoryBuilder(octopusLogFactory, halibutTimeoutsAndLimits);
 
             if (this.pendingRequestQueueFactoryBuilder != null)
             {

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactoryBuilder.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactoryBuilder.cs
@@ -7,11 +7,13 @@ namespace Halibut.Tests.Support
     public class PendingRequestQueueFactoryBuilder
     {
         readonly ILogFactory logFactory;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
         Func<ILogFactory, IPendingRequestQueueFactory, IPendingRequestQueueFactory>? createDecorator;
 
-        public PendingRequestQueueFactoryBuilder(ILogFactory logFactory)
+        public PendingRequestQueueFactoryBuilder(ILogFactory logFactory, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             this.logFactory = logFactory;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
         
         public PendingRequestQueueFactoryBuilder WithDecorator(Func<ILogFactory, IPendingRequestQueueFactory, IPendingRequestQueueFactory> createDecorator)
@@ -22,7 +24,7 @@ namespace Halibut.Tests.Support
 
         public IPendingRequestQueueFactory Build()
         {
-            IPendingRequestQueueFactory factory = new PendingRequestQueueFactoryAsync(new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logFactory);
+            IPendingRequestQueueFactory factory = new PendingRequestQueueFactoryAsync(halibutTimeoutsAndLimits, logFactory);
             if (createDecorator is not null)
             {
                 factory = createDecorator(logFactory, factory);

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -26,7 +26,7 @@ namespace Halibut.Diagnostics
         /// 
         ///     This setting allows us to feature toggle turning off PollingRequestMaximumMessageProcessingTimeout.
         /// </summary>
-        public bool RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout { get; set; }
+        public bool RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout { get; set; } = true;
 
         /// <summary>
         ///     The amount of time to wait between connection requests to the remote endpoint (applies


### PR DESCRIPTION
This is a Spike to see how our tests behave when `RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout` is turned on by default.

This PR can be progressed when we feel we are ready to see through removing `PollingRequestMaximumMessageProcessingTimeout`