### PR TITLE
Changing RPC Observer to include all of the RPC

### DIFF
--- a/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
+++ b/source/Halibut.Tests/Transport/Protocol/ProtocolFixture.cs
@@ -24,7 +24,7 @@ namespace Halibut.Tests.Transport.Protocol
         {
             stream = new DumpStream();
             stream.SetRemoteIdentity(new RemoteIdentity(RemoteIdentityType.Server));
-            protocol = new MessageExchangeProtocol(stream, Substitute.For<IRpcObserver>(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), Substitute.For<ILog>());
+            protocol = new MessageExchangeProtocol(stream, new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), Substitute.For<ILog>());
         }
 
         // TODO - ASYNC ME UP! ExchangeAsClientAsync cancellation

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -65,7 +65,7 @@ namespace Halibut.Tests.Transport
             for (int i = 0; i < halibutTimeoutsAndLimits.RetryCountLimit; i++)
             {
                 var connection = Substitute.For<IConnection>();
-                connection.Protocol.Returns(new MessageExchangeProtocol(stream, new NoRpcObserver(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), log));
+                connection.Protocol.Returns(new MessageExchangeProtocol(stream, new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), log));
 
                 await connectionManager.ReleaseConnectionAsync(endpoint, connection, CancellationToken.None);
             }
@@ -92,7 +92,7 @@ namespace Halibut.Tests.Transport
 
         public MessageExchangeProtocol GetProtocol(Stream stream, ILog logger)
         {
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger), new NoRpcObserver(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger), new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logger);
         }
     }
 }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -198,18 +198,18 @@ namespace Halibut
 
         async Task<ResponseMessage> SendOutgoingRequestAsync(RequestMessage request, MethodInfo methodInfo, CancellationToken cancellationToken)
         {
+            var endPoint = request.Destination;
+
+            var cachedResponse = responseCache.Value.GetCachedResponse(endPoint, request, methodInfo);
+
+            if (cachedResponse != null)
+            {
+                return cachedResponse;
+            }
+
             rpcObserver.StartCall(request);
             try
             {
-                var endPoint = request.Destination;
-
-                var cachedResponse = responseCache.Value.GetCachedResponse(endPoint, request, methodInfo);
-
-                if (cachedResponse != null)
-                {
-                    return cachedResponse;
-                }
-
                 ResponseMessage response;
 
                 switch (endPoint.BaseUri.Scheme.ToLowerInvariant())


### PR DESCRIPTION
[sc-64938]

# Background
On the [Instance Dashboard](https://octopuscloudprod.de.sumologic.com/ui/#/dashboardv2/prQcCDIBCROhDLLDYBoiWGHqvSRxUgcaQUvMrddixQd3cObQZcQbkM30NgWU?variables=instance:i007526) we noticed that for some instances, despite there being many RPC failures, there were no recorded metrics for `octopus_tentacle_halibut_RPC_active_calls`:
![image](https://github.com/OctopusDeploy/Halibut/assets/91929764/25fcf8a5-ab02-44b0-9b22-a3daade1c01d)


# Results


## Before
Halibut considered "active RPC calls" to be the actual RPC portion of the communication only. 

I.e., the point at which we are performing the call itself, excluding connecting etc.

This is why we never saw anything in `octopus_tentacle_halibut_RPC_active_calls` when the Tentacle did not exist, as it was failing during the "connection" phase, and therefore never got to the section where it was performing the call itself.

For example, here is an extract of the metrics after a failed health check, where the Tentacle was turned off. Note the lack of `octopus_tentacle_halibut_RPC_active_calls`:
![image](https://github.com/OctopusDeploy/Halibut/assets/91929764/e3b1c794-bedc-422e-a2d9-bb0cc5d8bf42)

## After
We now consider "active RPC calls" to be the amount of time for Halibut to "perform the entire remote call process". This will include the time it takes to connect. 

In the case of a polling tentacle, this will include the amount of time it takes to queue the item, wait for it to be dequeued, processed, and a result set (or a timeout).

Now, after a failed health check, we will see a metric recorded for `octopus_tentacle_halibut_RPC_active_calls`:
![image](https://github.com/OctopusDeploy/Halibut/assets/91929764/f6b7821a-c529-43de-b278-2f134b7aa786)


During a failed attempt, note that the count will be 1, as this call is now "active":
![image](https://github.com/OctopusDeploy/Halibut/assets/91929764/fdbfe132-b779-448d-ac7e-1f20c56510c2)


# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
