### PR TITLE
Passing operation cancelled exceptions up instead of wrapping them in HalibutClientExceptions

### DIFF
--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -36,7 +36,7 @@ namespace Halibut.Tests
             (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken))))
                 .And.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out.");
         }
-
+        
         [Test]
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
         public async Task WhenThePollingRequestMaximumMessageProcessingTimeoutIsReached_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
@@ -57,6 +57,33 @@ namespace Halibut.Tests
 
             (await AssertException.Throws<HalibutClientException>(async () => await doSomeActionClient.ActionAsync(new(CancellationToken))))
                 .And.Message.Should().Contain("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:06), so the request timed out.");
+
+            waitSemaphore.Release();
+        }
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestHasBegunTransfer_AndRelyingOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout_ThenTimeoutIsReached_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+            halibutTimeoutsAndLimits.TcpClientReceiveResponseTimeout = TimeSpan.FromSeconds(6);
+            halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = true;
+
+            var waitSemaphore = new SemaphoreSlim(0, 1);
+
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithDoSomeActionService(() => waitSemaphore.Wait(CancellationToken))
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .Build(CancellationToken);
+
+            var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+            (await AssertException.Throws<HalibutClientException>(async () => await doSomeActionClient.ActionAsync(new(CancellationToken))))
+                .And.Message.Should().ContainAny(
+                    "Unable to read data from the transport connection: Connection timed out.",
+                    "Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond");
 
             waitSemaphore.Release();
         }
@@ -96,7 +123,32 @@ namespace Halibut.Tests
 
             waitSemaphore.Release();
         }
-        
+
+        [Test]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        public async Task WhenThePollingRequestIsCancelledWhileDequeued_AndRelyingOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout_AnOperationCanceledExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
+        {
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = true;
+
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            var waitSemaphore = new SemaphoreSlim(0, 1);
+            
+            await using var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
+                .AsLatestClientAndLatestServiceBuilder()
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                .WithDoSomeActionService(() => waitSemaphore.Wait(CancellationToken))
+                .WithPendingRequestQueueFactoryBuilder(builder => builder.WithDecorator((_, inner) => new CancelWhenRequestDequeuedPendingRequestQueueFactory(inner, cancellationTokenSource)))
+                .Build(CancellationToken);
+
+            var doSomeActionClient = clientAndService.CreateAsyncClient<IDoSomeActionService, IAsyncClientDoSomeActionServiceWithOptions>();
+
+            await AssertException.Throws<OperationCanceledException>(async () => await doSomeActionClient.ActionAsync(new(cancellationTokenSource.Token)));
+
+            waitSemaphore.Release();
+        }
+
         [Test]
         [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testPolling: false, testWebSocket: false)]
         public async Task WhenTheListeningRequestFailsToBeSent_AsTheServiceDoesNotAcceptTheConnection_AHalibutClientExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)

--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Exceptions;
 using Halibut.Tests.Support;
 using Halibut.Tests.Support.PendingRequestQueueFactories;
 using Halibut.Tests.Support.TestAttributes;
@@ -88,7 +89,8 @@ namespace Halibut.Tests
             waitSemaphore.Release();
         }
 
-        [Test] [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
+        [Test] 
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
         public async Task WhenThePollingRequestIsCancelledWhileQueued_AnOperationCanceledExceptionShouldBeThrown(ClientAndServiceTestCase clientAndServiceTestCase)
         {
             var cancellationTokenSource = new CancellationTokenSource();
@@ -233,7 +235,7 @@ namespace Halibut.Tests
 
             var cancellationTokenSource = new CancellationTokenSource();
             
-            (await AssertException.Throws<HalibutClientException>(async () =>
+            (await AssertException.Throws<ConnectingRequestCancelledException>(async () =>
             {
                 var task = client.SayHelloAsync("Hello", new(cancellationTokenSource.Token));
                 cancellationTokenSource.Cancel();
@@ -264,7 +266,7 @@ namespace Halibut.Tests
 
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-            (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token))))
+            (await AssertException.Throws<ConnectingRequestCancelledException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token))))
                 .And.Message.Should().Contain("An error occurred when sending a request to 'https://20.5.79.31:10933/', after the request began: The Request was cancelled while Connecting.");
         }
 
@@ -289,7 +291,7 @@ namespace Halibut.Tests
 
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
-            var exception = (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token)))).And;
+            var exception = (await AssertException.Throws<ConnectingRequestCancelledException>(async () => await client.SayHelloAsync("Hello", new(cancellationTokenSource.Token)))).And;
             exception.Message.Should().Be($"An error occurred when sending a request to '{clientAndService.ServiceUri}', after the request began: The Request was cancelled while Connecting.");
         }
         
@@ -321,7 +323,7 @@ namespace Halibut.Tests
                 cancellationTokenSource.Cancel();
             });
 
-            (await AssertException.Throws<HalibutClientException>(async () => await doSomeActionClient.ActionAsync(new(cancellationTokenSource.Token))))
+            (await AssertException.Throws<TransferringRequestCancelledException>(async () => await doSomeActionClient.ActionAsync(new(cancellationTokenSource.Token))))
                 .And.Message.Should().Contain($"An error occurred when sending a request to '{clientAndService.ServiceUri}', after the request began: The Request was cancelled while Transferring.");
 
             waitSemaphore.Release();

--- a/source/Halibut.Tests/Support/LatestClientBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientBuilder.cs
@@ -236,7 +236,7 @@ namespace Halibut.Tests.Support
                 return pendingRequestQueueFactory(octopusLogFactory);
             }
 
-            var pendingRequestQueueFactoryBuilder = new PendingRequestQueueFactoryBuilder(octopusLogFactory);
+            var pendingRequestQueueFactoryBuilder = new PendingRequestQueueFactoryBuilder(octopusLogFactory, halibutTimeoutsAndLimits);
 
             if (this.pendingRequestQueueFactoryBuilder != null)
             {

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactoryBuilder.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactoryBuilder.cs
@@ -7,11 +7,13 @@ namespace Halibut.Tests.Support
     public class PendingRequestQueueFactoryBuilder
     {
         readonly ILogFactory logFactory;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
         Func<ILogFactory, IPendingRequestQueueFactory, IPendingRequestQueueFactory>? createDecorator;
 
-        public PendingRequestQueueFactoryBuilder(ILogFactory logFactory)
+        public PendingRequestQueueFactoryBuilder(ILogFactory logFactory, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
         {
             this.logFactory = logFactory;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
         }
         
         public PendingRequestQueueFactoryBuilder WithDecorator(Func<ILogFactory, IPendingRequestQueueFactory, IPendingRequestQueueFactory> createDecorator)
@@ -22,7 +24,7 @@ namespace Halibut.Tests.Support
 
         public IPendingRequestQueueFactory Build()
         {
-            IPendingRequestQueueFactory factory = new PendingRequestQueueFactoryAsync(new HalibutTimeoutsAndLimitsForTestsBuilder().Build(), logFactory);
+            IPendingRequestQueueFactory factory = new PendingRequestQueueFactoryAsync(halibutTimeoutsAndLimits, logFactory);
             if (createDecorator is not null)
             {
                 factory = createDecorator(logFactory, factory);


### PR DESCRIPTION
[sc-66743]

# Background

We want to make it easier to detect an `OperationCanceledException` from consumers of Halibut (e.g. Tentacle Client).

# Results


## Before

All exceptions throw within the `SecureListeningClient` were wrapped in a `HalibutClientException`. Meaning consumers would have to 'unpack' the exception to see if it was an `OperationCanceledException`

## After

We now throw an exception of the respective `OperationCanceledException` type instead.

Contractually, this should be fine for the consumer, as Polling tentacles will already throw `OperationCanceledExceptions`.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
