### PR TITLE
Fix flakey WhenTheListeningRequestFailsToBeSent_AsTheServiceRejectsTheConnection_AHalibutClientExceptionShouldBeThrown test

### DIFF
--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -190,8 +190,10 @@ namespace Halibut.Tests
 
             (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken))))
                 .And.Message.Should().ContainAny(
-                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Unable to read data from the transport connection:",
-                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Unable to write data to the transport connection:");
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Unable to read data from the transport connection",
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Unable to write data to the transport connection",
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin:  Received an unexpected EOF or 0 bytes from the transport stream",
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Transport endpoint is not connected");
         }
         
         [Test]


### PR DESCRIPTION
# Background

Fix flakey WhenTheListeningRequestFailsToBeSent_AsTheServiceRejectsTheConnection_AHalibutClientExceptionShouldBeThrown test

It is difficult to consistently get a network connection into the desired state, so the actual error can change between test runs. This adds a couple of other scenarios due to the network connection being in a different state / OS differences.

![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/2a1ba460-7a70-4251-8c92-39efaf23c549)


![image](https://github.com/OctopusDeploy/Halibut/assets/86938706/f843eb86-00d4-4962-9626-c0db8e8d0174)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
