### PR TITLE
Fixing RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout bug

### DIFF
--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -249,7 +249,7 @@ namespace Halibut.ServiceModel
                 if (waitForTransferToComplete)
                 {
                     responseSet = await WaitForResponseToBeSet(
-                        request.Destination.PollingRequestMaximumMessageProcessingTimeout, 
+                        relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout ? null : request.Destination.PollingRequestMaximumMessageProcessingTimeout,
                         // Cancel the dequeued request to force Reads and Writes to be cancelled
                         cancelTheRequestWhenTransferHasBegun: true,
                         cancellationToken);
@@ -287,9 +287,12 @@ namespace Halibut.ServiceModel
                 }
             }
             
-            async Task<bool> WaitForResponseToBeSet(TimeSpan timeout, bool cancelTheRequestWhenTransferHasBegun, CancellationToken cancellationToken)
+            async Task<bool> WaitForResponseToBeSet(
+                TimeSpan? timeout, 
+                bool cancelTheRequestWhenTransferHasBegun, 
+                CancellationToken cancellationToken)
             {
-                using var timeoutCancellationTokenSource = relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout ? new CancellationTokenSource() : new CancellationTokenSource(timeout);
+                using var timeoutCancellationTokenSource = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : new CancellationTokenSource();
                 using var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(timeoutCancellationTokenSource.Token, cancellationToken);
 
                 try


### PR DESCRIPTION
# Background

While testing the [operation cancellation work](https://github.com/OctopusDeploy/Halibut/pull/582), we found that if the `RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout` feature toggle was used, it would cause the `PendingRequestQueueAsync` to wait forever for the queue item to be dequeued instead of timing out.

# Results

## Before
In `WaitForResponseToBeSet`, the `relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout` flag was being used to wait forever always. 

Whereas it should **not** do this when we call `WaitForResponseToBeSet` initially (i.e. when we are waiting for the item to be dequeued), and should be used only when we call `WaitForResponseToBeSet` the second time (i.e. when we are allowing time for the tentacle to process the message).

## After

The flag has been moved out of `WaitForResponseToBeSet` so that it can be used in the appropriate spot. A test was written beforehand to prove the bug.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
