### PR TITLE
Remove a race condition from QueueAndWait_Can_Queue_Dequeue_WhenRequestsAreBeingCancelled

### DIFF
--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -400,7 +400,7 @@ namespace Halibut.Tests.ServiceModel
             // This test is pretty non-deterministic. It attempts to create some cancellation chaos
             // and we just want to ensure some things did cancel and some things did complete and nothing
             // threw an exception
-            completedTask.Count(x => x != null).Should().BeLessThan(totalRequest - minimumCancelledRequest).And.BeGreaterThanOrEqualTo(totalRequest / 2);
+            completedTask.Count(x => x != null).Should().BeLessThanOrEqualTo(totalRequest - minimumCancelledRequest).And.BeGreaterThanOrEqualTo(totalRequest / 2);
         }
 
         [Test]

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -366,8 +366,8 @@ namespace Halibut.Tests.ServiceModel
 
                     if (currentIndex % 2 == 0)
                     {
-                        Interlocked.Increment(ref cancelled);
                         queueAndWaitTasksInOrder.ElementAt(index - 1).Item2.Cancel();
+                        Interlocked.Increment(ref cancelled);
                     }
                 }
             });


### PR DESCRIPTION
# Background

[SC-67432]

Sometimes (2 in 1000 runs) this test fails with:
```
Expected completedTask.Count(x => x != *******) to be less than 400, but found 400.
```

This might be because:
* cancelling the cancellation token on the tuple is relatively slow, while de-queueing from the queue is relatively fast.
* the count of cancelled requests was incremented before the `CancellationTokenSource` was cancelled.
* the number of completed tasks could legitimately be 400 if exactly 100 requests were cancelled. (total request count is 500)

this means it might be possible to be in a state in which only:
* 99
* or 100

tasks are cancelled!

Thus 400 tasks (or technically even 401 tasks) could have completed successfully. Explaining the `to be less than 400, but found 400.` error.

The fix is to:
* check that completed is smaller than or **equal to** total tasks - cancelled tasks.
* the count of cancelled request to only be incremented if the request is actually cancelled.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
