### PR TITLE
Set the ConnectionState for the HalibutClientException to queued when a polling request times out when queued

### DIFF
--- a/source/Halibut.Tests/ServiceModel/HalibutProxyFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/HalibutProxyFixture.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Halibut.Diagnostics;
 using Halibut.Exceptions;
 using Halibut.ServiceModel;
+using Halibut.Transport;
 using Halibut.Transport.Protocol;
 using NUnit.Framework;
 

--- a/source/Halibut/HalibutClientException.cs
+++ b/source/Halibut/HalibutClientException.cs
@@ -18,7 +18,7 @@ namespace Halibut
         }
 
         public HalibutClientException(string message, Exception inner, ConnectionState connectionState)
-            : base(message, inner)
+            : this(message, inner)
         {
             ConnectionState = connectionState;
         }
@@ -26,6 +26,12 @@ namespace Halibut
         public HalibutClientException(string message, string serverException)
             : base(message + Environment.NewLine + Environment.NewLine + "Server exception: " + Environment.NewLine + serverException)
         {
+        }
+
+        public HalibutClientException(string message, string serverException, ConnectionState connectionState)
+            : this(message, serverException)
+        {
+            ConnectionState = connectionState;
         }
     }
 }

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -157,8 +157,7 @@ namespace Halibut.ServiceModel
                 logger.Write(EventType.Error, "Error {0} when processing ServerError", exception);
             }
 
-            throw new HalibutClientException(error.Message, realException);
-
+            throw new HalibutClientException(error.Message, realException, error.ConnectionState);
         }
 
         internal static (object[] args, HalibutProxyRequestOptions? halibutProxyRequestOptions) TrimOffHalibutProxyRequestOptions(object[] args)

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
 using Halibut.Exceptions;
+using Halibut.Transport;
 using Halibut.Transport.Protocol;
 using Nito.AsyncEx;
 
@@ -271,19 +272,27 @@ namespace Halibut.ServiceModel
                         if (cancellationToken.IsCancellationRequested)
                         {
                             log.Write(EventType.MessageExchange, "Request {0} was cancelled before a response was received", request);
-                            SetResponse(ResponseMessage.FromException(request, new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded.")));
+                            SetResponse(ResponseMessage.FromException(
+                                request, 
+                                new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded."),
+                                ConnectionState.Connecting));
                         }
                         else
                         {
                             log.Write(EventType.MessageExchange, "Request {0} timed out before it could be collected by the polling endpoint", request);
-                            SetResponse(ResponseMessage.FromException(request, new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time ({request.Destination.PollingRequestMaximumMessageProcessingTimeout}), so the request timed out.")));
+                            SetResponse(ResponseMessage.FromException(
+                                request, 
+                                new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time ({request.Destination.PollingRequestMaximumMessageProcessingTimeout}), so the request timed out.")));
                         }
                     }
                 }
                 else
                 {
                     log.Write(EventType.MessageExchange, "Request {0} timed out before it could be collected by the polling endpoint", request);
-                    SetResponse(ResponseMessage.FromException(request, new TimeoutException($"A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time ({request.Destination.PollingRequestQueueTimeout}), so the request timed out.")));
+                    SetResponse(ResponseMessage.FromException(
+                        request, 
+                        new TimeoutException($"A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time ({request.Destination.PollingRequestQueueTimeout}), so the request timed out."),
+                        ConnectionState.Connecting));
                 }
             }
             

--- a/source/Halibut/Transport/Protocol/ResponseMessage.cs
+++ b/source/Halibut/Transport/Protocol/ResponseMessage.cs
@@ -28,12 +28,12 @@ namespace Halibut.Transport.Protocol
             return new ResponseMessage { Id = request.Id, Error = new ServerError { Message = message } };
         }
 
-        public static ResponseMessage FromException(RequestMessage request, Exception ex)
+        public static ResponseMessage FromException(RequestMessage request, Exception ex, ConnectionState connectionState = ConnectionState.Unknown)
         {
-            return new ResponseMessage {Id = request.Id, Error = ServerErrorFromException(ex)};
+            return new ResponseMessage { Id = request.Id, Error = ServerErrorFromException(ex, connectionState) };
         }
 
-        internal static ServerError ServerErrorFromException(Exception ex)
+        internal static ServerError ServerErrorFromException(Exception ex, ConnectionState connectionState = ConnectionState.Unknown)
         {
             string? errorType = null;
 
@@ -42,7 +42,13 @@ namespace Halibut.Transport.Protocol
                 errorType = ex.GetType().FullName;
             }
 
-            return new ServerError { Message = ex.UnpackFromContainers().Message, Details = ex.ToString(), HalibutErrorType = errorType };
+            return new ServerError
+            {
+                Message = ex.UnpackFromContainers().Message, 
+                Details = ex.ToString(), 
+                HalibutErrorType = errorType,
+                ConnectionState = connectionState
+            };
         }
     }
 }

--- a/source/Halibut/Transport/Protocol/ServerError.cs
+++ b/source/Halibut/Transport/Protocol/ServerError.cs
@@ -14,5 +14,8 @@ namespace Halibut.Transport.Protocol
         public string? Details { get; set; }
         
         public string? HalibutErrorType { get; set; }
+
+        [JsonIgnore]
+        public ConnectionState ConnectionState { get; set; } = ConnectionState.Unknown;
     }
 }


### PR DESCRIPTION
# Background

Set the ConnectionState for the HalibutClientException to queued when a polling request times out when queued

This will allow TentacleClient to correctly identify that the RPC is still connecting (Pending Request has not been dequeued).

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
