### PR TITLE
Remove pollingRequestMaximumMessageProcessingTimeout

### DIFF
--- a/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
+++ b/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
@@ -42,9 +42,8 @@ namespace Halibut.Tests.Builders
             var log = this.log ?? new InMemoryConnectionLog(endpoint);
 
             var pollingQueueWaitTimeout = this.pollingQueueWaitTimeout ?? halibutTimeoutsAndLimits.PollingQueueWaitTimeout;
-            var relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout = this.relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout ?? halibutTimeoutsAndLimits.RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout;
 
-            return new PendingRequestQueueAsync(log, pollingQueueWaitTimeout, relyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout);
+            return new PendingRequestQueueAsync(log, pollingQueueWaitTimeout);
         }
     }
 }

--- a/source/Halibut.Tests/Builders/ServiceEndPointBuilder.cs
+++ b/source/Halibut.Tests/Builders/ServiceEndPointBuilder.cs
@@ -21,11 +21,6 @@ namespace Halibut.Tests.Builders
             return this;
         }
 
-        public ServiceEndPointBuilder WithPollingRequestMaximumMessageProcessingTimeout(TimeSpan timeout)
-        {
-            return this;
-        }
-
         public ServiceEndPoint Build()
         {
             var endpoint = this.endpoint ?? "poll://endpoint001";

--- a/source/Halibut.Tests/Builders/ServiceEndPointBuilder.cs
+++ b/source/Halibut.Tests/Builders/ServiceEndPointBuilder.cs
@@ -8,7 +8,6 @@ namespace Halibut.Tests.Builders
     {
         string? endpoint;
         TimeSpan? pollingRequestQueueTimeout;
-        TimeSpan? pollingRequestMaximumMessageProcessingTimeout;
 
         public ServiceEndPointBuilder WithEndpoint(string endpoint)
         {
@@ -24,7 +23,6 @@ namespace Halibut.Tests.Builders
 
         public ServiceEndPointBuilder WithPollingRequestMaximumMessageProcessingTimeout(TimeSpan timeout)
         {
-            pollingRequestMaximumMessageProcessingTimeout = timeout;
             return this;
         }
 
@@ -36,10 +34,6 @@ namespace Halibut.Tests.Builders
             if (pollingRequestQueueTimeout is not null)
             {
                 serviceEndPoint.PollingRequestQueueTimeout = pollingRequestQueueTimeout.Value;
-            }
-            if (pollingRequestMaximumMessageProcessingTimeout is not null)
-            {
-                serviceEndPoint.PollingRequestMaximumMessageProcessingTimeout = pollingRequestMaximumMessageProcessingTimeout.Value;
             }
 
             return serviceEndPoint;

--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -15,7 +15,6 @@ namespace Halibut.Tests
                 // The following 4 can be overriden, so set them high and let the test author drop the values as needed.
                 // Also set to a "weird value" to make it more obvious which timeout is at play in tests.
                 PollingRequestQueueTimeout = TimeSpan.FromSeconds(66),
-                PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(66),
                 RetryListeningSleepInterval = TimeSpan.FromSeconds(1),
                 ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(66), // Must always be greater than the heartbeat timeout.
             

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
             var request = new RequestMessageBuilder(endpoint).Build();
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
@@ -46,7 +46,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
             var request = new RequestMessageBuilder(endpoint).Build();
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
             var unexpectedResponse = new ResponseMessageBuilder(Guid.NewGuid().ToString()).Build();
@@ -80,7 +80,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
             var request = new RequestMessageBuilder(endpoint)
                 .WithServiceEndpoint(seb => seb.WithPollingRequestQueueTimeout(TimeSpan.FromMilliseconds(1000)))
                 .Build();
@@ -106,7 +106,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithRelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout(true)
                 .WithEndpoint(endpoint)
                 .Build();
@@ -135,7 +135,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
                 .Build();
@@ -167,7 +167,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
                 .WithRelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout(true)
@@ -205,7 +205,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
                 .Build();
@@ -240,7 +240,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
 
             var requestsInOrder = Enumerable.Range(0, 3)
                 .Select(_ => new RequestMessageBuilder(endpoint).Build())
@@ -270,7 +270,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
 
             var requestsInOrder = Enumerable.Range(0, 30)
                 .Select(_ => new RequestMessageBuilder(endpoint).Build())
@@ -302,7 +302,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
 
             // Choose a number large enough that it will fail when doing the 'synchronous' version.
             var requestsInOrder = Enumerable.Range(0, 5000)
@@ -335,7 +335,7 @@ namespace Halibut.Tests.ServiceModel
             const int totalRequest = 500;
             const int minimumCancelledRequest = 100;
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
 
             var requestsInOrder = Enumerable.Range(0, totalRequest)
                 .Select(_ => new RequestMessageBuilder(endpoint).Build())
@@ -409,7 +409,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
             var request = new RequestMessageBuilder(endpoint).Build();
 
             var cancellationTokenSource = new CancellationTokenSource();
@@ -432,7 +432,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
                 .Build();
@@ -466,7 +466,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.FromSeconds(1))
                 .Build();
@@ -487,7 +487,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.FromSeconds(1))
                 .Build();
@@ -517,7 +517,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
             var request = new RequestMessageBuilder(endpoint).Build();
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
@@ -549,7 +549,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
+            await using var sut = new PendingRequestQueueBuilder().WithEndpoint(endpoint).Build();
             var request = new RequestMessageBuilder(endpoint).Build();
             var expectedResponse = ResponseMessageBuilder.FromRequest(request).Build();
 
@@ -578,7 +578,7 @@ namespace Halibut.Tests.ServiceModel
             // Arrange
             const string endpoint = "poll://endpoint001";
 
-            var sut = new PendingRequestQueueBuilder()
+            await using var sut = new PendingRequestQueueBuilder()
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
                 .Build();

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestDequeuedPendingRequestQueueFactory.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestDequeuedPendingRequestQueueFactory.cs
@@ -67,6 +67,11 @@ namespace Halibut.Tests.Support.PendingRequestQueueFactories
 
             public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken requestCancellationToken)
                 => await inner.QueueAndWaitAsync(request, requestCancellationToken);
+
+            public ValueTask DisposeAsync()
+            {
+                return inner.DisposeAsync();
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
+++ b/source/Halibut.Tests/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
@@ -61,6 +61,11 @@ namespace Halibut.Tests.Support.PendingRequestQueueFactories
                 await task;
                 return result;
             }
+
+            public ValueTask DisposeAsync()
+            {
+                return this.inner.DisposeAsync();
+            }
         }
     }
 }

--- a/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/SendingAndReceivingRequestMessagesTimeoutsFixture.cs
@@ -221,7 +221,6 @@ namespace Halibut.Tests.Timeouts
             return point =>
             {
                 // We don't want to measure the polling queue timeouts.
-                point.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromMinutes(10);
                 point.PollingRequestQueueTimeout = TimeSpan.FromMinutes(10);
             };
         }

--- a/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
+++ b/source/Halibut.Tests/Timeouts/TimeoutsApplyDuringHandShake.cs
@@ -95,7 +95,6 @@ namespace Halibut.Tests.Timeouts
         static void IncreasePollingQueueTimeout(ServiceEndPoint point)
         {
             // We don't want to measure the polling queue timeouts.
-            point.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromMinutes(10);
             point.PollingRequestQueueTimeout = TimeSpan.FromMinutes(10);
             point.RetryCountLimit = 1;
         }

--- a/source/Halibut.sln.DotSettings
+++ b/source/Halibut.sln.DotSettings
@@ -246,6 +246,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/source/Halibut.sln.DotSettings
+++ b/source/Halibut.sln.DotSettings
@@ -246,7 +246,6 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_PRIVATE_MODIFIER/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EXPLICIT_INTERNAL_MODIFIER/@EntryValue">False</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -13,22 +13,6 @@ namespace Halibut.Diagnostics
         public TimeSpan PollingRequestQueueTimeout { get; set; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
-        ///     The default amount of time the client will wait for the server to process a message collected
-        ///     from the polling request queue before it raises a TimeoutException. Can be overridden via the ServiceEndPoint.
-        /// </summary>
-        public TimeSpan PollingRequestMaximumMessageProcessingTimeout { get; set; } = TimeSpan.FromMinutes(10);
-
-        /// <summary>
-        ///     We believe that PollingRequestMaximumMessageProcessingTimeout is redundant.
-        ///     This makes clients talking to polling services have similar behaviour to talking to listening services.
-        ///     In listening we wait for the request to finish or for an error.
-        ///     Enabling this results in the same behaviour as listening.
-        /// 
-        ///     This setting allows us to feature toggle turning off PollingRequestMaximumMessageProcessingTimeout.
-        /// </summary>
-        public bool RelyOnConnectionTimeoutsInsteadOfPollingRequestMaximumMessageProcessingTimeout { get; set; }
-
-        /// <summary>
         ///     The amount of time to wait between connection requests to the remote endpoint (applies
         ///     to both polling and listening connections). Can be overridden via the ServiceEndPoint.
         /// </summary>

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -338,6 +338,16 @@ namespace Halibut
 
         public async ValueTask DisposeAsync()
         {
+            foreach (var pendingRequestQueue in this.queues.Values)
+            {
+                try
+                {
+                    await pendingRequestQueue.DisposeAsync();
+                }
+                catch (Exception)
+                {
+                }
+            }
             pollingClients.Dispose();
             await connectionManager.DisposeAsync();
             

--- a/source/Halibut/ServiceEndPoint.cs
+++ b/source/Halibut/ServiceEndPoint.cs
@@ -37,7 +37,6 @@ namespace Halibut
             halibutTimeoutsAndLimits ??= new HalibutTimeoutsAndLimits();
 
             this.PollingRequestQueueTimeout = halibutTimeoutsAndLimits.PollingRequestQueueTimeout;
-            this.PollingRequestMaximumMessageProcessingTimeout = halibutTimeoutsAndLimits.PollingRequestMaximumMessageProcessingTimeout;
             this.RetryListeningSleepInterval = halibutTimeoutsAndLimits.RetryListeningSleepInterval;
             this.RetryCountLimit = halibutTimeoutsAndLimits.RetryCountLimit;
             this.ConnectionErrorRetryTimeout = halibutTimeoutsAndLimits.ConnectionErrorRetryTimeout;
@@ -49,13 +48,6 @@ namespace Halibut
         /// polling request queue before raising a TimeoutException
         /// </summary>
         public TimeSpan PollingRequestQueueTimeout { get; set; }
-
-
-        /// <summary>
-        /// The amount of time the client will wait for the server to process a message collected
-        /// from the polling request queue before it raises a TimeoutException
-        /// </summary>
-        public TimeSpan PollingRequestMaximumMessageProcessingTimeout { get; set; }
 
         /// <summary>
         /// The amount of time to wait between connection requests to the remote endpoint (applies

--- a/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
+++ b/source/Halibut/ServiceModel/HalibutProxyWithAsync.cs
@@ -71,7 +71,9 @@ namespace Halibut.ServiceModel
 
             var request = CreateRequest(asyncMethod, serviceMethod, args);
 
-            var response = await messageRouter(request, serviceMethod, halibutProxyRequestOptions?.RequestCancellationToken ?? CancellationToken.None);
+            var requestCancellationToken = halibutProxyRequestOptions?.RequestCancellationToken ?? CancellationToken.None;
+            
+            var response = await messageRouter(request, serviceMethod, requestCancellationToken);
 
             EnsureNotError(response);
             

--- a/source/Halibut/ServiceModel/IPendingRequestQueue.cs
+++ b/source/Halibut/ServiceModel/IPendingRequestQueue.cs
@@ -5,7 +5,7 @@ using Halibut.Transport.Protocol;
 
 namespace Halibut.ServiceModel
 {
-    public interface IPendingRequestQueue
+    public interface IPendingRequestQueue : IAsyncDisposable
     {
         bool IsEmpty { get; }
         int Count { get; }

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -34,10 +34,10 @@ namespace Halibut.ServiceModel
             this.pollingQueueWaitTimeout = pollingQueueWaitTimeout;
         }
 
-        public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken ct)
+        public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
         {
-            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct, this.entireQueueCancellationTokenSource.Token);
-            var cancellationToken = cancellationTokenSource.Token;
+            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.entireQueueCancellationTokenSource.Token);
+            cancellationToken = cancellationTokenSource.Token;
             
             using var pending = new PendingRequest(request, log);
 

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -383,7 +383,7 @@ namespace Halibut.ServiceModel
         {
             entireQueueCancellationTokenSource.Cancel();
             entireQueueCancellationTokenSource.Dispose();
-            return ValueTask.CompletedTask;
+            return new ValueTask();
         }
     }
 }

--- a/source/Halibut/ServiceModel/PendingRequestQueueInternalException.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueInternalException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Halibut.ServiceModel
+{
+    public class PendingRequestQueueInternalException : Exception 
+    {
+        public PendingRequestQueueInternalException(string s) : base(s)
+        {
+        }
+    }
+}


### PR DESCRIPTION
# Background

[SC-67117]

Removes the `pollingRequestMaximumMessageProcessingTimeout` since it provided no value, we now entirely depend on TCP connection timeouts to determine if the request is dead similar to listening tentacles.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
