### PR TITLE
Add option for serializing the message envelope as generic

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -17,6 +17,8 @@ namespace Halibut.Transport.Protocol
         // Initial prod telemetry indicated values < 7K would be fine. But to be safe, 64K to future proof, and stay below the LOH threshold of 85K.
         long writeIntoMemoryLimitBytes = 1024L * 64L;
 
+        bool useGenericMessageEnvelope;
+
         public MessageSerializerBuilder(ILogFactory logFactory)
         {
             this.logFactory = logFactory;
@@ -47,6 +49,12 @@ namespace Halibut.Transport.Protocol
             return this;
         }
 
+        public MessageSerializerBuilder WithGenericMessageEnvelope()
+        {
+            useGenericMessageEnvelope = true;
+            return this;
+        }
+
         public MessageSerializer Build()
         {
             var typeRegistry = this.typeRegistry ?? new TypeRegistry();
@@ -68,7 +76,8 @@ namespace Halibut.Transport.Protocol
                 messageSerializerObserver,
                 readIntoMemoryLimitBytes,
                 writeIntoMemoryLimitBytes,
-                logFactory);
+                logFactory,
+                useGenericMessageEnvelope);
 
             return messageSerializer;
         }


### PR DESCRIPTION
# Background

Moving a service response type to another namespace/assembly breaks backwards compatibility of s service. This is because `Newtonsoft.Json` is configured with `TypeNameHandling.Auto` and the response is serialized as `MessageEnvelope<object>` instead of `MessageEnvelope<T>`. 

My team is currently handling this by forwarding to the correct type manually in a custom `SerializationBinder`, but this is prone to errors and introduces manual steps to our releases.

You might also consider making this the default behavior if this is true: `Once ALL sources and targets are deserializing to MessageEnvelope<T>, (ReadBsonMessage) then this can be changed to T`

# Results

Users of the Halibut runtime can optionally specify that the message envelope will be serialized as a generic. Thus removing the `$type` from the response 

# Pre-requisites
- [ x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ x] I have considered appropriate testing for my change.
