### PR TITLE
Log ClientDenied events as Debug

### DIFF
--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -62,6 +62,7 @@ namespace Halibut.Diagnostics
                 case EventType.MessageExchange:
                     return LogLevel.Trace;
                 case EventType.OpeningNewConnection:
+                case EventType.ClientDenied:
                     return LogLevel.Debug;
                 default:
                     return LogLevel.Info;


### PR DESCRIPTION
# Background

The client denied error messages can create a lot of noise in the logs.

# Results

Client denied events will be logged as Debug level events.

Resolves #598

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.