### PR TITLE
Improve linux performance when listening on many ports

### DIFF
--- a/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
+++ b/source/Halibut.Tests/HalibutTimeoutsAndLimitsForTestsBuilder.cs
@@ -49,6 +49,8 @@ namespace Halibut.Tests
                 limits.MaximumActiveTcpConnectionsPerPollingSubscription = maximumActiveTcpConnectionsPerPollingSubscription.Value;
             }
 
+            limits.UseAsyncListener = true;
+
             return limits;
         }
     }

--- a/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
+++ b/source/Halibut.Tests/Support/SerilogLoggerBuilder.cs
@@ -75,7 +75,12 @@ namespace Halibut.Tests.Support
         {
             using (SHA256 mySHA256 = SHA256.Create())
             {
-                return Convert.ToBase64String(mySHA256.ComputeHash(TestContext.CurrentContext.Test.FullName.GetUTF8Bytes()))
+                string s = TestContext.CurrentContext.Test.FullName;
+#if NETFRAMEWORK
+                // Allow net6 and net48 tests to run at the same time by giving them different test hashes.
+                s += "Net48";
+#endif
+                return Convert.ToBase64String(mySHA256.ComputeHash(s.GetUTF8Bytes()))
                     .Replace("=", "")
                     .Replace("+", "")
                     .Replace("/", "")

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Runtime.Versioning;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Diagnostics;
 using Halibut.Tests.Support;
-using Halibut.Tests.Support.TestAttributes;
 using Halibut.Transport;
 using Halibut.Transport.Observability;
 using Halibut.Transport.Streams;
@@ -53,7 +52,7 @@ namespace Halibut.Tests.Transport
 
         [Test]
         [WindowsTest]
-        public void SecureListenerDoesNotCreateHundredsOfIoEventsPerSecondOnWindows()
+        public async Task SecureListenerDoesNotCreateHundredsOfIoEventsPerSecondOnWindows()
         {
             var logger = new SerilogLoggerBuilder().Build();
             const int secondsToSample = 5;
@@ -82,7 +81,7 @@ namespace Halibut.Tests.Transport
 
                 float listeningAverage;
 
-                using (client)
+                await using (client)
                 {
                     client.Start();
 

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -112,6 +113,93 @@ namespace Halibut.Tests.Transport
 #pragma warning restore CA1416 // Validate platform compatibility
             }
             // ReSharper disable once IteratorNeverReturns : Take is limit
+        }
+
+        static IEnumerable<int> NumberOfAttempts = Enumerable.Range(0, 20).ToArray();
+        
+        
+        [Test]
+        [TestCaseSource(nameof(NumberOfAttempts))]
+        public async Task CanShutdownWhileAcceptingNewConnections(int _)
+        {
+            await Task.WhenAll(Enumerable.Range(0, Environment.ProcessorCount)
+                .Select(i => Task.Run(() => ShutdownWhileAcceptingConnections()))
+                .ToArray());
+            
+        }
+
+        static async Task ShutdownWhileAcceptingConnections()
+        {
+            var limits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
+            limits.UseAsyncListener = true;
+            var cts = new CancellationTokenSource();
+            var connectTasks = new List<Task>();
+            using (var halibut = new HalibutRuntimeBuilder().WithHalibutTimeoutsAndLimits(limits)
+                       .WithServerCertificate(CertAndThumbprint.Octopus.Certificate2)
+                       .Build())
+            {
+                var port = halibut.Listen();
+
+                for (int i = 0; i < 64; i++)
+                {
+                    connectTasks.Add(Task.Run(async () =>
+                    {
+                        while (!cts.Token.IsCancellationRequested)
+                        {
+                            try
+                            {
+                                await ConnectAndDisconnect(limits, port);
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                    }));
+                }
+                
+                // Let's do one ourselves, to kill time and verify this call does work.
+                await ConnectAndDisconnect(limits, port);
+                // A little more time for tasks to start.
+                await Task.Delay(TimeSpan.FromMilliseconds(30));
+            } // Here is the test we dispose/stop the listner. We should not hang here forever.
+            
+            cts.Cancel();
+            foreach (var connectTask in connectTasks)
+            {
+                await connectTask;
+            }
+        }
+
+        static async Task ConnectAndDisconnect(HalibutTimeoutsAndLimits limits, int port)
+        {
+            var tcpClient = CreateTcpClientAsync(limits);
+            await tcpClient.ConnectAsync("localhost", port);
+            tcpClient.Client.Shutdown(SocketShutdown.Both);
+            tcpClient.Dispose();
+        }
+
+        internal static TcpClient CreateTcpClientAsync(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        {
+            var addressFamily = Socket.OSSupportsIPv6
+                ? AddressFamily.InterNetworkV6
+                : AddressFamily.InterNetwork;
+
+            return CreateTcpClientAsync(addressFamily, halibutTimeoutsAndLimits);
+        }
+        
+        internal static TcpClient CreateTcpClientAsync(AddressFamily addressFamily, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        {
+            var client = new TcpClient(addressFamily)
+            {
+                SendTimeout = (int)halibutTimeoutsAndLimits.TcpClientTimeout.SendTimeout.TotalMilliseconds,
+                ReceiveTimeout = (int)halibutTimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout.TotalMilliseconds
+            };
+
+            if (client.Client.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                client.Client.DualMode = true;
+            }
+            return client;
         }
     }
 }

--- a/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
+++ b/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs
@@ -162,6 +162,8 @@ namespace Halibut.Diagnostics
         /// The number of authorized, active connections are aggregated per polling subscription, and new connections that exceed the limit are rejected.
         /// </remarks>
         public int? MaximumActiveTcpConnectionsPerPollingSubscription { get; set; }
+        
+        public bool UseAsyncListener { get; set; }
 
         /// <summary>
         /// In the future these will become the default

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -209,8 +209,8 @@ namespace Halibut.Transport
         {
 
             const int errorThreshold = 3;
-
-            using (cancellationToken.Register(listener.Stop))
+            
+            using (IsWindows() ? cancellationToken.Register(listener.Stop) : (IDisposable)null!)
             {
                 var numberOfFailedAttemptsInRow = 0;
                 while (!cancellationToken.IsCancellationRequested)

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -28,7 +28,7 @@ namespace Halibut.Transport
         PROTECT_FROM_CLOSE = 2
     }
 
-    public class SecureListener : IDisposable
+    public class SecureListener : IAsyncDisposable
     {
         [DllImport("kernel32.dll", SetLastError = true)]
         static extern bool SetHandleInformation(IntPtr hObject, HANDLE_FLAGS dwMask, HANDLE_FLAGS dwFlags);
@@ -51,6 +51,7 @@ namespace Halibut.Transport
         ILog log;
         TcpListener listener;
         Thread? backgroundThread;
+        Task? backgroundTask;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public SecureListener(
@@ -106,12 +107,21 @@ namespace Halibut.Transport
             log = logFactory.ForEndpoint(new Uri("listen://" + listener.LocalEndpoint));
             log.Write(EventType.ListenerStarted, "Listener started");
 
-            backgroundThread = new Thread(Accept)
+            if (halibutTimeoutsAndLimits.UseAsyncListener)
             {
-                Name = "Accept connections on " + listener.LocalEndpoint
-            };
-            backgroundThread.IsBackground = true;
-            backgroundThread.Start();
+                backgroundTask = Task.Run(() => AcceptAsyncIgnoringExceptions(cancellationToken));
+            }
+            else
+            {
+#pragma warning disable CS0612 // Type or member is obsolete
+                backgroundThread = new Thread(Accept)
+#pragma warning restore CS0612 // Type or member is obsolete
+                {
+                    Name = "Accept connections on " + listener.LocalEndpoint
+                };
+                backgroundThread.IsBackground = true;
+                backgroundThread.Start();
+            }
 
             return ((IPEndPoint)listener.LocalEndpoint).Port;
         }
@@ -122,6 +132,7 @@ namespace Halibut.Transport
             tcpClientManager.Disconnect(thumbprint);
         }
 
+        [Obsolete]
         void Accept()
         {
             // See: https://github.com/OctopusDeploy/Issues/issues/6035
@@ -155,6 +166,61 @@ namespace Halibut.Transport
                         client = listener.AcceptTcpClient();
 
                         Task.Run(async () => await HandleClient(client).ConfigureAwait(false)).ConfigureAwait(false);
+                        numberOfFailedAttemptsInRow = 0;
+                    }
+                    catch (SocketException e) when (e.SocketErrorCode == SocketError.Interrupted)
+                    {
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // Happens on shutdown
+                    }
+                    catch (Exception ex)
+                    {
+                        numberOfFailedAttemptsInRow++;
+                        log.WriteException(EventType.ErrorInInitialisation, "Error accepting TCP client: {0}", ex, client!.GetRemoteEndpointString());
+                        // Slow down the logs in case an exception is immediately encountered after X failed AcceptTcpClient calls
+                        if (numberOfFailedAttemptsInRow >= errorThreshold)
+                        {
+                            var millisecondsTimeout = Math.Max(0, Math.Min(numberOfFailedAttemptsInRow - errorThreshold, 100)) * 10;
+                            log.Write(
+                                EventType.ErrorInInitialisation,
+                                $"Accepting a connection has failed {numberOfFailedAttemptsInRow} times in a row. Waiting {millisecondsTimeout}ms before attempting to accept another connection. For a detailed troubleshooting guide go to https://g.octopushq.com/TentacleTroubleshooting"
+                            );
+                            Thread.Sleep(millisecondsTimeout);
+                        }
+                    }
+                }
+            }
+        }
+
+        async Task AcceptAsyncIgnoringExceptions(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await AcceptAsync(cancellationToken);
+            }
+            catch (Exception)
+            {
+                // This matches what we did before, in theory this will never happen.
+            }
+        }
+        async Task AcceptAsync(CancellationToken cancellationToken)
+        {
+
+            const int errorThreshold = 3;
+
+            using (cancellationToken.Register(listener.Stop))
+            {
+                var numberOfFailedAttemptsInRow = 0;
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    TcpClient? client = null;
+                    try
+                    {
+                        client = await listener.AcceptTcpClientAsync(this.cancellationToken);
+
+                        var _ = Task.Run(async () => await HandleClient(client).ConfigureAwait(false)).ConfigureAwait(false);
                         numberOfFailedAttemptsInRow = 0;
                     }
                     catch (SocketException e) when (e.SocketErrorCode == SocketError.Interrupted)
@@ -433,10 +499,11 @@ namespace Halibut.Transport
             return builder.ToString();
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             cts.Cancel();
             backgroundThread?.Join();
+            if (backgroundTask != null) await backgroundTask; 
             listener?.Stop();
             tcpClientManager.Dispose();
             cts.Dispose();

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -249,7 +249,7 @@ namespace Halibut.Transport
                                 EventType.ErrorInInitialisation,
                                 $"Accepting a connection has failed {numberOfFailedAttemptsInRow} times in a row. Waiting {millisecondsTimeout}ms before attempting to accept another connection. For a detailed troubleshooting guide go to https://g.octopushq.com/TentacleTroubleshooting"
                             );
-                            Thread.Sleep(millisecondsTimeout);
+                            await Task.Delay(millisecondsTimeout, cancellationToken);
                         }
                     }
                 }

--- a/source/Halibut/Transport/SecureWebSocketListener.cs
+++ b/source/Halibut/Transport/SecureWebSocketListener.cs
@@ -13,7 +13,7 @@ using Halibut.Transport.Streams;
 
 namespace Halibut.Transport
 {
-    public class SecureWebSocketListener : IDisposable
+    public class SecureWebSocketListener : IAsyncDisposable
     {
         readonly string endPoint;
         readonly ExchangeProtocolBuilder exchangeProtocolBuilder;
@@ -266,8 +266,9 @@ namespace Halibut.Transport
             }
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
+            await Task.CompletedTask;
             cts.Cancel();
             cts.Dispose();
             log.Write(EventType.ListenerStopped, "Listener stopped");

--- a/source/Halibut/Util/MutexedItem.cs
+++ b/source/Halibut/Util/MutexedItem.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Util
+{
+    /// <summary>
+    /// Ensures that an item is only accessed by one thread at a time.
+    ///
+    /// Use this in place of trying to remeber to lock(foo){} around each place you want to use foo.
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class MutexedItem<T>
+    {
+        readonly SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
+        readonly T itemWhichCanOnlyBeAccessedByOneThreadAtATime;
+
+        public MutexedItem(T itemWhichCanOnlyBeAccessedByOneThreadAtATime)
+        {
+            this.itemWhichCanOnlyBeAccessedByOneThreadAtATime = itemWhichCanOnlyBeAccessedByOneThreadAtATime;
+        }
+
+        public void DoWithExclusiveAccess(Action<T> action)
+        {
+            semaphoreSlim.Wait();
+            try
+            {
+                action(itemWhichCanOnlyBeAccessedByOneThreadAtATime);
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+
+        public async Task DoWithExclusiveAccess(Func<T, Task> action)
+        {
+            await semaphoreSlim.WaitAsync();
+            try
+            {
+                await action(itemWhichCanOnlyBeAccessedByOneThreadAtATime);
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+
+        public R DoWithExclusiveAccess<R>(Func<T, R> action)
+        {
+            semaphoreSlim.Wait();
+            try
+            {
+                return action(itemWhichCanOnlyBeAccessedByOneThreadAtATime);
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

While trying to get 1000s of listening simulated tentacles working, I was running into issues in which Octopus was unable to communicate with the Tentacle. Eventually I discovered that the CPU usage of Tentacle Simulator was high despite it not doing anything. Turns out it was spending all its time in `SpinWait`.

This was done because `TcpListener.Stop hangs if Accept is in progress` https://github.com/dotnet/runtime/issues/24513 . Which is claimed to be fixed, although I see an absolute disaster of reverts so it is not clear if it is fixed.

Working on the assumption `TcpListener.Stop` still hangs if Accept is in progress, the new optional path is to:
* await waiting to accept a connection with the cancellation token.
* when the `SecureListener` is disposed first the CancellationToken is cancelled, then we wait for the accept task to complete (which will be some sort cancellation exception), after that when we know we are not in the middle of Accept we then call `TcpListener.Stop`.


Note that the new behaviour must be opted in by setting:
```
UseAsyncListener = true;
```
on `HalibutTimeoutsAndLimits`.

# Results


## Before

CPU usage was half my cores when listening on 1000 sockets.

## After

CPU usage is near nothing.

Tentacle Simulator can actually be used with 1000s of listening tentacles.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
