### PR TITLE
Retry assertion to resolve timing issues

### DIFF
--- a/source/Halibut.Tests/MaximumActiveTcpConnectionsFixture.cs
+++ b/source/Halibut.Tests/MaximumActiveTcpConnectionsFixture.cs
@@ -35,13 +35,17 @@ namespace Halibut.Tests
             
             var echoService = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
             await echoService.SayHelloAsync("Hello");
-
-            //we should have 2 log messages saying that a client exceeded the max number of authorized connections
-            clientLogs.SelectMany(kvp => kvp.Value.GetLogs())
-                .Select(l => l.FormattedMessage)
-                .Where(msg => msg.Contains("has exceeded the maximum number of active connections"))
-                .Should()
-                .HaveCount(2);
+            
+            Wait.UntilActionSucceeds(() =>
+            {
+                //we should have 2 log messages saying that a client exceeded the max number of authorized connections
+                clientLogs.SelectMany(kvp => kvp.Value.GetLogs())
+                    .Select(l => l.FormattedMessage)
+                    .Where(msg => msg.Contains("has exceeded the maximum number of active connections"))
+                    .ToList()
+                    .Should()
+                    .HaveCount(2); 
+            }, TimeSpan.FromSeconds(30), Logger, CancellationToken);
             
             countingRetryPolicy.TryCount.Should().Be(5);
             countingRetryPolicy.SuccessCount.Should().Be(3);


### PR DESCRIPTION
# Background

We've noticed that this test can be flaky. It seems that the assertion sometimes runs _just_ before the logs are populated. To resolve this, we now put the assertion in `Wait.UntilActionSucceeds` to do some retry for up to 30s.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
