### PR TITLE
Add simple message to polling timeout error

### DIFF
--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -35,7 +35,7 @@ namespace Halibut.Tests
             var client = clientOnly.CreateClientWithoutService<IEchoService, IAsyncClientEchoServiceWithOptions>();
 
             (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken))))
-                .And.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out.");
+                .And.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out. Please check the tentacle logs to investigate this timeout.");
         }
         
 

--- a/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
+++ b/source/Halibut.Tests/PollingServiceTimeoutsFixture.cs
@@ -33,7 +33,7 @@ namespace Halibut.Tests
                 var stopwatch = Stopwatch.StartNew();
                 var exception = (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken)))).And;
 
-                exception.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out.");
+                exception.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out. Please check the tentacle logs to investigate this timeout.");
                 exception.ConnectionState.Should().Be(ConnectionState.Connecting);
 
                 stopwatch.Stop();

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -94,7 +94,7 @@ namespace Halibut.Tests.ServiceModel
             // Although we sleep for 1 second, sometimes it can be just under. So be generous with the buffer.
             stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(800));
             response.Id.Should().Be(request.Id);
-            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:01), so the request timed out.");
+            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:01), so the request timed out. Please check the tentacle logs to investigate this timeout.");
 
             var next = await sut.DequeueAsync(CancellationToken);
             next.Should().BeNull();
@@ -123,7 +123,7 @@ namespace Halibut.Tests.ServiceModel
             // Although we sleep for 1 second, sometimes it can be just under. So be generous with the buffer.
             stopwatch.Elapsed.Should().BeGreaterThan(TimeSpan.FromMilliseconds(800));
             response.Id.Should().Be(request.Id);
-            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:01), so the request timed out.");
+            response.Error!.Message.Should().Be("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:01), so the request timed out. Please check the tentacle logs to investigate this timeout.");
 
             var next = await sut.DequeueAsync(CancellationToken);
             next.Should().BeNull();

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -291,7 +291,7 @@ namespace Halibut.ServiceModel
                     log.Write(EventType.MessageExchange, "Request {0} timed out before it could be collected by the polling endpoint", request);
                     SetResponse(ResponseMessage.FromException(
                         request, 
-                        new TimeoutException($"A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time ({request.Destination.PollingRequestQueueTimeout}), so the request timed out."),
+                        new TimeoutException($"A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time ({request.Destination.PollingRequestQueueTimeout}), so the request timed out. Please check the tentacle logs to investigate this timeout."),
                         ConnectionState.Connecting));
                 }
             }


### PR DESCRIPTION
# Background
The errors around polling tentacles not connecting are vague and don't help the customer investigate issues that may arise. This PR adds a simple message to re-direct them to the tentacle logs to investigate, as there is no current way of writing the halibut exception from tentacle to the server/task logs.

# Results
Relates to https://github.com/OctopusDeploy/Issues/issues/8761

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
