### PR TITLE
Add subscription id to tcp connections exceeded error message

### DIFF
--- a/source/Halibut.Tests/MaximumActiveTcpConnectionsFixture.cs
+++ b/source/Halibut.Tests/MaximumActiveTcpConnectionsFixture.cs
@@ -41,7 +41,7 @@ namespace Halibut.Tests
                 //we should have 2 log messages saying that a client exceeded the max number of authorized connections
                 clientLogs.SelectMany(kvp => kvp.Value.GetLogs())
                     .Select(l => l.FormattedMessage)
-                    .Where(msg => msg.Contains("has exceeded the maximum number of active connections"))
+                    .Where(msg => msg.Contains("has exceeded the maximum number of active connections") && msg.Contains(LatestServiceBuilder.PollingTentacleServiceUri.ToString()))
                     .ToList()
                     .Should()
                     .HaveCount(2); 

--- a/source/Halibut/Exceptions/ActiveTcpConnectionsExceededException.cs
+++ b/source/Halibut/Exceptions/ActiveTcpConnectionsExceededException.cs
@@ -4,12 +4,16 @@ namespace Halibut.Exceptions
 {
     public class ActiveTcpConnectionsExceededException : Exception
     {
-        public ActiveTcpConnectionsExceededException(string message) : base(message)
+        public Uri SubscriptionId { get; }
+        
+        public ActiveTcpConnectionsExceededException(Uri subscriptionId, string message) : base(message)
         {
+            SubscriptionId = subscriptionId;
         }
 
-        public ActiveTcpConnectionsExceededException(string message, Exception innerException) : base(message, innerException)
+        public ActiveTcpConnectionsExceededException(Uri subscriptionId, string message, Exception innerException) : base(message, innerException)
         {
+            SubscriptionId = subscriptionId;
         }
     }
 }

--- a/source/Halibut/Transport/ActiveTcpConnectionsLimiter.cs
+++ b/source/Halibut/Transport/ActiveTcpConnectionsLimiter.cs
@@ -74,7 +74,7 @@ namespace Halibut.Transport
                         count.Value--;
 
                         //throw an exception, bailing on the connection
-                        throw new ActiveTcpConnectionsExceededException($"Exceeded the maximum number ({maximumAcceptedTcpConnectionsPerThumbprint}) of active TCP connections for subscription {subscriptionId}");
+                        throw new ActiveTcpConnectionsExceededException(this.subscriptionId, $"Exceeded the maximum number ({maximumAcceptedTcpConnectionsPerThumbprint}) of active TCP connections for subscription {subscriptionId}");
                     }
                 }
             }

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -336,9 +336,9 @@ namespace Halibut.Transport
             {
                 log.WriteException(EventType.ClientDenied, "Client failed authentication: {0}", ex, clientName);
             }
-            catch (ActiveTcpConnectionsExceededException)
+            catch (ActiveTcpConnectionsExceededException ex)
             {
-                log.Write(EventType.ErrorInInitialisation, "A polling client at {0} has exceeded the maximum number of active connections ({1}). New connections will be rejected", clientName, halibutTimeoutsAndLimits.MaximumActiveTcpConnectionsPerPollingSubscription);
+                log.Write(EventType.ErrorInInitialisation, "A polling client at {0} has exceeded the maximum number of active connections ({1}) for subscription {2}. New connections will be rejected", clientName, halibutTimeoutsAndLimits.MaximumActiveTcpConnectionsPerPollingSubscription, ex.SubscriptionId.ToString());
             }
             catch (IOException ex) when (ex.InnerException is SocketException)
             {


### PR DESCRIPTION
# Background

When enabled and monitoring in PreProd Cloud, this error doesn't tell you which subscription has exceeded the limit, which is a bit annoying.
<!-- Why does this PR exist? -->

# Results

Add the subscription id/uri to the exception & error log message

Example:

> A polling client at [::1]:59764 has exceeded the maximum number of active connections (3) for subscription poll://sq-tentapoll/. New connections will be rejected

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [s] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [s] I have considered appropriate testing for my change.
