### PR TITLE
Don't try to guess when Halibut is sending control messages in tests.

### DIFF
--- a/source/Halibut.Tests/Support/FuncControlMessageObserver.cs
+++ b/source/Halibut.Tests/Support/FuncControlMessageObserver.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2012-2013 Octopus Deploy Pty. Ltd.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Halibut.Transport.Observability;
+
+namespace Halibut.Tests.Support
+{
+    public class FuncControlMessageObserver : IControlMessageObserver
+    {
+        public Action<string> BeforeSendingControlMessageAction = (_) => { };
+        public Action<string> FinishSendingControlMessageAction = (_) => { };
+        public Action WaitingForControlMessageAction = () => { };
+        public Action<string> ReceivedControlMessageAction = (_) => { };
+
+        void IControlMessageObserver.BeforeSendingControlMessage(string controlMessage)
+        {
+            BeforeSendingControlMessageAction(controlMessage);
+        }
+
+        void IControlMessageObserver.FinishSendingControlMessage(string controlMessage)
+        {
+            FinishSendingControlMessageAction(controlMessage);
+        }
+
+        void IControlMessageObserver.WaitingForControlMessage()
+        {
+            WaitingForControlMessageAction();
+        }
+
+        void IControlMessageObserver.ReceivedControlMessage(string controlMessage)
+        {
+            ReceivedControlMessageAction(controlMessage);
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/FuncControlMessageObserver.cs
+++ b/source/Halibut.Tests/Support/FuncControlMessageObserver.cs
@@ -1,18 +1,4 @@
-﻿// Copyright 2012-2013 Octopus Deploy Pty. Ltd.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// 
-//   http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-using System;
+﻿using System;
 using Halibut.Transport.Observability;
 
 namespace Halibut.Tests.Support

--- a/source/Halibut.Tests/Support/HalibutRuntimeBuilderExtensionMethods.cs
+++ b/source/Halibut.Tests/Support/HalibutRuntimeBuilderExtensionMethods.cs
@@ -1,4 +1,5 @@
-﻿using Halibut.Transport.Streams;
+﻿using Halibut.Transport.Observability;
+using Halibut.Transport.Streams;
 
 namespace Halibut.Tests.Support
 {
@@ -7,6 +8,12 @@ namespace Halibut.Tests.Support
         public static HalibutRuntimeBuilder WithStreamFactoryIfNotNull(this HalibutRuntimeBuilder halibutRuntimeBuilder, IStreamFactory? streamFactory)
         {
             if (streamFactory != null) halibutRuntimeBuilder.WithStreamFactory(streamFactory);
+            return halibutRuntimeBuilder;
+        }
+        
+        public static HalibutRuntimeBuilder WithControlMessageObserverIfNotNull(this HalibutRuntimeBuilder halibutRuntimeBuilder, IControlMessageObserver? controlMessageObserver)
+        {
+            if (controlMessageObserver != null) halibutRuntimeBuilder.WithControlMessageObserver(controlMessageObserver);
             return halibutRuntimeBuilder;
         }
     }

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Logging;
 using Halibut.TestProxy;
+using Halibut.Transport.Observability;
 using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests.Support

--- a/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/IClientAndServiceBuilder.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Logging;
 using Halibut.TestProxy;
-using Halibut.Transport.Observability;
 using Octopus.TestPortForwarder;
 
 namespace Halibut.Tests.Support

--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -97,6 +97,18 @@ namespace Halibut.Tests.Support
             return this;
         }
 
+        public IClientAndServiceBuilder WithClientControlMessageObserver(IControlMessageObserver controlMessageObserver)
+        {
+            clientBuilder.WithControlMessageObserver(controlMessageObserver);
+            return this;
+        }
+        
+        public IClientAndServiceBuilder WithServiceControlMessageObserver(IControlMessageObserver controlMessageObserver)
+        {
+            serviceBuilder.WithControlMessageObserver(controlMessageObserver);
+            return this;
+        }
+
         public LatestClientAndLatestServiceBuilder WithServiceConnectionsObserver(IConnectionsObserver connectionsObserver)
         {
             serviceBuilder.WithServiceConnectionsObserver(connectionsObserver);

--- a/source/Halibut.Tests/Support/LatestClientBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientBuilder.cs
@@ -34,7 +34,7 @@ namespace Halibut.Tests.Support
         HalibutTimeoutsAndLimits halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
         IStreamFactory? clientStreamFactory;
         IConnectionsObserver? clientConnectionsObserver;
-        
+        IControlMessageObserver? controlMessageObserver;
 
         public LatestClientBuilder(
             ServiceConnectionType serviceConnectionType,
@@ -64,6 +64,12 @@ namespace Halibut.Tests.Support
         public LatestClientBuilder WithStreamFactory(IStreamFactory streamFactory)
         {
             this.clientStreamFactory = streamFactory;
+            return this;
+        }
+
+        public LatestClientBuilder WithControlMessageObserver(IControlMessageObserver controlMessageObserver)
+        {
+            this.controlMessageObserver = controlMessageObserver;
             return this;
         }
         
@@ -174,6 +180,7 @@ namespace Halibut.Tests.Support
                 .WithPendingRequestQueueFactory(factory)
                 .WithTrustProvider(clientTrustProvider!)
                 .WithStreamFactoryIfNotNull(clientStreamFactory)
+                .WithControlMessageObserverIfNotNull(controlMessageObserver)
                 .WithConnectionsObserver(clientConnectionsObserver!)
                 .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                 .WithOnUnauthorizedClientConnect(clientOnUnauthorizedClientConnect!);

--- a/source/Halibut.Tests/Support/LatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestServiceBuilder.cs
@@ -41,6 +41,7 @@ namespace Halibut.Tests.Support
         IStreamFactory? serviceStreamFactory;
         IConnectionsObserver? serviceConnectionsObserver;
         int pollingConnectionCount = 1;
+        IControlMessageObserver? controlMessageObserver;
 
         public LatestServiceBuilder(
             ServiceConnectionType serviceConnectionType,
@@ -192,6 +193,7 @@ namespace Halibut.Tests.Support
                 .WithServerCertificate(serviceCertAndThumbprint.Certificate2)
                 .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                 .WithStreamFactoryIfNotNull(serviceStreamFactory)
+                .WithControlMessageObserverIfNotNull(controlMessageObserver)
                 .WithConnectionsObserver(serviceConnectionsObserver!)
                 .WithLogFactory(BuildServiceLogger());
 
@@ -279,6 +281,12 @@ namespace Halibut.Tests.Support
                 return this;
 
             pollingConnectionCount = count;
+            return this;
+        }
+
+        public LatestServiceBuilder WithControlMessageObserver(IControlMessageObserver controlMessageObserver)
+        {
+            this.controlMessageObserver = controlMessageObserver;
             return this;
         }
     }

--- a/source/Halibut.Tests/Support/Streams/StreamWrappingStreamFactory.cs
+++ b/source/Halibut.Tests/Support/Streams/StreamWrappingStreamFactory.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using Halibut.Transport.Streams;
+
+namespace Halibut.Tests.Support.Streams
+{
+    public class StreamWrappingStreamFactory :  IStreamFactory
+    {
+        public Func<Stream, Stream> WrapStreamWith = s => s;
+        
+        public Stream CreateStream(TcpClient stream)
+        {
+            return WrapStreamWith(new StreamFactory().CreateStream(stream));
+        }
+
+        public Stream CreateStream(WebSocket webSocket)
+        {
+            return new StreamFactory().CreateStream(webSocket);
+        }
+    }
+}

--- a/source/Halibut.Tests/Support/Streams/StreamWrappingStreamFactory.cs
+++ b/source/Halibut.Tests/Support/Streams/StreamWrappingStreamFactory.cs
@@ -17,7 +17,7 @@ namespace Halibut.Tests.Support.Streams
 
         public Stream CreateStream(WebSocket webSocket)
         {
-            return new StreamFactory().CreateStream(webSocket);
+            return WrapStreamWith(new StreamFactory().CreateStream(webSocket));
         }
     }
 }

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -98,9 +98,6 @@ namespace Halibut.Tests.Timeouts
                 sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
                     // the response to the 'Second last message' is put back into the queue.
                     .And.BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
-                
-                
-                Logger.Information("The service has sent {BytesSentFromService} bytes, The client has received {Bytes} bytes. Will wait until those equals.", bytesSentFromService!.BytesWritten, bytesReceivedByClient!.BytesRead);
             }
         }
     }

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -28,7 +28,7 @@ namespace Halibut.Tests.Timeouts
             var sw = new Stopwatch();
             
             ByteCountingStream? bytesSentFromService = null;
-            ByteCountingStream? bytesRecievedByClient = null; 
+            ByteCountingStream? bytesReceivedByClient = null; 
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
                              .AsLatestClientAndLatestServiceBuilder()
                              .WithPortForwarding(out var portForwarder)
@@ -46,7 +46,7 @@ namespace Halibut.Tests.Timeouts
                                  WrapStreamWith = s =>
                                  {
                                      var wrapped = new ByteCountingStream(s, OnDispose.DisposeInputStream);
-                                     bytesRecievedByClient ??= wrapped;
+                                     bytesReceivedByClient ??= wrapped;
                                      return wrapped;
                                  }
                              })
@@ -60,7 +60,7 @@ namespace Halibut.Tests.Timeouts
                                          while (true)
                                          {
                                              var currentBytesSentFromService = bytesSentFromService!.BytesWritten;
-                                             var currentBytesRecievedByClient = bytesRecievedByClient!.BytesRead;
+                                             var currentBytesRecievedByClient = bytesReceivedByClient!.BytesRead;
                                              Logger.Information("The service has sent {BytesSentFromService} bytes, The client has received {Bytes} bytes. Will wait until those equals.", currentBytesSentFromService, currentBytesRecievedByClient);
                                              if (currentBytesRecievedByClient == currentBytesSentFromService) break;
                                              CancellationToken.ThrowIfCancellationRequested();
@@ -98,6 +98,9 @@ namespace Halibut.Tests.Timeouts
                 sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
                     // the response to the 'Second last message' is put back into the queue.
                     .And.BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
+                
+                
+                Logger.Information("The service has sent {BytesSentFromService} bytes, The client has received {Bytes} bytes. Will wait until those equals.", bytesSentFromService!.BytesWritten, bytesReceivedByClient!.BytesRead);
             }
         }
     }

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -1,12 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Diagnostics;
 using Halibut.Tests.Support;
-using Halibut.Tests.Support.PortForwarding;
 using Halibut.Tests.Support.TestAttributes;
 using Halibut.Tests.Support.TestCases;
 using Halibut.Tests.TestServices.Async;
@@ -20,51 +16,45 @@ namespace Halibut.Tests.Timeouts
     public class NextAndProceedControlMessageTimeoutsFixture : BaseTest
     {
         [Test]
-        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening:false)]
+        [LatestClientAndLatestServiceTestCases(testNetworkConditions: false, testListening: false)]
         public async Task PauseOnPollingTentacleSendingNextControlMessage_ShouldNotHangForEver(ClientAndServiceTestCase clientAndServiceTestCase)
         {
-            var dataSentSizes = new List<long>();
-            long? pauseStreamWhenServiceSendsMessageOfSize = null;
+            var shouldPausePumpOnNextNextControlMessage = false;
+            var sw = new Stopwatch();
             await using (var clientAndService = await clientAndServiceTestCase.CreateTestCaseBuilder()
-                       .WithPortForwarding(port => PortForwarderUtil.ForwardingToLocalPort(port)
-                           .WithPortForwarderDataLogging(clientAndServiceTestCase.ServiceConnectionType)
-                           .WithPortForwarderServiceSentDataObserver(clientAndServiceTestCase.ServiceConnectionType, (tcpPump, stream) =>
-                           {
-                               dataSentSizes.Add(stream.Length);
-                               if (pauseStreamWhenServiceSendsMessageOfSize != null && pauseStreamWhenServiceSendsMessageOfSize == stream.Length)
-                               {
-                                   Logger.Information("Pausing pump since a write of size {Size} was received", stream.Length);
-                                   tcpPump.Pause();
-                                   pauseStreamWhenServiceSendsMessageOfSize = null;
-                               }
-                           })
-                           .Build())
-                       .As<LatestClientAndLatestServiceBuilder>()
-                       .WithEchoService()
-                       .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
-                       .Build(CancellationToken))
+                             .AsLatestClientAndLatestServiceBuilder()
+                             .WithPortForwarding(out var portForwarder)
+                             .WithServiceControlMessageObserver(new FuncControlMessageObserver
+                             {
+                                 BeforeSendingControlMessageAction = controlMessage =>
+                                 {
+                                     if (shouldPausePumpOnNextNextControlMessage && controlMessage.Equals("NEXT"))
+                                     {
+                                         Logger.Information("Pausing pump");
+                                         shouldPausePumpOnNextNextControlMessage = false;
+                                         portForwarder.Value!.PauseExistingConnections();
+                                         sw.Start();
+                                     }
+                                 }
+                             })
+                             .As<LatestClientAndLatestServiceBuilder>()
+                             .WithEchoService()
+                             .WithPollingReconnectRetryPolicy(() => new RetryPolicy(1, TimeSpan.Zero, TimeSpan.Zero))
+                             .Build(CancellationToken))
             {
                 var echo = clientAndService.CreateAsyncClient<IEchoService, IAsyncClientEchoService>();
-                
-                await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000));
-                // --> NEXT sent
-                // --> Proceed sent
-                await Task.Delay(TimeSpan.FromSeconds(3)); // Allow enough time for the polling queue to unnecessarily send a null message down the queue because of a race condition in the queue. 
-                long nextMessageSize = dataSentSizes.Last();
-                pauseStreamWhenServiceSendsMessageOfSize = nextMessageSize; // Lets hope they are all the same size
-                Logger.Information("Will pause the pump next time the polling service sends a message of size {Size}", pauseStreamWhenServiceSendsMessageOfSize);
 
-                await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000)); // Second last message
-                // --> NEXT sent and pump paused here.
-                
-                var sw = Stopwatch.StartNew();
-                // Service must detect that it can't get a PROCEED back in time and so must decide to abandon and then try again within
-                // its retry policy.
                 await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000));
+
+                shouldPausePumpOnNextNextControlMessage = true;
+                // When the port forwarder is paused the stopwatch is started,
+                // we time the length it takes for recovery on that paused connection
+                await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000));
+                await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000)); // Do a second call just in case we missed the NEXT control message
                 sw.Stop();
                 Logger.Information("It took: " + sw.Elapsed);
                 sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after
-                                                                                                                                     // the response to the 'Second last message' is put back into the queue.
+                    // the response to the 'Second last message' is put back into the queue.
                     .And.BeLessThan(clientAndService.Service.TimeoutsAndLimits.TcpClientTimeout.ReceiveTimeout, "Service should not be using this timeout to detect the control message is not coming back, it should use the shorter one.");
             }
         }

--- a/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
+++ b/source/Halibut.Tests/Timeouts/NextAndProceedControlMessageTimeoutsFixture.cs
@@ -92,7 +92,7 @@ namespace Halibut.Tests.Timeouts
                 // When the port forwarder is paused the stopwatch is started,
                 // we time the length it takes for recovery on that paused connection
                 await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000));
-                await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000)); // Do a second call just in case we missed the NEXT control message
+                await echo.SayHelloAsync(Some.RandomAsciiStringOfLength(2000)); // Do a second call just in case we missed the NEXT control message, since the polling tentacle can come back with a "NEXT" ctrl message before we have a request ready for it.
                 sw.Stop();
                 Logger.Information("It took: " + sw.Elapsed);
                 sw.Elapsed.Should().BeGreaterThanOrEqualTo(clientAndService.Service.TimeoutsAndLimits.TcpClientHeartbeatTimeout.ReceiveTimeout - TimeSpan.FromSeconds(2)) // -2s since tentacle will begin its countdown on the read which may start just after

--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -96,7 +96,7 @@ namespace Halibut.Tests.Transport
         {
             var limits = new HalibutTimeoutsAndLimitsForTestsBuilder().Build();
             var activeConnectionLimiter = new ActiveTcpConnectionsLimiter(limits);
-            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), limits, logger), limits, activeConnectionLimiter, logger);
+            return new MessageExchangeProtocol(new MessageExchangeStream(stream, new MessageSerializerBuilder(new LogFactory()).Build(), new NoOpControlMessageObserver(), limits, logger), limits, activeConnectionLimiter, logger);
         }
     }
 }

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -44,6 +44,7 @@ namespace Halibut
         readonly TcpConnectionFactory tcpConnectionFactory;
         readonly IConnectionsObserver connectionsObserver;
         readonly IActiveTcpConnectionsLimiter activeTcpConnectionsLimiter;
+        readonly IControlMessageObserver controlMessageObserver;
 
         internal HalibutRuntime(
             IServiceFactory serviceFactory,
@@ -57,7 +58,8 @@ namespace Halibut
             HalibutTimeoutsAndLimits halibutTimeoutsAndLimits,
             IStreamFactory streamFactory,
             IRpcObserver rpcObserver,
-            IConnectionsObserver connectionsObserver)
+            IConnectionsObserver connectionsObserver, 
+            IControlMessageObserver controlMessageObserver)
         {
             this.serverCertificate = serverCertificate;
             this.trustProvider = trustProvider;
@@ -71,6 +73,7 @@ namespace Halibut
             invoker = new ServiceInvoker(serviceFactory);
             TimeoutsAndLimits = halibutTimeoutsAndLimits;
             this.connectionsObserver = connectionsObserver;
+            this.controlMessageObserver = controlMessageObserver;
 
             connectionManager = new ConnectionManagerAsync();
             this.tcpConnectionFactory = new TcpConnectionFactory(serverCertificate, TimeoutsAndLimits, streamFactory);
@@ -103,7 +106,7 @@ namespace Halibut
 
         ExchangeProtocolBuilder ExchangeProtocolBuilder()
         {
-            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, messageSerializer, TimeoutsAndLimits, log), TimeoutsAndLimits, activeTcpConnectionsLimiter, log);
+            return (stream, log) => new MessageExchangeProtocol(new MessageExchangeStream(stream, messageSerializer, controlMessageObserver, TimeoutsAndLimits, log), TimeoutsAndLimits, activeTcpConnectionsLimiter, log);
         }
 
         public int Listen(IPEndPoint endpoint)

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -26,6 +26,7 @@ namespace Halibut
         IStreamFactory? streamFactory;
         IRpcObserver? rpcObserver;
         IConnectionsObserver? connectionsObserver;
+        IControlMessageObserver? controlMessageObserver;
 
         public HalibutRuntimeBuilder WithConnectionsObserver(IConnectionsObserver connectionsObserver)
         {
@@ -106,6 +107,12 @@ namespace Halibut
             return this;
         }
 
+        internal HalibutRuntimeBuilder WithControlMessageObserver(IControlMessageObserver controlMessageObserver)
+        {
+            this.controlMessageObserver = controlMessageObserver;
+            return this;
+        }
+
         public HalibutRuntimeBuilder WithOnUnauthorizedClientConnect(Func<string, string, UnauthorizedClientConnectResponse> onUnauthorizedClientConnect)
         {
             this.onUnauthorizedClientConnect = onUnauthorizedClientConnect;
@@ -149,6 +156,7 @@ namespace Halibut
             var streamFactory = this.streamFactory ?? new StreamFactory();
             var connectionsObserver = this.connectionsObserver ?? NoOpConnectionsObserver.Instance;
             var rpcObserver = this.rpcObserver ?? new NoRpcObserver();
+            var controlMessageObserver = this.controlMessageObserver ?? new NoOpControlMessageObserver();
 
             var halibutRuntime = new HalibutRuntime(
                 serviceFactory,
@@ -162,7 +170,8 @@ namespace Halibut
                 halibutTimeoutsAndLimits,
                 streamFactory,
                 rpcObserver,
-                connectionsObserver);
+                connectionsObserver,
+                controlMessageObserver);
 
             if (onUnauthorizedClientConnect is not null)
             {

--- a/source/Halibut/Transport/Observability/IControlMessageObserver.cs
+++ b/source/Halibut/Transport/Observability/IControlMessageObserver.cs
@@ -1,0 +1,11 @@
+
+namespace Halibut.Transport.Observability
+{
+    public interface IControlMessageObserver
+    {
+        internal void BeforeSendingControlMessage(string controlMessage);
+        internal void FinishSendingControlMessage(string controlMessage);
+        internal void WaitingForControlMessage();
+        internal void ReceivedControlMessage(string controlMessage);
+    }
+}

--- a/source/Halibut/Transport/Observability/NoOpControlMessageObserver.cs
+++ b/source/Halibut/Transport/Observability/NoOpControlMessageObserver.cs
@@ -1,0 +1,21 @@
+namespace Halibut.Transport.Observability
+{
+    public class NoOpControlMessageObserver : IControlMessageObserver
+    {
+        void IControlMessageObserver.BeforeSendingControlMessage(string controlMessage)
+        {
+        }
+
+        void IControlMessageObserver.FinishSendingControlMessage(string controlMessage)
+        {
+        }
+
+        void IControlMessageObserver.WaitingForControlMessage()
+        {
+        }
+
+        void IControlMessageObserver.ReceivedControlMessage(string controlMessage)
+        {
+        }
+    }
+}

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -67,8 +67,7 @@ namespace Halibut.Transport.Protocol
         {
             // The identity line and the additional empty line must be sent together as a single write operation when using a stream to mimic the 
             // buffering behaviour of the StreamWriter. When sent as 2 writes to the Stream, old Halibut Services e.g. 4.4.8 will often fail when reading the identity line.
-            await stream.WriteControlLineAsync(
-                identityLine + StreamExtensionMethods.ControlMessageNewLine, cancellationToken);
+            await stream.WriteControlLineAsync(identityLine + StreamExtensionMethods.ControlMessageNewLine, cancellationToken);
             await stream.FlushAsync(cancellationToken);
         }
 


### PR DESCRIPTION
# Background

On this [PR](https://github.com/OctopusDeploy/Halibut/pull/610) we are finding that `PauseOnPollingTentacleSendingNextControlMessage_ShouldNotHangForEver` sometimes fails because the port forwarder is observing the NEXT control message is arriving to the port forwarder close enough to the Response message they are considered a single "thing". This confuses the test which relies on finding small packets to know when to pause.

This improves on that rather than make assumption and have deep dependencies on what the code is doing, we (in test only) allow the test to observe when control messages are being sent. This allows the test to pause the port forwarder at exactly the right time without guessing.

This introduces a IControlMessageObserver which allows observation of what is happening with control messages. The halibut builder to set this is marked internal which should prevent surprise uses of this (although if anyone did do this they would probably know what their in for :D )


Using this along with existing byte counting streams we can fix the test by:
* Delaying sending of the "NEXT" control message
* until we know the client has received all bytes. 

An alternative would be to man in the middle ourselves, but then we are just parsing the halibut protocol and depending on how it exactly works, also this becomes tricky since the port forwarder allows pausing on partial SSL frames but if we de-crypted the SSL we wouldn't be able to do that type of pausing.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
