### PR TITLE
Remove `TestWindowsNet60` build target

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -96,7 +96,6 @@
               "TestLinux",
               "TestWindows",
               "TestWindowsNet48",
-              "TestWindowsNet60",
               "TestWindowsNet80"
             ]
           }
@@ -123,7 +122,6 @@
               "TestLinux",
               "TestWindows",
               "TestWindowsNet48",
-              "TestWindowsNet60",
               "TestWindowsNet80"
             ]
           }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -111,11 +111,6 @@ class Build : NukeBuild
     [PublicAPI]
     Target TestWindowsNet80 => _ => TestDefinition(_, CompileNet80, "net8.0", runDotMemoryTests: false);
 
-    // This temporary target is included to run the net8 tests on a pipeline configured for net6.0
-    // It can be removed once the build pipeline is updated to reference the new target.
-    [PublicAPI]
-    Target TestWindowsNet60 => t => t.DependsOn(TestWindowsNet80);
-
     ITargetDefinition TestDefinition(ITargetDefinition targetDefinition, Target dependsOn, [CanBeNull] string framework, bool runDotMemoryTests)
     {
         return targetDefinition


### PR DESCRIPTION
# Background

The `TestWindowsNet60` build target was still in use by the TeamCity build. This has now been updated to use the `TestWindowsNet80` target.

This PR removes the obsolete target name.

# Results

Builds should use the `TestWindowsNet80` target to run net8.0 tests on Windows.

# How to review this PR

- Quality :heavy_check_mark:
- Verify builds (especially Windows net8.0)

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
