### PR TITLE
Suppress cancellation shutdown log

### DIFF
--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -234,6 +234,9 @@ namespace Halibut.Transport
                     catch (SocketException e) when (e.SocketErrorCode == SocketError.Interrupted)
                     {
                     }
+                    catch (OperationCanceledException)
+                    {
+                    }
                     catch (ObjectDisposedException)
                     {
                         // Happens on shutdown

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -205,11 +205,11 @@ namespace Halibut.Transport
                 // This matches what we did before, in theory this will never happen.
             }
         }
+
         async Task AcceptAsync(CancellationToken cancellationToken)
         {
-
             const int errorThreshold = 3;
-            
+
             // Don't call listener.Stop until we sure we are not doing an Accept
             // See: https://github.com/OctopusDeploy/Issues/issues/6035
             // See: https://github.com/dotnet/corefx/issues/26034
@@ -222,10 +222,10 @@ namespace Halibut.Transport
                     try
                     {
 #if !NETFRAMEWORK
-            client = await listener.AcceptTcpClientAsync(this.cancellationToken);
+                        client = await listener.AcceptTcpClientAsync(this.cancellationToken);
 #else
-            // This only works because in the using we stop the listener which should work on windows
-            client = await listener.AcceptTcpClientAsync();
+                        // This only works because in the using we stop the listener which should work on windows
+                        client = await listener.AcceptTcpClientAsync();
 #endif
                         client.NoDelay = halibutTimeoutsAndLimits.TcpNoDelay;
                         var _ = Task.Run(async () => await HandleClient(client).ConfigureAwait(false)).ConfigureAwait(false);
@@ -520,7 +520,7 @@ namespace Halibut.Transport
         {
             cts.Cancel();
             backgroundThread?.Join();
-            if (backgroundTask != null) await backgroundTask; 
+            if (backgroundTask != null) await backgroundTask;
             listener?.Stop();
             tcpClientManager.Dispose();
             cts.Dispose();


### PR DESCRIPTION
# Background

The following log will be written when the `SecureListener` is canceled. This happens when Octopus Server is shut down.

```
Halibut initial communication failure of type ErrorInInitialisation occurred: "Error accepting TCP client: <none>"
System.OperationCanceledException: The operation was canceled.
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Threading.CancellationToken.ThrowIfCancellationRequested()
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Net.Sockets.Socket>.GetResult(Int16 token)
   at System.Net.Sockets.TcpListener.<AcceptTcpClientAsync>g__WaitAndWrap|32_0(ValueTask`1 task)
   at Halibut.Transport.SecureListener.AcceptAsync(CancellationToken cancellationToken)
```

This log is clearly misleading, as being canceled is expected, and does not indicate that an error has occurred. These messages can also be seen [in Cloud instances](https://customerinstance-seq.octopushq.com/#/events?from=2025-02-15T13:00:00.000Z&filter=EventType%20%3D%20'ErrorInInitialisation'%20and%20@Exception%20like%20'%25The%20operation%20was%20canceled%25').

# Results

Ignore the `OperationCanceledException` when cancelling the listener, similar to other shutdown exception types that are ignored.

# How to review this PR

✔️ Quality

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
