### PR TITLE
Introduce Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "nuget"
-    directory: "/source/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/approve-renovate-pull-request.yml
+++ b/.github/workflows/approve-renovate-pull-request.yml
@@ -1,0 +1,26 @@
+name: 'Approve Renovate Pull Request'
+
+on:
+  pull_request:
+    branches: [main]
+
+# Increase the access for the GITHUB_TOKEN
+permissions:
+  # This Allows the GITHUB_TOKEN to approve pull requests
+  pull-requests: write
+  # This Allows the GITHUB_TOKEN to auto merge pull requests
+  contents: write
+
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  # By default, GitHub Actions workflows triggered by renovate get a GITHUB_TOKEN with read-only permissions.
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  approve_renovate_pull_requests:
+    runs-on: ubuntu-latest
+    name: Approve renovate pull request
+    if: ${{ (github.actor == 'Octobob') && (contains(github.head_ref, 'renovate')) }}
+    steps:
+      - name: Approve a renovate created PR
+        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/approve-renovate-pull-request.yml
+++ b/.github/workflows/approve-renovate-pull-request.yml
@@ -1,3 +1,5 @@
+# Derived from https://github.com/OctopusDeploy/OctopusDeploy/blob/main/.github/workflows/portal-update-pull-request-automation.yml
+
 name: 'Approve Renovate Pull Request'
 
 on:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,28 @@
+name: Renovate update dependencies
+on:
+  schedule:
+    # UTC 10:00 PM (8AM AEST, Monday - Thursday)
+    - cron: '0 22 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  renovate-backend:
+    name: Self-hosted Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v39.0.1
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || null }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,3 +1,5 @@
+# Derived from https://github.com/OctopusDeploy/OctopusDeploy/blob/main/.github/workflows/update-dependencies.yml
+
 name: Renovate update dependencies
 on:
   schedule:

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,43 @@
+const excludeList = [
+    "dotnet-sdk", // The dotnet SDK update is a non-trivial piece of work.
+    "FluentAssertions", // FluentAssertions 8 and above introduced potential fees for developers
+];
+
+module.exports = {
+
+    timezone: "Australia/Brisbane",
+    requireConfig: "optional",
+    onboarding: false,
+
+    ignoreDeps: excludeList,
+    enabledManagers: ["nuget"],
+
+    // Full list of built-in presets: https://docs.renovatebot.com/presets-default/
+    extends: [
+        "config:base",
+        "group:monorepos",
+        "group:recommended",
+		":rebaseStalePrs",
+        ":automergeRequireAllStatusChecks",
+    ],
+
+    // Renovate will create a new issue in the repository.
+    // This issue has a "dashboard" where you can get an overview of the status of all updates.
+    // https://docs.renovatebot.com/key-concepts/dashboard/
+    dependencyDashboard: true,
+    dependencyDashboardTitle: "Halibut Dependency Dashboard",
+
+    platform: "github",
+    repositories: ["OctopusDeploy/Halibut"],
+    reviewers: ["OctopusDeploy/team-server-at-scale"],
+    labels: ["dependencies", "Halibut"],
+    branchPrefix: "renovate-dotnet/",
+
+    // Limit the amount of PRs created
+    prConcurrentLimit: 2,
+    prHourlyLimit: 1,
+
+    // If set to false, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.
+    // https://docs.renovatebot.com/configuration-options/#separatemajorminor
+    separateMajorMinor: false,
+};

--- a/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
+++ b/source/Halibut.Tests.DotMemory/Halibut.Tests.DotMemory.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="JetBrains.dotMemoryUnit" Version="3.2.20220510" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Assent" Version="1.8.2" />
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
+        <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />

--- a/source/Halibut.Tests/DependenciesTest.cs
+++ b/source/Halibut.Tests/DependenciesTest.cs
@@ -1,0 +1,20 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Halibut.Tests
+{
+    public class DependenciesTest
+    {
+        [Test]
+        public void FluentAssertionsIsVersion7()
+        {
+            typeof(AssertionOptions).Assembly.GetName().Version!.Major
+                .Should()
+                .Be(
+                    7,
+                    "We want to keep using the FOSS version of FluentAssertions, which changed in v8."
+                );
+        }
+    }
+}

--- a/source/Halibut.Tests/Halibut.Tests.csproj
+++ b/source/Halibut.Tests/Halibut.Tests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="CliWrap" Version="3.6.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Assent" Version="1.8.2" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.7.30" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />


### PR DESCRIPTION
# Background

We would like to ensure that our dependencies don't fall very far behind. Octopus Server and Tentacle uses Renovate, and for consistency, introducing this on Halibut too.

Previously Closed PR: https://github.com/OctopusDeploy/Halibut/pull/575

This PR is based off [this Tentacle PR](https://github.com/OctopusDeploy/OctopusTentacle/pull/687).

[sc-65919]

We would also like to prevent the FluentAssertions version from auto-updating as [v8 upwards is not FOSS](https://github.com/fluentassertions/fluentassertions/pull/2943).

# Results

Renovate will create PRs every day Mon-Fri, ready for Server-at-Scale to review.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
