### PR TITLE
Allow users (of halibut) to define the polling re-connect policy

### DIFF
--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -101,7 +101,7 @@ namespace Halibut
             return this;
         }
 
-        internal HalibutRuntimeBuilder WithPollingReconnectRetryPolicy(Func<RetryPolicy> pollingReconnectRetryPolicy)
+        public HalibutRuntimeBuilder WithPollingReconnectRetryPolicy(Func<RetryPolicy> pollingReconnectRetryPolicy)
         {
             this.pollingReconnectRetryPolicy = pollingReconnectRetryPolicy;
             return this;

--- a/source/Halibut/Util/RetryPolicy.cs
+++ b/source/Halibut/Util/RetryPolicy.cs
@@ -7,7 +7,7 @@ namespace Halibut.Util
     {
         readonly Stopwatch stopwatch = new Stopwatch();
 
-        internal RetryPolicy(double backoffMultiplier, TimeSpan minimumDelay, TimeSpan maximumDelay)
+        public RetryPolicy(double backoffMultiplier, TimeSpan minimumDelay, TimeSpan maximumDelay)
         {
             if (backoffMultiplier <= 0) throw new ArgumentOutOfRangeException(nameof(backoffMultiplier), "Must be greater than zero");
 


### PR DESCRIPTION
# Background

Halibut previously made assumptions around how users would want polling services to re-connected. Which meant that for local development we would need to wait for up to 2 minutes for tentacle or simulated tentacle to re-connect.

This change allows clients of Halibut to change the reconnect policy. For example in local dev this would allow us to define a faster retry policy avoiding that 2min delay that currently applies.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
