### PR TITLE
Add ForContext support to logging.

### DIFF
--- a/source/Halibut.Tests.DotMemory/Support/TestContextConnectionLog.cs
+++ b/source/Halibut.Tests.DotMemory/Support/TestContextConnectionLog.cs
@@ -36,6 +36,11 @@ namespace Halibut.Tests.Support.Logging
             throw new NotImplementedException();
         }
 
+        public ILog ForContext<T>()
+        {
+            return this;
+        }
+
         void WriteInternal(LogEvent logEvent)
         {
             var logEventLogLevel = GetLogLevel(logEvent);

--- a/source/Halibut.Tests/Support/Logging/InMemoryLogWriter.cs
+++ b/source/Halibut.Tests/Support/Logging/InMemoryLogWriter.cs
@@ -30,5 +30,10 @@ namespace Halibut.Tests.Support.Logging
         {
             return events.ToArray();
         }
+
+        public ILog ForContext<T>()
+        {
+            return this;
+        }
     }
 }

--- a/source/Halibut/Diagnostics/ILog.cs
+++ b/source/Halibut/Diagnostics/ILog.cs
@@ -7,5 +7,7 @@ namespace Halibut.Diagnostics
     public interface ILog : ILogWriter
     {
         IList<LogEvent> GetLogs();
+
+        ILog ForContext<T>();
     }
 }

--- a/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
+++ b/source/Halibut/Diagnostics/InMemoryConnectionLog.cs
@@ -39,6 +39,8 @@ namespace Halibut.Diagnostics
             return events.ToArray();
         }
 
+        public ILog ForContext<T>() => this;
+
         void WriteInternal(LogEvent logEvent)
         {
             var logLevel = GetLogLevel(logEvent);

--- a/source/Halibut/Diagnostics/LogCreators/AggregateLogWriterLogCreator.cs
+++ b/source/Halibut/Diagnostics/LogCreators/AggregateLogWriterLogCreator.cs
@@ -6,9 +6,9 @@ namespace Halibut.Diagnostics.LogCreators
     public class AggregateLogWriterLogCreator : ICreateNewILog
     {
         readonly ICreateNewILog logCreator;
-        readonly Func<string, ILogWriter[]> logWriterFactoryForPrefix;
+        readonly Func<string, ILog[]> logWriterFactoryForPrefix;
 
-        public AggregateLogWriterLogCreator(ICreateNewILog logCreator, Func<string, ILogWriter[]> logWriterFactoryForPrefix)
+        public AggregateLogWriterLogCreator(ICreateNewILog logCreator, Func<string, ILog[]> logWriterFactoryForPrefix)
         {
             this.logCreator = logCreator;
             this.logWriterFactoryForPrefix = logWriterFactoryForPrefix;

--- a/source/Halibut/Diagnostics/LogWriters/AggregateLogWriter.cs
+++ b/source/Halibut/Diagnostics/LogWriters/AggregateLogWriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Halibut.Diagnostics.LogWriters
 {
@@ -9,9 +10,9 @@ namespace Halibut.Diagnostics.LogWriters
     public class AggregateLogWriter : ILog
     {
         readonly ILog log;
-        readonly ILogWriter[] logWriter;
+        readonly ILog[] logWriter;
 
-        public AggregateLogWriter(ILog log, ILogWriter[] logWriter)
+        public AggregateLogWriter(ILog log, ILog[] logWriter)
         {
             this.log = log;
             this.logWriter = logWriter;
@@ -38,6 +39,11 @@ namespace Halibut.Diagnostics.LogWriters
         public IList<LogEvent> GetLogs()
         {
             return log.GetLogs();
+        }
+
+        public ILog ForContext<T>()
+        {
+            return new AggregateLogWriter(log.ForContext<T>(), logWriter.Select(lw => lw.ForContext<T>()).ToArray());
         }
     }
 }


### PR DESCRIPTION
# Background

Currently the halibut ILog does not support `ForContext<T>` this makes it hard to grep verbose logs to find logs from one place.

With this change it is not possible to specify the context for example:
```
new TestContextLogCreator("Bob", LogLevel.Trace)
    .CreateNewForPrefix("poll://alice")
    .ForContext<UsageFixture>()
    .Write(EventType.Error, "oh noes");
```
give:
```
10:03:06.386 +10:00 UsageFixture              Bob: Error: poll://alice  13 oh noes
```

This is used extensively in the Redis PRQ yet to be merged.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
