### PR TITLE
Add IsRetryableError() method

### DIFF
--- a/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
+++ b/source/Halibut.Tests/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethodFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Diagnostics;
@@ -18,6 +19,30 @@ namespace Halibut.Tests.Diagnostics
     {
         public class WhenGivenA
         {
+            [Test]
+            public void MethodNotFoundHalibutClientException_ItIsNotARetryableError()
+            {
+                new MethodNotFoundHalibutClientException("").IsRetryableError()
+                    .Should()
+                    .Be(HalibutRetryableErrorType.NotRetryable);
+            }
+            
+            [Test]
+            public void SocketExceptionError_ItIsARetryableError()
+            {
+                new SocketException(123).IsRetryableError()
+                    .Should()
+                    .Be(HalibutRetryableErrorType.IsRetryable);
+            }
+            
+            [Test]
+            public void SomeRandomException_ItIsARetryableError()
+            {
+                new Exception("Totally random").IsRetryableError()
+                    .Should()
+                    .Be(HalibutRetryableErrorType.UnknownError);
+            }
+            
             [Test]
             public void MethodNotFoundHalibutClientException_ItIsNotANetworkError()
             {
@@ -62,6 +87,10 @@ namespace Halibut.Tests.Diagnostics
                     exception.IsNetworkError()
                         .Should()
                         .Be(HalibutNetworkExceptionType.IsNetworkError);
+
+                    exception.IsRetryableError()
+                        .Should()
+                        .Be(HalibutRetryableErrorType.IsRetryable);
                     
                         exception.Message.Should().ContainAny(new []
                             {

--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -10,6 +10,22 @@ namespace Halibut.Diagnostics
 {
     public static class ExceptionReturnedByHalibutProxyExtensionMethod
     {
+        public static HalibutRetryableErrorType IsRetryableError(this Exception exception)
+        {
+            var halibutNetworkExceptionType = IsNetworkError(exception);
+            switch (halibutNetworkExceptionType)
+            {
+                case HalibutNetworkExceptionType.IsNetworkError:
+                    return HalibutRetryableErrorType.IsRetryable;
+                case HalibutNetworkExceptionType.UnknownError:
+                    return HalibutRetryableErrorType.UnknownError;
+                case HalibutNetworkExceptionType.NotANetworkError:
+                    return HalibutRetryableErrorType.NotRetryable;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+        
         /// <summary>
         ///     Classifies the exception thrown from a halibut proxy as a network error or not.
         ///     In some cases it is not possible to tell if the exception is a network error.

--- a/source/Halibut/Diagnostics/HalibutRetryableErrorType.cs
+++ b/source/Halibut/Diagnostics/HalibutRetryableErrorType.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Halibut.Diagnostics
+{
+    public enum HalibutRetryableErrorType
+    {
+        IsRetryable,
+        UnknownError,
+        NotRetryable
+    }
+}


### PR DESCRIPTION
# Background

Tentacle client needs to be able to know when to retry an RPC. Currently it does this by retrying so longer as the error was either a Network error or an unknown error.

With the RedisQueue we will have new different errors, that are not in themselves network errors (although maybe caused by the network) but are indeed retryable.

This PR adds a new concept/method: `IsRetryableError()` which can be used to determine if an RPC should be retried. With this PR tentacle can be updated to use `IsRetryableError()`. This allows us to add new retryable errors, without needing to make further changes to Tentacle Client.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
