### PR TITLE
Dispose created but unused queues

### DIFF
--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -87,7 +87,14 @@ namespace Halibut
 
         IPendingRequestQueue GetQueue(Uri target)
         {
-            return queues.GetOrAdd(target, u => queueFactory.CreateQueue(target));
+            IPendingRequestQueue? createdQueue = null;
+            var queue = queues.GetOrAdd(target, u => createdQueue = queueFactory.CreateQueue(target));
+            if (createdQueue != null && !ReferenceEquals(createdQueue, queue))
+            {
+                createdQueue.DisposeAsync();
+            }
+
+            return queue;
         }
 
         public int Listen()


### PR DESCRIPTION
# Background

Fixes an issue where queues were being created but not disposed. This was a race condition where the queue for the same endpoint might be created multiple times but only one queue was kept.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
