### PR TITLE
Add support for DataStreamMetadata, to make it easy to store small DataStreams in redis or metadata for datastreams in redis.

### DIFF
--- a/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeWhenRedisGoesDownAwayTests.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeWhenRedisGoesDownAwayTests.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Tests.Queue.Redis.Utils;
@@ -74,11 +75,13 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             portForwarder.ReturnToNormalMode();
             
             // Assert
-            await redisFacade.SetInHash("test-hash", "test-field", "test-value", TimeSpan.FromMinutes(1), CancellationToken);
+            await redisFacade.SetInHash("test-hash", new Dictionary<string, string>(){{"test-field", "test-value"}}, TimeSpan.FromMinutes(1), CancellationToken);
             
             // Check that the value was set.
-            var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", "test-field", CancellationToken);
-            retrievedValue.Should().Be("test-value");
+            var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", new []{"test-field"}, CancellationToken);
+            retrievedValue.Should().NotBeNull();
+            retrievedValue.Should().ContainKey("test-field");
+            retrievedValue!["test-field"].Should().Be("test-value");
         }
 
         [Test]
@@ -89,13 +92,15 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade(portForwarder);
 
             // Establish connection and set up test data
-            await redisFacade.SetInHash("test-hash", "test-field", "test-value", TimeSpan.FromMinutes(1), CancellationToken);
+            await redisFacade.SetInHash("test-hash", new Dictionary<string, string>(){{"test-field", "test-value"}}, TimeSpan.FromMinutes(1), CancellationToken);
 
             portForwarder.EnterKillNewAndExistingConnectionsMode();
             portForwarder.ReturnToNormalMode();
             
-            var result = await redisFacade.TryGetAndDeleteFromHash("test-hash", "test-field", CancellationToken);
-            result.Should().Be("test-value");
+            var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", new []{"test-field"}, CancellationToken);
+            retrievedValue.Should().NotBeNull();
+            retrievedValue.Should().ContainKey("test-field");
+            retrievedValue!["test-field"].Should().Be("test-value");
         }
 
         [Test]
@@ -180,7 +185,7 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade(portForwarder);
 
             // Establish connection and set up test data
-            await redisFacade.SetInHash("test-hash", "test-field", "test-value", TimeSpan.FromMinutes(1), CancellationToken);
+            await redisFacade.SetInHash("test-hash", new Dictionary<string, string>(){{"test-field", "test-value"}}, TimeSpan.FromMinutes(1), CancellationToken);
 
             portForwarder.EnterKillNewAndExistingConnectionsMode();
             portForwarder.ReturnToNormalMode();

--- a/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeWhenRedisGoesDownAwayTests.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeWhenRedisGoesDownAwayTests.cs
@@ -80,8 +80,8 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             // Check that the value was set.
             var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", new []{"test-field"}, CancellationToken);
             retrievedValue.Should().NotBeNull();
-            retrievedValue.Should().ContainKey("test-field");
-            retrievedValue!["test-field"].Should().Be("test-value");
+            retrievedValue.Should().ContainKey("test-field")
+                .WhoseValue.Should().Be("test-value");
         }
 
         [Test]
@@ -99,8 +99,8 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             
             var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", new []{"test-field"}, CancellationToken);
             retrievedValue.Should().NotBeNull();
-            retrievedValue.Should().ContainKey("test-field");
-            retrievedValue!["test-field"].Should().Be("test-value");
+            retrievedValue.Should().ContainKey("test-field")
+                .WhoseValue.Should().Be("test-value");
         }
 
         [Test]

--- a/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
@@ -217,7 +217,7 @@ namespace Halibut.Tests.Queue.Redis
             var redisDataLoseDetector = new CancellableDataLossWatchForRedisLosingAllItsData();
 
             var redisTransport = Substitute.ForPartsOf<HalibutRedisTransportWithVirtuals>(new HalibutRedisTransport(redisFacade));
-            redisTransport.Configure().PutRequest(Arg.Any<Uri>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            redisTransport.Configure().PutRequest(Arg.Any<Uri>(), Arg.Any<Guid>(), Arg.Any<RedisStoredMessage>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
                 .Returns(async callInfo =>
                 {
                     await redisDataLoseDetector.DataLossHasOccured();

--- a/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
@@ -150,6 +150,44 @@ namespace Halibut.Tests.Queue.Redis
             (await returnObject.Payload1!.ReadAsString(CancellationToken)).Should().Be("good");
             (await returnObject.Payload2!.ReadAsString(CancellationToken)).Should().Be("bye");
         }
+        
+        [Test]
+        public async Task FullSendAndReceive_WithDataStreamsStoredAsJsonInDataStreamMetadata_ShouldWork()
+        {
+            // Arrange
+            var endpoint = new Uri("poll://" + Guid.NewGuid());
+            await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade();
+            var redisTransport = new HalibutRedisTransport(redisFacade);
+            var dataStreamStore = new JsonStoreDataStreamsForDistributedQueues();
+            var messageSerializer = new QueueMessageSerializerBuilder().Build();
+            var messageReaderWriter = new MessageSerialiserAndDataStreamStorage(messageSerializer, dataStreamStore);
+
+            var request = new RequestMessageBuilder("poll://test-endpoint").Build();
+            request.Params = new[] { new ComplexObjectMultipleDataStreams(DataStream.FromString("hello"), DataStream.FromString("world")) };
+
+            var node1Sender = new RedisPendingRequestQueue(endpoint, new RedisNeverLosesData(), HalibutLog, redisTransport, messageReaderWriter, new HalibutTimeoutsAndLimits());
+            var node2Receiver = new RedisPendingRequestQueue(endpoint, new RedisNeverLosesData(), HalibutLog, redisTransport, messageReaderWriter, new HalibutTimeoutsAndLimits());
+            await node2Receiver.WaitUntilQueueIsSubscribedToReceiveMessages();
+
+            var queueAndWaitAsync = node1Sender.QueueAndWaitAsync(request, CancellationToken.None);
+
+            var requestMessageWithCancellationToken = await node2Receiver.DequeueAsync(CancellationToken);
+
+            var objWithDataStreams = (ComplexObjectMultipleDataStreams)requestMessageWithCancellationToken!.RequestMessage.Params[0];
+            (await objWithDataStreams.Payload1!.ReadAsString(CancellationToken)).Should().Be("hello");
+            (await objWithDataStreams.Payload2!.ReadAsString(CancellationToken)).Should().Be("world");
+
+            var response = ResponseMessage.FromResult(requestMessageWithCancellationToken.RequestMessage,
+                new ComplexObjectMultipleDataStreams(DataStream.FromString("good"), DataStream.FromString("bye")));
+
+            await node2Receiver.ApplyResponse(response, requestMessageWithCancellationToken.RequestMessage.ActivityId);
+
+            var responseMessage = await queueAndWaitAsync;
+
+            var returnObject = (ComplexObjectMultipleDataStreams)responseMessage.Result!;
+            (await returnObject.Payload1!.ReadAsString(CancellationToken)).Should().Be("good");
+            (await returnObject.Payload2!.ReadAsString(CancellationToken)).Should().Be("bye");
+        }
 
         [Test]
         public async Task WhenReadingTheResponseFromTheQueueFails_TheQueueAndWaitTaskReturnsAnUnknownError()

--- a/source/Halibut.Tests/Queue/Redis/Utils/HalibutRedisTransportWithVirtuals.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/HalibutRedisTransportWithVirtuals.cs
@@ -4,7 +4,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Queue.Redis;
+using Halibut.Queue.Redis.MessageStorage;
 using Halibut.Queue.Redis.NodeHeartBeat;
+using Halibut.Queue.Redis.RedisHelpers;
 using StackExchange.Redis;
 
 namespace Halibut.Tests.Queue.Redis.Utils
@@ -38,12 +40,12 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return halibutRedisTransport.TryPopNextRequestGuid(endpoint, cancellationToken);
         }
 
-        public virtual Task PutRequest(Uri endpoint, Guid requestId, string requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken)
+        public virtual Task PutRequest(Uri endpoint, Guid requestId, RedisStoredMessage requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken)
         {
             return halibutRedisTransport.PutRequest(endpoint, requestId, requestMessage, requestPickupTimeout, cancellationToken);
         }
 
-        public Task<string?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
+        public Task<RedisStoredMessage?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
         {
             return halibutRedisTransport.TryGetAndRemoveRequest(endpoint, requestId, cancellationToken);
         }
@@ -93,17 +95,17 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return halibutRedisTransport.PublishThatResponseIsAvailable(endpoint, identifier, cancellationToken);
         }
 
-        public Task SetResponseMessage(Uri endpoint, Guid identifier, string responseMessage, TimeSpan ttl, CancellationToken cancellationToken)
+        public Task SetResponseMessage(Uri endpoint, Guid identifier, RedisStoredMessage responseMessage, TimeSpan ttl, CancellationToken cancellationToken)
         {
             return halibutRedisTransport.SetResponseMessage(endpoint, identifier, responseMessage, ttl, cancellationToken);
         }
 
-        public Task<string?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        public Task<RedisStoredMessage?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
         {
             return halibutRedisTransport.GetResponseMessage(endpoint, identifier, cancellationToken);
         }
 
-        public Task<bool> DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        public Task DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
         {
             return halibutRedisTransport.DeleteResponseMessage(endpoint, identifier, cancellationToken);
         }

--- a/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
@@ -10,7 +10,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
     public class InMemoryStoreDataStreamsForDistributedQueues : IStoreDataStreamsForDistributedQueues
     {
         readonly IDictionary<Guid, byte[]> dataStreamsStored = new Dictionary<Guid, byte[]>();
-        public async Task StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task<string> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             foreach (var dataStream in dataStreams)
             {
@@ -18,9 +18,11 @@ namespace Halibut.Tests.Queue.Redis.Utils
                 await dataStream.WriteData(memoryStream, cancellationToken);
                 dataStreamsStored[dataStream.Id] = memoryStream.ToArray();
             }
+
+            return "";
         }
 
-        public async Task ReHydrateDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task ReHydrateDataStreams(string _, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             foreach (var dataStream in dataStreams)

--- a/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return "";
         }
 
-        public async Task ReHydrateDataStreams(string _, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task ReHydrateDataStreams(string dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             foreach (var dataStream in dataStreams)

--- a/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Queue.QueuedDataStreams;
+using Halibut.Transport.Streams;
 using Newtonsoft.Json;
 
 namespace Halibut.Tests.Queue.Redis.Utils
@@ -55,7 +56,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
                 var bytes = Convert.FromBase64String(base64Data);
                 dataStream.SetWriterAsync(async (stream, ct) =>
                 {
-                    await stream.WriteAsync(bytes, ct);
+                    await stream.WriteByteArrayAsync(bytes, ct);
                 });
             }
         }

--- a/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Queue.QueuedDataStreams;
+using Newtonsoft.Json;
+
+namespace Halibut.Tests.Queue.Redis.Utils
+{
+    /// <summary>
+    /// A test implementation of IStoreDataStreamsForDistributedQueues that stores 
+    /// data streams as JSON in the metadata string, using base64 encoding for binary data.
+    /// </summary>
+    public class JsonStoreDataStreamsForDistributedQueues : IStoreDataStreamsForDistributedQueues
+    {
+        public async Task<string> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        {
+            var dataStreamData = new Dictionary<Guid, string>();
+
+            foreach (var dataStream in dataStreams)
+            {
+                using var memoryStream = new MemoryStream();
+                await dataStream.WriteData(memoryStream, cancellationToken);
+                var bytes = memoryStream.ToArray();
+                var base64Data = Convert.ToBase64String(bytes);
+                dataStreamData[dataStream.Id] = base64Data;
+            }
+
+            return JsonConvert.SerializeObject(dataStreamData);
+        }
+
+        public async Task ReHydrateDataStreams(string dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            
+            if (string.IsNullOrWhiteSpace(dataStreamMetadata))
+            {
+                throw new ArgumentException("Data stream metadata cannot be null or empty", nameof(dataStreamMetadata));
+            }
+
+            var dataStreamData = JsonConvert.DeserializeObject<Dictionary<Guid, string>>(dataStreamMetadata);
+            if (dataStreamData == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize data stream metadata");
+            }
+
+            foreach (var dataStream in dataStreams)
+            {
+                if (!dataStreamData.TryGetValue(dataStream.Id, out var base64Data))
+                {
+                    throw new InvalidOperationException($"No stored data found for DataStream with ID: {dataStream.Id}");
+                }
+
+                var bytes = Convert.FromBase64String(base64Data);
+                dataStream.SetWriterAsync(async (stream, ct) =>
+                {
+                    await stream.WriteAsync(bytes, ct);
+                });
+            }
+        }
+    }
+}

--- a/source/Halibut.Tests/Queue/Redis/Utils/MessageReaderWriterExtensionsMethods.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/MessageReaderWriterExtensionsMethods.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Halibut.Queue.Redis;
 using Halibut.Queue.Redis.MessageStorage;
+using Halibut.Queue.Redis.RedisHelpers;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.Tests.Queue.Redis.Utils
@@ -29,22 +29,22 @@ namespace Halibut.Tests.Queue.Redis.Utils
             this.messageSerialiserAndDataStreamStorage = messageSerialiserAndDataStreamStorage;
         }
 
-        public virtual Task<string> PrepareRequest(RequestMessage request, CancellationToken cancellationToken)
+        public virtual Task<RedisStoredMessage> PrepareRequest(RequestMessage request, CancellationToken cancellationToken)
         {
             return messageSerialiserAndDataStreamStorage.PrepareRequest(request, cancellationToken);
         }
 
-        public virtual Task<RequestMessage> ReadRequest(string jsonRequest, CancellationToken cancellationToken)
+        public virtual Task<RequestMessage> ReadRequest(RedisStoredMessage jsonRequest, CancellationToken cancellationToken)
         {
             return messageSerialiserAndDataStreamStorage.ReadRequest(jsonRequest, cancellationToken);
         }
 
-        public virtual Task<string> PrepareResponse(ResponseMessage response, CancellationToken cancellationToken)
+        public virtual Task<RedisStoredMessage> PrepareResponse(ResponseMessage response, CancellationToken cancellationToken)
         {
             return messageSerialiserAndDataStreamStorage.PrepareResponse(response, cancellationToken);
         }
 
-        public virtual Task<ResponseMessage> ReadResponse(string jsonResponse, CancellationToken cancellationToken)
+        public virtual Task<ResponseMessage> ReadResponse(RedisStoredMessage jsonResponse, CancellationToken cancellationToken)
         {
             return messageSerialiserAndDataStreamStorage.ReadResponse(jsonResponse, cancellationToken);
         }
@@ -59,7 +59,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
             this.exception = exception;
         }
 
-        public override Task<ResponseMessage> ReadResponse(string jsonResponse, CancellationToken cancellationToken)
+        public override Task<ResponseMessage> ReadResponse(RedisStoredMessage jsonResponse, CancellationToken cancellationToken)
         {
             throw exception();
         }
@@ -74,7 +74,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
             this.exception = exception;
         }
 
-        public override Task<string> PrepareRequest(RequestMessage request, CancellationToken cancellationToken)
+        public override Task<RedisStoredMessage> PrepareRequest(RequestMessage request, CancellationToken cancellationToken)
         {
             throw exception();
         }

--- a/source/Halibut/Queue/QueuedDataStreams/IStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut/Queue/QueuedDataStreams/IStoreDataStreamsForDistributedQueues.cs
@@ -21,16 +21,18 @@ namespace Halibut.Queue.QueuedDataStreams
         /// </summary>
         /// <param name="dataStreams"></param>
         /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
-        
+        /// <returns>A string, DataStreamMetadata, containing a small amount of data that will be stored in redis, this will be
+        /// given to ReHydrateDataStreams</returns>
+        public Task<string> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
+
         /// <summary>
         /// Updates the dataStreams `writerAsync` to write the previously stored data. Using
         /// the SetWriterAsync method. 
         /// </summary>
+        /// <param name="dataStreamMetadata"></param>
         /// <param name="dataStreams"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task ReHydrateDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
+        public Task ReHydrateDataStreams(string dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Queue/Redis/MessageStorage/IMessageSerialiserAndDataStreamStorage.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/IMessageSerialiserAndDataStreamStorage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Queue.Redis.RedisHelpers;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.Queue.Redis.MessageStorage
@@ -15,9 +16,9 @@ namespace Halibut.Queue.Redis.MessageStorage
     /// </summary>
     public interface IMessageSerialiserAndDataStreamStorage
     {
-        Task<string> PrepareRequest(RequestMessage request, CancellationToken cancellationToken);
-        Task<RequestMessage> ReadRequest(string jsonRequest, CancellationToken cancellationToken);
-        Task<string> PrepareResponse(ResponseMessage response, CancellationToken cancellationToken);
-        Task<ResponseMessage> ReadResponse(string jsonResponse, CancellationToken cancellationToken);
+        Task<RedisStoredMessage> PrepareRequest(RequestMessage request, CancellationToken cancellationToken);
+        Task<RequestMessage> ReadRequest(RedisStoredMessage jsonRequest, CancellationToken cancellationToken);
+        Task<RedisStoredMessage> PrepareResponse(ResponseMessage response, CancellationToken cancellationToken);
+        Task<ResponseMessage> ReadResponse(RedisStoredMessage jsonResponse, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Queue/Redis/MessageStorage/RedisStoredMessage.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/RedisStoredMessage.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Halibut.Queue.Redis.MessageStorage
+{
+    public class RedisStoredMessage
+    {
+        public RedisStoredMessage(string message, string dataStreamMetadata)
+        {
+            Message = message;
+            DataStreamMetadata = dataStreamMetadata;
+        }
+
+        /// <summary>
+        /// Either the Request or Response Message
+        /// </summary>
+        public string Message { get; set; }
+        
+        /// <summary>
+        /// Metadata returned by and given to IStoreDataStreamsForDistributedQueues.
+        /// This will be stored in Redis alongside the Message. 
+        /// </summary>
+        public string DataStreamMetadata { get; }
+    }
+}

--- a/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
+++ b/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
@@ -1,10 +1,13 @@
 
 #if NET8_0_OR_GREATER
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Queue.Redis.MessageStorage;
 using Halibut.Queue.Redis.NodeHeartBeat;
 using Halibut.Util;
+using Microsoft.VisualBasic.CompilerServices;
 using StackExchange.Redis;
 
 namespace Halibut.Queue.Redis.RedisHelpers
@@ -78,8 +81,6 @@ namespace Halibut.Queue.Redis.RedisHelpers
         {
             return $"{Namespace}::RequestMessage::{endpoint}::{requestId}";
         }
-
-        static readonly string RequestMessageField = "RequestMessageField";
         
         /// <summary>
         /// The amount of time on top of the requestPickupTimout, the request will stay on the queue
@@ -90,15 +91,17 @@ namespace Halibut.Queue.Redis.RedisHelpers
         /// </summary>
         static readonly TimeSpan AdditionalRequestMessageTtl = TimeSpan.FromMinutes(2);
 
-        public async Task PutRequest(Uri endpoint, Guid requestId, string requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken)
+        public async Task PutRequest(Uri endpoint, Guid requestId, RedisStoredMessage requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken)
         {
             var requestKey = RequestMessageKey(endpoint, requestId);
             
             var ttl = requestPickupTimeout + AdditionalRequestMessageTtl;
 
-            await facade.SetInHash(requestKey, RequestMessageField, requestMessage, ttl, cancellationToken);
+            var dict = RedisStoredMessageToDictionary(requestMessage);
+
+            await facade.SetInHash(requestKey, dict, ttl, cancellationToken);
         }
-        
+
         /// <summary>
         /// Atomically Gets and removes the request from the queue.
         /// Exactly up to one caller of this method will be given the RequestMessage, all
@@ -112,11 +115,11 @@ namespace Halibut.Queue.Redis.RedisHelpers
         /// <param name="requestId"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<string?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
+        public async Task<RedisStoredMessage?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
         {
             var requestKey = RequestMessageKey(endpoint, requestId);
-            var requestMessage = await facade.TryGetAndDeleteFromHash(requestKey, RequestMessageField, cancellationToken);
-            return requestMessage;
+            var dit = await facade.TryGetAndDeleteFromHash(requestKey, RedisStoredMessageHashFields, cancellationToken);
+            return DictionaryToRedisStoredMessage(dit);
         }
 
         public async Task<bool> IsRequestStillOnQueue(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
@@ -253,22 +256,52 @@ namespace Halibut.Queue.Redis.RedisHelpers
             return $"{Namespace}::Response::{endpoint}::{identifier}";
         }
         
-        public async Task SetResponseMessage(Uri endpoint, Guid identifier, string responseMessage, TimeSpan ttl, CancellationToken cancellationToken)
+        public async Task SetResponseMessage(Uri endpoint, Guid identifier, RedisStoredMessage responseMessage, TimeSpan ttl, CancellationToken cancellationToken)
         {
             var key = ResponseMessageKey(endpoint, identifier);
-            await facade.SetString(key, responseMessage, ttl, cancellationToken);
+            var dict = RedisStoredMessageToDictionary(responseMessage);
+            await facade.SetInHash(key, dict, ttl, cancellationToken);
         }
         
-        public async Task<string?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        public async Task<RedisStoredMessage?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
         {
             var key = ResponseMessageKey(endpoint, identifier);
-            return await facade.GetString(key, cancellationToken);
+            var dict = await facade.TryGetFromHash(key, RedisStoredMessageHashFields, cancellationToken);
+            return DictionaryToRedisStoredMessage(dict);
         }
         
-        public async Task<bool> DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        public async Task DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
         {
             var key = ResponseMessageKey(endpoint, identifier);
-            return await facade.DeleteString(key, cancellationToken);
+            await facade.DeleteHash(key, cancellationToken);
+        }
+        
+        static readonly string RequestMessageField = "RequestMessageField";
+        static readonly string DataStreamMetaDataField = "DataStreamMetaDataField";
+        static string[] RedisStoredMessageHashFields => new[] { RequestMessageField, DataStreamMetaDataField };
+        
+        static RedisStoredMessage? DictionaryToRedisStoredMessage(Dictionary<string, string?>? dit)
+        {
+            if(dit == null) return null;
+            var requestMessage = dit[RequestMessageField]!;
+            
+            // As it turns out Redis or our client seems to treat "" as null, which is insane
+            // and results in us needing to deal with that here.
+            var dataStreamMetaData = "";
+            if(dit.TryGetValue(DataStreamMetaDataField, out var dataStreamMetaDataFromRedis))
+            {
+                dataStreamMetaData = dataStreamMetaDataFromRedis ?? "";
+            }
+            
+            return new RedisStoredMessage(requestMessage, dataStreamMetaData);
+        }
+        
+        static Dictionary<string, string> RedisStoredMessageToDictionary(RedisStoredMessage requestMessage)
+        {
+            var dict = new Dictionary<string, string>();
+            dict[RequestMessageField] = requestMessage.Message;
+            dict[DataStreamMetaDataField] = requestMessage.DataStreamMetadata;
+            return dict;
         }
     }
 }

--- a/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
+++ b/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
@@ -118,8 +118,8 @@ namespace Halibut.Queue.Redis.RedisHelpers
         public async Task<RedisStoredMessage?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
         {
             var requestKey = RequestMessageKey(endpoint, requestId);
-            var dit = await facade.TryGetAndDeleteFromHash(requestKey, RedisStoredMessageHashFields, cancellationToken);
-            return DictionaryToRedisStoredMessage(dit);
+            var dict = await facade.TryGetAndDeleteFromHash(requestKey, RedisStoredMessageHashFields, cancellationToken);
+            return DictionaryToRedisStoredMessage(dict);
         }
 
         public async Task<bool> IsRequestStillOnQueue(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
@@ -280,15 +280,15 @@ namespace Halibut.Queue.Redis.RedisHelpers
         static readonly string DataStreamMetaDataField = "DataStreamMetaDataField";
         static string[] RedisStoredMessageHashFields => new[] { RequestMessageField, DataStreamMetaDataField };
         
-        static RedisStoredMessage? DictionaryToRedisStoredMessage(Dictionary<string, string?>? dit)
+        static RedisStoredMessage? DictionaryToRedisStoredMessage(Dictionary<string, string?>? dict)
         {
-            if(dit == null) return null;
-            var requestMessage = dit[RequestMessageField]!;
+            if(dict == null) return null;
+            var requestMessage = dict[RequestMessageField]!;
             
             // As it turns out Redis or our client seems to treat "" as null, which is insane
             // and results in us needing to deal with that here.
             var dataStreamMetaData = "";
-            if(dit.TryGetValue(DataStreamMetaDataField, out var dataStreamMetaDataFromRedis))
+            if(dict.TryGetValue(DataStreamMetaDataField, out var dataStreamMetaDataFromRedis))
             {
                 dataStreamMetaData = dataStreamMetaDataFromRedis ?? "";
             }

--- a/source/Halibut/Queue/Redis/RedisHelpers/IHalibutRedisTransport.cs
+++ b/source/Halibut/Queue/Redis/RedisHelpers/IHalibutRedisTransport.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Queue.Redis.MessageStorage;
 using Halibut.Queue.Redis.NodeHeartBeat;
 using StackExchange.Redis;
 
@@ -18,8 +19,8 @@ namespace Halibut.Queue.Redis
         Task<Guid?> TryPopNextRequestGuid(Uri endpoint, CancellationToken cancellationToken);
         
         
-        Task PutRequest(Uri endpoint, Guid requestId, string requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken);
-        Task<string?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken);
+        Task PutRequest(Uri endpoint, Guid requestId, RedisStoredMessage requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken);
+        Task<RedisStoredMessage?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken);
         Task<bool> IsRequestStillOnQueue(Uri endpoint, Guid requestId, CancellationToken cancellationToken);
 
         Task<IAsyncDisposable> SubscribeToRequestCancellation(
@@ -51,9 +52,9 @@ namespace Halibut.Queue.Redis
         Task PublishThatResponseIsAvailable(Uri endpoint, Guid identifier, CancellationToken cancellationToken);
         
         
-        Task SetResponseMessage(Uri endpoint, Guid identifier, string responseMessage, TimeSpan ttl, CancellationToken cancellationToken);
-        Task<string?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken);
-        Task<bool> DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken);
+        Task SetResponseMessage(Uri endpoint, Guid identifier, RedisStoredMessage responseMessage, TimeSpan ttl, CancellationToken cancellationToken);
+        Task<RedisStoredMessage?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken);
+        Task DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken);
     }
 }
 #endif

--- a/source/Halibut/Queue/Redis/ResponseMessageTransfer/PollAndSubscribeToResponse.cs
+++ b/source/Halibut/Queue/Redis/ResponseMessageTransfer/PollAndSubscribeToResponse.cs
@@ -4,6 +4,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
+using Halibut.Queue.Redis.MessageStorage;
+using Halibut.Queue.Redis.RedisHelpers;
 using Halibut.Util;
 using Nito.AsyncEx;
 
@@ -18,12 +20,12 @@ namespace Halibut.Queue.Redis.ResponseMessageTransfer
         readonly Guid activityId;
         readonly LinearBackoffStrategy pollBackoffStrategy;
 
-        readonly TaskCompletionSource<string> responseJsonCompletionSource = new();
+        readonly TaskCompletionSource<RedisStoredMessage> responseJsonCompletionSource = new();
         
         /// <summary>
         /// An awaitable task that returns when the response is available.
         /// </summary>
-        public Task<string> ResponseJson => responseJsonCompletionSource.Task;
+        public Task<RedisStoredMessage> ResponseJson => responseJsonCompletionSource.Task;
 
         public PollAndSubscribeToResponse(Uri endpoint, Guid activityId, IHalibutRedisTransport halibutRedisTransport, ILog log)
         {
@@ -145,7 +147,7 @@ namespace Halibut.Queue.Redis.ResponseMessageTransfer
             }
         }
 
-        void TrySetResponse(string value)
+        void TrySetResponse(RedisStoredMessage value)
         {
             try
             {

--- a/source/Halibut/Queue/Redis/ResponseMessageTransfer/ResponseMessageSender.cs
+++ b/source/Halibut/Queue/Redis/ResponseMessageTransfer/ResponseMessageSender.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using Halibut.Diagnostics;
+using Halibut.Queue.Redis.MessageStorage;
 using Halibut.Util;
 
 namespace Halibut.Queue.Redis.ResponseMessageTransfer
@@ -12,7 +13,7 @@ namespace Halibut.Queue.Redis.ResponseMessageTransfer
             IHalibutRedisTransport halibutRedisTransport, 
             Uri endpoint, 
             Guid activityId,
-            string responseMessage,
+            RedisStoredMessage responseMessage,
             TimeSpan ttl,
             ILog log)
         {


### PR DESCRIPTION
# Background

Under a shared Pending Request Queue, we are often in the situation where the DataStream (the thing that can send arbitrary amounts of bytes) can be things that are:
* small (including dynamically generated data)
* large, but already in a shared location between all clients. 

To efficiently deal with those cases above the `IStoreDataStreamsForDistributedQueues` implementation we would want to:
* For small data, store the data in redis.
* For large but already shared data, we want to just store a placeholder that outlines where to get the data.

To make that easy this PR introduces `DataStreamMetadata`. The `IStoreDataStreamsForDistributedQueues` can return metadata when storing DataStreams and will be given that metadata when re-hydrating the streams. This makes it easy to implement the efficiencies listed above as the queue conveniently provides a place to store that small amount of data.

For example we could store small data streams in the metadata as well as store place holders for larger data streams in that metadata.

The queue takes care of the lifecycle of that metadata as well, since it is tied to the Request/Response message. Thus it will be cleaned up when the Request/Response message is cleaned up.

The metadata should be stored as byte[], this will be done when the Request/Response message is also stored as byte[]. For now this is good enough to work with.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
