### PR TITLE
Store Messages and DataStreamMetadata as bytes, Allow manipulation of how the Request/Response messages are stored e.g. support encryption/compression/etc

### DIFF
--- a/source/Halibut.Tests/Queue/QueueMessageSerializerBuilder.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerBuilder.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Halibut.Diagnostics;
 using Halibut.Queue;
+using Halibut.Queue.MessageStreamWrapping;
 using Halibut.Transport.Protocol;
 using Newtonsoft.Json;
 
@@ -11,9 +13,17 @@ namespace Halibut.Tests.Queue
         ITypeRegistry? typeRegistry;
         Action<JsonSerializerSettings>? configureSerializer;
 
+        MessageStreamWrappers messageStreamWrappers = new MessageStreamWrappers(new List<IMessageStreamWrapper>());
+
         public QueueMessageSerializerBuilder WithTypeRegistry(ITypeRegistry typeRegistry)
         {
             this.typeRegistry = typeRegistry;
+            return this;
+        }
+
+        public QueueMessageSerializerBuilder WithMessageStreamWrappers(MessageStreamWrappers messageStreamWrappers)
+        {
+            this.messageStreamWrappers = messageStreamWrappers;
             return this;
         }
 
@@ -36,7 +46,7 @@ namespace Halibut.Tests.Queue
                 return new StreamCapturingJsonSerializer(settings);
             }
 
-            return new QueueMessageSerializer(StreamCapturingSerializer);
+            return new QueueMessageSerializer(StreamCapturingSerializer, messageStreamWrappers);
         }
     }
 }

--- a/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -12,7 +11,6 @@ using Halibut.Diagnostics;
 using Halibut.Queue.MessageStreamWrapping;
 using Halibut.Tests.Support;
 using Halibut.Transport.Protocol;
-using Halibut.Transport.Streams;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Queue
@@ -92,13 +90,13 @@ namespace Halibut.Tests.Queue
 
             dataStreams[1].Should().BeOfType<RepeatingStringDataStream>();
 
+            // Assert
             var jsonString = Encoding.UTF8.GetString(json);
             jsonString.Should().Contain("TypeWithDataStreams");
             jsonString.Should().NotContain("RepeatingStringDataStream");
             
             var (deserializedMessage, deserializedDataStreams) = sut.ReadMessage<RequestMessage>(json);
-
-            // Assert
+            
             // Manually check each field of the deserializedMessage matches the request
             deserializedMessage.Id.Should().Be(request.Id);
             deserializedMessage.ActivityId.Should().Be(request.ActivityId);
@@ -235,6 +233,11 @@ namespace Halibut.Tests.Queue
         
         private readonly Stream stream;
 
+        /// <summary>
+        /// The given stream is not disposed by this stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <param name="onDispose"></param>
         public StreamWithOnDisposeFunc(Stream stream, Action onDispose)
         {
             this.stream = stream;

--- a/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
@@ -218,12 +218,12 @@ namespace Halibut.Tests.Queue
 
     public class Base64StreamWrapper : IMessageStreamWrapper
     {
-        public Stream WrapForWriting(Stream stream)
+        public Stream WrapMessageSerialisationStream(Stream stream)
         {
             return new CryptoStream(stream, new ToBase64Transform(), CryptoStreamMode.Write, leaveOpen: true);
         }
 
-        public Stream WrapForReading(Stream stream)
+        public Stream WrapMessageDeserialisationStream(Stream stream)
         {
             return new CryptoStream(stream, new FromBase64Transform(), CryptoStreamMode.Read, leaveOpen: true);
         }
@@ -299,10 +299,10 @@ namespace Halibut.Tests.Queue
             this.wrappedForReading = wrappedForReading;
         }
 
-        public Stream WrapForWriting(Stream stream) => wrappedForWriting(stream);
+        public Stream WrapMessageSerialisationStream(Stream stream) => wrappedForWriting(stream);
 
 
-        public Stream WrapForReading(Stream stream) => wrappedForReading(stream);
+        public Stream WrapMessageDeserialisationStream(Stream stream) => wrappedForReading(stream);
     }
 } 
 #endif

--- a/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
@@ -1,6 +1,7 @@
 #if NET8_0_OR_GREATER
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -86,8 +87,9 @@ namespace Halibut.Tests.Queue
 
             dataStreams[1].Should().BeOfType<RepeatingStringDataStream>();
 
-            json.Should().Contain("TypeWithDataStreams");
-            json.Should().NotContain("RepeatingStringDataStream");
+            var jsonString = Encoding.UTF8.GetString(json);
+            jsonString.Should().Contain("TypeWithDataStreams");
+            jsonString.Should().NotContain("RepeatingStringDataStream");
             
             var (deserializedMessage, deserializedDataStreams) = sut.ReadMessage<RequestMessage>(json);
 

--- a/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerFixture.cs
@@ -1,13 +1,18 @@
 #if NET8_0_OR_GREATER
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Diagnostics;
+using Halibut.Queue.MessageStreamWrapping;
 using Halibut.Tests.Support;
 using Halibut.Transport.Protocol;
+using Halibut.Transport.Streams;
 using NUnit.Framework;
 
 namespace Halibut.Tests.Queue
@@ -108,6 +113,68 @@ namespace Halibut.Tests.Queue
             
             deserializedDataStreams.Count.Should().Be(2);
         }
+        
+        [Test]
+        public void SerializeAndDeserializeSimpleStringMessage_WithStreamWrappers_ShouldRoundTrip()
+        {
+            // Arrange
+            var sut = new QueueMessageSerializerBuilder()
+                .WithMessageStreamWrappers(MessageStreamWrappersBuilder
+                    .WrapStreamWith(new GzipMessageStreamWrapper())
+                    .AndThenWrapThatWith(new Base64StreamWrapper())
+                    .Build())
+                .Build();
+
+            const string testMessage = "Hello, Queue!";
+
+            // Act
+            var (json, dataStreams) = sut.WriteMessage(testMessage);
+            var (deserializedMessage, deserializedDataStreams) = sut.ReadMessage<string>(json);
+
+            // Assert
+            deserializedMessage.Should().Be(testMessage);
+            dataStreams.Should().BeEmpty();
+            deserializedDataStreams.Should().BeEmpty();
+        }
+        
+        [Test]
+        public void SerializeAndDeserializeSimpleStringMessage_WithStreamWrappers_ShouldDisposeStreamsInCorrectOrder()
+        {
+            // Arrange
+            var disposeOrderWriter = new List<string>();
+            var disposeOrderReader = new List<string>();
+            
+            var firstWrapper = new FuncMessageStreamWrapper(
+                writingStream => new StreamWithOnDisposeFunc(writingStream, () => disposeOrderWriter.Add("FirstWriteDisposed")),
+                readingStream => new StreamWithOnDisposeFunc(readingStream, () => disposeOrderReader.Add("FirstReadDisposed")));
+            
+            var secondWrapper = new FuncMessageStreamWrapper(
+                writingStream => new StreamWithOnDisposeFunc(writingStream, () => disposeOrderWriter.Add("SecondWriteDisposed")),
+                readingStream => new StreamWithOnDisposeFunc(readingStream, () => disposeOrderReader.Add("SecondReadDisposed")));
+            
+            
+            var sut = new QueueMessageSerializerBuilder()
+                .WithMessageStreamWrappers(MessageStreamWrappersBuilder
+                    .WrapStreamWith(firstWrapper)
+                    .AndThenWrapThatWith(secondWrapper)
+                    .Build())
+                .Build();
+
+            const string testMessage = "Hello, Queue!";
+
+            // Act
+            var (json, dataStreams) = sut.WriteMessage(testMessage);
+            var (deserializedMessage, deserializedDataStreams) = sut.ReadMessage<string>(json);
+
+            // Assert
+            deserializedMessage.Should().Be(testMessage);
+            dataStreams.Should().BeEmpty();
+            deserializedDataStreams.Should().BeEmpty();
+
+            // The dispose order should be in reverse to how the streams were created.
+            disposeOrderWriter.Should().BeEquivalentTo("SecondWriteDisposed", "FirstWriteDisposed");
+            disposeOrderReader.Should().BeEquivalentTo("SecondReadDisposed", "FirstReadDisposed");
+        }
 
         public interface IHaveTypeWithDataStreamsService
         {
@@ -147,6 +214,95 @@ namespace Halibut.Tests.Queue
                 });
             }
         }
+    }
+
+    public class Base64StreamWrapper : IMessageStreamWrapper
+    {
+        public Stream WrapForWriting(Stream stream)
+        {
+            return new CryptoStream(stream, new ToBase64Transform(), CryptoStreamMode.Write, leaveOpen: true);
+        }
+
+        public Stream WrapForReading(Stream stream)
+        {
+            return new CryptoStream(stream, new FromBase64Transform(), CryptoStreamMode.Read, leaveOpen: true);
+        }
+    }
+
+    public class StreamWithOnDisposeFunc : Stream
+    {
+        Action OnDispose;
+        
+        private readonly Stream stream;
+
+        public StreamWithOnDisposeFunc(Stream stream, Action onDispose)
+        {
+            this.stream = stream;
+            OnDispose = onDispose;
+        }
+
+        public override void Flush()
+        {
+            stream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return stream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return stream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            stream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            stream.Write(buffer, offset, count);
+        }
+
+        public override bool CanRead => stream.CanRead;
+
+        public override bool CanSeek => stream.CanSeek;
+
+        public override bool CanWrite => stream.CanWrite;
+
+        public override long Length => stream.Length;
+
+        public override long Position
+        {
+            get => stream.Position;
+            set => stream.Position = value;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            OnDispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    public class FuncMessageStreamWrapper : IMessageStreamWrapper
+    {
+        Func<Stream, Stream> wrappedForWriting;
+        Func<Stream, Stream> wrappedForReading;
+        
+
+        public FuncMessageStreamWrapper(Func<Stream, Stream> wrappedForWriting, Func<Stream, Stream> wrappedForReading)
+        {
+            this.wrappedForWriting = wrappedForWriting;
+            this.wrappedForReading = wrappedForReading;
+        }
+
+        public Stream WrapForWriting(Stream stream) => wrappedForWriting(stream);
+
+
+        public Stream WrapForReading(Stream stream) => wrappedForReading(stream);
     }
 } 
 #endif

--- a/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeFixture.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Logging;
-using Halibut.Queue.Redis;
 using Halibut.Queue.Redis.RedisHelpers;
 using Halibut.Tests.Queue.Redis.Utils;
 using Halibut.Tests.Support;
@@ -65,8 +64,10 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
 
             // Assert - We'll verify by trying to get and delete it
             var retrievedValues = await redisFacade.TryGetAndDeleteFromHash(key, new[] { field }, CancellationToken);
-            retrievedValues.Should().NotBeNull();
-            Encoding.UTF8.GetString(retrievedValues![field]!).Should().Be(payload);
+            var bytes = retrievedValues.Should().NotBeNull()
+                .And.Subject.Should().ContainKey(field)
+                .WhoseValue!;
+            Encoding.UTF8.GetString(bytes).Should().Be(payload);
         }
 
         [Test]
@@ -85,8 +86,10 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             var retrievedValues = await redisFacade.TryGetAndDeleteFromHash(key, new[] { field }, CancellationToken);
 
             // Assert
-            retrievedValues.Should().NotBeNull();
-            Encoding.UTF8.GetString(retrievedValues![field]!).Should().Be(payload);
+            var bytes = retrievedValues.Should().NotBeNull()
+                .And.Subject.Should().ContainKey(field)
+                .WhoseValue!;
+            Encoding.UTF8.GetString(bytes).Should().Be(payload);
         }
 
         [Test]

--- a/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeWhenRedisGoesDownAwayTests.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisHelpers/RedisFacadeWhenRedisGoesDownAwayTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Tests.Queue.Redis.Utils;
@@ -75,13 +76,13 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             portForwarder.ReturnToNormalMode();
             
             // Assert
-            await redisFacade.SetInHash("test-hash", new Dictionary<string, string>(){{"test-field", "test-value"}}, TimeSpan.FromMinutes(1), CancellationToken);
+            await redisFacade.SetInHash("test-hash", new Dictionary<string, byte[]>(){{"test-field", Encoding.UTF8.GetBytes("test-value")}}, TimeSpan.FromMinutes(1), CancellationToken);
             
             // Check that the value was set.
             var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", new []{"test-field"}, CancellationToken);
             retrievedValue.Should().NotBeNull();
             retrievedValue.Should().ContainKey("test-field")
-                .WhoseValue.Should().Be("test-value");
+                .WhoseValue.Should().BeEquivalentTo(Encoding.UTF8.GetBytes("test-value"));
         }
 
         [Test]
@@ -92,7 +93,7 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade(portForwarder);
 
             // Establish connection and set up test data
-            await redisFacade.SetInHash("test-hash", new Dictionary<string, string>(){{"test-field", "test-value"}}, TimeSpan.FromMinutes(1), CancellationToken);
+            await redisFacade.SetInHash("test-hash", new Dictionary<string, byte[]>(){{"test-field", Encoding.UTF8.GetBytes("test-value")}}, TimeSpan.FromMinutes(1), CancellationToken);
 
             portForwarder.EnterKillNewAndExistingConnectionsMode();
             portForwarder.ReturnToNormalMode();
@@ -100,7 +101,7 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             var retrievedValue = await redisFacade.TryGetAndDeleteFromHash("test-hash", new []{"test-field"}, CancellationToken);
             retrievedValue.Should().NotBeNull();
             retrievedValue.Should().ContainKey("test-field")
-                .WhoseValue.Should().Be("test-value");
+                .WhoseValue.Should().BeEquivalentTo(Encoding.UTF8.GetBytes("test-value"));
         }
 
         [Test]
@@ -185,7 +186,7 @@ namespace Halibut.Tests.Queue.Redis.RedisHelpers
             await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade(portForwarder);
 
             // Establish connection and set up test data
-            await redisFacade.SetInHash("test-hash", new Dictionary<string, string>(){{"test-field", "test-value"}}, TimeSpan.FromMinutes(1), CancellationToken);
+            await redisFacade.SetInHash("test-hash", new Dictionary<string, byte[]>(){{"test-field", Encoding.UTF8.GetBytes("test-value")}}, TimeSpan.FromMinutes(1), CancellationToken);
 
             portForwarder.EnterKillNewAndExistingConnectionsMode();
             portForwarder.ReturnToNormalMode();

--- a/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
@@ -7,6 +7,7 @@ using Halibut.Diagnostics;
 using Halibut.Exceptions;
 using Halibut.Logging;
 using Halibut.Queue;
+using Halibut.Queue.MessageStreamWrapping;
 using Halibut.Queue.Redis;
 using Halibut.Queue.Redis.Exceptions;
 using Halibut.Queue.Redis.MessageStorage;
@@ -838,7 +839,7 @@ namespace Halibut.Tests.Queue.Redis
                     return new StreamCapturingJsonSerializer(settings);
                 }
 
-                return new QueueMessageSerializer(StreamCapturingSerializer);
+                return new QueueMessageSerializer(StreamCapturingSerializer, new MessageStreamWrappers());
             }
         }
         

--- a/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
@@ -10,7 +10,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
     public class InMemoryStoreDataStreamsForDistributedQueues : IStoreDataStreamsForDistributedQueues
     {
         readonly IDictionary<Guid, byte[]> dataStreamsStored = new Dictionary<Guid, byte[]>();
-        public async Task<string> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task<byte[]> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             foreach (var dataStream in dataStreams)
             {
@@ -19,10 +19,10 @@ namespace Halibut.Tests.Queue.Redis.Utils
                 dataStreamsStored[dataStream.Id] = memoryStream.ToArray();
             }
 
-            return "";
+            return Array.Empty<byte>();
         }
-
-        public async Task ReHydrateDataStreams(string dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        
+        public async Task ReHydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             foreach (var dataStream in dataStreams)

--- a/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/InMemoryStoreDataStreamsForDistributedQueues.cs
@@ -22,7 +22,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return Array.Empty<byte>();
         }
         
-        public async Task ReHydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task RehydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             foreach (var dataStream in dataStreams)

--- a/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
@@ -33,7 +33,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return Encoding.UTF8.GetBytes(json);
         }
 
-        public async Task ReHydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task RehydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             

--- a/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/JsonStoreDataStreamsForDistributedQueues.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Queue.QueuedDataStreams;
@@ -15,7 +16,7 @@ namespace Halibut.Tests.Queue.Redis.Utils
     /// </summary>
     public class JsonStoreDataStreamsForDistributedQueues : IStoreDataStreamsForDistributedQueues
     {
-        public async Task<string> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task<byte[]> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             var dataStreamData = new Dictionary<Guid, string>();
 
@@ -28,19 +29,21 @@ namespace Halibut.Tests.Queue.Redis.Utils
                 dataStreamData[dataStream.Id] = base64Data;
             }
 
-            return JsonConvert.SerializeObject(dataStreamData);
+            var json = JsonConvert.SerializeObject(dataStreamData);
+            return Encoding.UTF8.GetBytes(json);
         }
 
-        public async Task ReHydrateDataStreams(string dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
+        public async Task ReHydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
             
-            if (string.IsNullOrWhiteSpace(dataStreamMetadata))
+            if (dataStreamMetadata == null || dataStreamMetadata.Length == 0)
             {
                 throw new ArgumentException("Data stream metadata cannot be null or empty", nameof(dataStreamMetadata));
             }
 
-            var dataStreamData = JsonConvert.DeserializeObject<Dictionary<Guid, string>>(dataStreamMetadata);
+            var json = Encoding.UTF8.GetString(dataStreamMetadata);
+            var dataStreamData = JsonConvert.DeserializeObject<Dictionary<Guid, string>>(json);
             if (dataStreamData == null)
             {
                 throw new InvalidOperationException("Failed to deserialize data stream metadata");

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -29,7 +29,7 @@ namespace Halibut
         IRpcObserver? rpcObserver;
         IConnectionsObserver? connectionsObserver;
         IControlMessageObserver? controlMessageObserver;
-        MessageStreamWrappers queueMessageStreamWrappers = new MessageStreamWrappers();
+        MessageStreamWrappers queueMessageStreamWrappers = new();
 
         public HalibutRuntimeBuilder WithQueueMessageStreamWrappers(MessageStreamWrappers queueMessageStreamWrappers)
         {

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Halibut.Diagnostics;
 using Halibut.Queue;
+using Halibut.Queue.MessageStreamWrapping;
 using Halibut.ServiceModel;
 using Halibut.Transport.Observability;
 using Halibut.Transport.Protocol;
@@ -28,7 +29,14 @@ namespace Halibut
         IRpcObserver? rpcObserver;
         IConnectionsObserver? connectionsObserver;
         IControlMessageObserver? controlMessageObserver;
+        MessageStreamWrappers queueMessageStreamWrappers = new MessageStreamWrappers();
 
+        public HalibutRuntimeBuilder WithQueueMessageStreamWrappers(MessageStreamWrappers queueMessageStreamWrappers)
+        {
+            this.queueMessageStreamWrappers = queueMessageStreamWrappers;
+            return this;
+        }
+        
         public HalibutRuntimeBuilder WithConnectionsObserver(IConnectionsObserver connectionsObserver)
         {
             this.connectionsObserver = connectionsObserver;
@@ -161,7 +169,7 @@ namespace Halibut
             configureMessageSerializerBuilder?.Invoke(builder);
             var messageSerializer = builder.WithTypeRegistry(typeRegistry).Build();
             
-            var queueMessageSerializer = new QueueMessageSerializer(messageSerializer.CreateStreamCapturingSerializer);
+            var queueMessageSerializer = new QueueMessageSerializer(messageSerializer.CreateStreamCapturingSerializer, queueMessageStreamWrappers);
             var queueFactory = this.queueFactoryFactory?.Invoke(queueMessageSerializer)
                                ?? new PendingRequestQueueFactoryAsync(halibutTimeoutsAndLimits, logFactory);
             

--- a/source/Halibut/Queue/MessageStreamWrapping/GzipMessageStreamWrapper.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/GzipMessageStreamWrapper.cs
@@ -4,17 +4,22 @@ using System.IO.Compression;
 
 namespace Halibut.Queue.MessageStreamWrapping
 {
+    /// <summary>
+    /// Example implementation of IMessageStreamWrapper, which compresses
+    /// on serilisation and decompresses when deserialising Request/Response
+    /// messages.
+    /// </summary>
     public class GzipMessageStreamWrapper : IMessageStreamWrapper
     {
 
-        public Stream WrapForWriting(Stream stream)
+        public Stream WrapMessageSerialisationStream(Stream stream)
         {
-            return new GZipStream(stream, CompressionMode.Compress);
+            return new GZipStream(stream, CompressionMode.Compress, leaveOpen: true);
         }
         
-        public Stream WrapForReading(Stream stream)
+        public Stream WrapMessageDeserialisationStream(Stream stream)
         {
-            return new GZipStream(stream, CompressionMode.Decompress);
+            return new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
         }
     }
 }

--- a/source/Halibut/Queue/MessageStreamWrapping/GzipMessageStreamWrapper.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/GzipMessageStreamWrapper.cs
@@ -1,0 +1,20 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace Halibut.Queue.MessageStreamWrapping
+{
+    public class GzipMessageStreamWrapper : IMessageStreamWrapper
+    {
+
+        public Stream WrapForWriting(Stream stream)
+        {
+            return new GZipStream(stream, CompressionMode.Compress);
+        }
+        
+        public Stream WrapForReading(Stream stream)
+        {
+            return new GZipStream(stream, CompressionMode.Decompress);
+        }
+    }
+}

--- a/source/Halibut/Queue/MessageStreamWrapping/IMessageStreamWrapper.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/IMessageStreamWrapper.cs
@@ -14,17 +14,17 @@ namespace Halibut.Queue.MessageStreamWrapping
         /// </summary>
         /// <param name="stream"></param>
         /// <returns></returns>
-        Stream WrapForWriting(Stream stream);
+        Stream WrapMessageSerialisationStream(Stream stream);
         
         /// <summary>
         /// Wraps the streams the messages are deserialised from.
         ///
-        /// An implmentation of this might be a stream that decompresses data.
+        /// An implementation of this might be a stream that decompresses data.
         ///
         /// The resulting stream must leaveOpen the given stream on dispose.
         /// </summary>
         /// <param name="stream"></param>
         /// <returns></returns>
-        Stream WrapForReading(Stream stream);
+        Stream WrapMessageDeserialisationStream(Stream stream);
     }
 }

--- a/source/Halibut/Queue/MessageStreamWrapping/IMessageStreamWrapper.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/IMessageStreamWrapper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+
+namespace Halibut.Queue.MessageStreamWrapping
+{
+    public interface IMessageStreamWrapper {
+    
+        /// <summary>
+        /// Wraps the stream the messages are serialised to.
+        ///
+        /// An implementation of this might be a stream that compresses data given to it.
+        /// 
+        /// The resulting stream must leaveOpen the given stream on dispose
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
+        Stream WrapForWriting(Stream stream);
+        
+        /// <summary>
+        /// Wraps the streams the messages are deserialised from.
+        ///
+        /// An implmentation of this might be a stream that decompresses data.
+        ///
+        /// The resulting stream must leaveOpen the given stream on dispose.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <returns></returns>
+        Stream WrapForReading(Stream stream);
+    }
+}

--- a/source/Halibut/Queue/MessageStreamWrapping/MessageStreamWrappers.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/MessageStreamWrappers.cs
@@ -18,31 +18,4 @@ namespace Halibut.Queue.MessageStreamWrapping
             Wrappers = new List<IMessageStreamWrapper>();
         }
     }
-
-    public class MessageStreamWrappersBuilder
-    {
-        readonly IList<IMessageStreamWrapper> wrappers = new List<IMessageStreamWrapper>();
-
-        MessageStreamWrappersBuilder()
-        {
-        }
-
-        public static MessageStreamWrappersBuilder WrapStreamWith(IMessageStreamWrapper wrapper)
-        {
-            return new MessageStreamWrappersBuilder().AndThenWrapThatWith(wrapper);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="wrapper"></param>
-        /// <returns></returns>
-        public MessageStreamWrappersBuilder AndThenWrapThatWith(IMessageStreamWrapper wrapper)
-        {
-            wrappers.Add(wrapper);
-            return this;
-        }
-
-        public MessageStreamWrappers Build() => new(wrappers);
-    }
 }

--- a/source/Halibut/Queue/MessageStreamWrapping/MessageStreamWrappers.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/MessageStreamWrappers.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Halibut.Queue.MessageStreamWrapping
+{
+    public class MessageStreamWrappers
+    {
+        public IReadOnlyList<IMessageStreamWrapper> Wrappers { get; }
+
+        public MessageStreamWrappers(IList<IMessageStreamWrapper> wrappers)
+        {
+            Wrappers = wrappers.ToList();
+        }
+
+        public MessageStreamWrappers()
+        {
+            Wrappers = new List<IMessageStreamWrapper>();
+        }
+    }
+
+    public class MessageStreamWrappersBuilder
+    {
+        readonly IList<IMessageStreamWrapper> wrappers = new List<IMessageStreamWrapper>();
+
+        MessageStreamWrappersBuilder()
+        {
+        }
+
+        public static MessageStreamWrappersBuilder WrapStreamWith(IMessageStreamWrapper wrapper)
+        {
+            return new MessageStreamWrappersBuilder().AndThenWrapThatWith(wrapper);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="wrapper"></param>
+        /// <returns></returns>
+        public MessageStreamWrappersBuilder AndThenWrapThatWith(IMessageStreamWrapper wrapper)
+        {
+            wrappers.Add(wrapper);
+            return this;
+        }
+
+        public MessageStreamWrappers Build() => new(wrappers);
+    }
+}

--- a/source/Halibut/Queue/MessageStreamWrapping/MessageStreamWrappersBuilder.cs
+++ b/source/Halibut/Queue/MessageStreamWrapping/MessageStreamWrappersBuilder.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace Halibut.Queue.MessageStreamWrapping
+{
+    public class MessageStreamWrappersBuilder
+    {
+        readonly IList<IMessageStreamWrapper> wrappers = new List<IMessageStreamWrapper>();
+
+        MessageStreamWrappersBuilder()
+        {
+        }
+
+        public static MessageStreamWrappersBuilder WrapStreamWith(IMessageStreamWrapper wrapper)
+        {
+            return new MessageStreamWrappersBuilder().AndThenWrapThatWith(wrapper);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="wrapper"></param>
+        /// <returns></returns>
+        public MessageStreamWrappersBuilder AndThenWrapThatWith(IMessageStreamWrapper wrapper)
+        {
+            wrappers.Add(wrapper);
+            return this;
+        }
+
+        public MessageStreamWrappers Build() => new(wrappers);
+    }
+}

--- a/source/Halibut/Queue/QueueMessageSerializer.cs
+++ b/source/Halibut/Queue/QueueMessageSerializer.cs
@@ -39,7 +39,7 @@ namespace Halibut.Queue
             using var disposables = new DisposableCollection();
             foreach (var streamer in messageStreamWrappers.Wrappers)
             {
-                stream = streamer.WrapForWriting(stream);
+                stream = streamer.WrapMessageSerialisationStream(stream);
                 disposables.Add(stream);
             }
             using (var sw = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true)){
@@ -61,7 +61,7 @@ namespace Halibut.Queue
             using var disposables = new DisposableCollection();
             foreach (var streamer in messageStreamWrappers.Wrappers)
             {
-                stream = streamer.WrapForReading(stream);
+                stream = streamer.WrapMessageDeserialisationStream(stream);
                 disposables.Add(stream);
             }
             using var sr = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);

--- a/source/Halibut/Queue/QueueMessageSerializer.cs
+++ b/source/Halibut/Queue/QueueMessageSerializer.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -42,7 +43,11 @@ namespace Halibut.Queue
                 stream = streamer.WrapMessageSerialisationStream(stream);
                 disposables.Add(stream);
             }
-            using (var sw = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true)){
+            using (var sw = new StreamWriter(stream, Encoding.UTF8
+#if NET8_0_OR_GREATER
+                       , leaveOpen: true
+#endif
+                       )){
                 using (var jsonTextWriter = new JsonTextWriter(sw) { CloseOutput = false })
                 {
                     var streamCapturingSerializer = createStreamCapturingSerializer();
@@ -64,7 +69,11 @@ namespace Halibut.Queue
                 stream = streamer.WrapMessageDeserialisationStream(stream);
                 disposables.Add(stream);
             }
-            using var sr = new StreamReader(stream, Encoding.UTF8, leaveOpen: true);
+            using var sr = new StreamReader(stream, Encoding.UTF8
+#if NET8_0_OR_GREATER
+                       , leaveOpen: true
+#endif
+            );
             using var reader = new JsonTextReader(sr);
             var streamCapturingSerializer = createStreamCapturingSerializer();
             var result = streamCapturingSerializer.Serializer.Deserialize<MessageEnvelope<T>>(reader);

--- a/source/Halibut/Queue/QueuedDataStreams/IStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut/Queue/QueuedDataStreams/IStoreDataStreamsForDistributedQueues.cs
@@ -9,8 +9,8 @@ namespace Halibut.Queue.QueuedDataStreams
     /// The Redis Queue requires that something else can store data streams. The
     /// Redis Queue will call this interface for storage and retrieval of data streams.
     ///
-    /// The ReHydrateDataStreams method will be called at most once, and each data stream passed to
-    /// ReHydrateDataStreams will be read at most once. Thus, it is safe to delete the DataStream from
+    /// The RehydrateDataStreams method will be called at most once, and each data stream passed to
+    /// RehydrateDataStreams will be read at most once. Thus, it is safe to delete the DataStream from
     /// storage once the DataStream `writerAsync` Func is called and will no longer return any more
     /// data. This includes in the case the writerAsync method throws.
     /// </summary>
@@ -22,7 +22,7 @@ namespace Halibut.Queue.QueuedDataStreams
         /// <param name="dataStreams"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>A string, DataStreamMetadata, containing a small amount of data that will be stored in redis, this will be
-        /// given to ReHydrateDataStreams</returns>
+        /// given to RehydrateDataStreams</returns>
         public Task<byte[]> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
 
         /// <summary>
@@ -33,6 +33,6 @@ namespace Halibut.Queue.QueuedDataStreams
         /// <param name="dataStreams"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task ReHydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
+        public Task RehydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Queue/QueuedDataStreams/IStoreDataStreamsForDistributedQueues.cs
+++ b/source/Halibut/Queue/QueuedDataStreams/IStoreDataStreamsForDistributedQueues.cs
@@ -23,7 +23,7 @@ namespace Halibut.Queue.QueuedDataStreams
         /// <param name="cancellationToken"></param>
         /// <returns>A string, DataStreamMetadata, containing a small amount of data that will be stored in redis, this will be
         /// given to ReHydrateDataStreams</returns>
-        public Task<string> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
+        public Task<byte[]> StoreDataStreams(IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates the dataStreams `writerAsync` to write the previously stored data. Using
@@ -33,6 +33,6 @@ namespace Halibut.Queue.QueuedDataStreams
         /// <param name="dataStreams"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task ReHydrateDataStreams(string dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
+        public Task ReHydrateDataStreams(byte[] dataStreamMetadata, IReadOnlyList<DataStream> dataStreams, CancellationToken cancellationToken);
     }
 }

--- a/source/Halibut/Queue/Redis/MessageStorage/MessageSerialiserAndDataStreamStorage.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/MessageSerialiserAndDataStreamStorage.cs
@@ -20,14 +20,14 @@ namespace Halibut.Queue.Redis.MessageStorage
         public async Task<RedisStoredMessage> PrepareRequest(RequestMessage request, CancellationToken cancellationToken)
         {
             var (jsonRequestMessage, dataStreams) = queueMessageSerializer.WriteMessage(request);
-            var dataStreamMetaData = await storeDataStreamsForDistributedQueues.StoreDataStreams(dataStreams, cancellationToken);
-            return new RedisStoredMessage(jsonRequestMessage, dataStreamMetaData);
+            var dataStreamMetadata = await storeDataStreamsForDistributedQueues.StoreDataStreams(dataStreams, cancellationToken);
+            return new RedisStoredMessage(jsonRequestMessage, dataStreamMetadata);
         }
         
         public async Task<RequestMessage> ReadRequest(RedisStoredMessage storedMessage, CancellationToken cancellationToken)
         {
             var (request, dataStreams) = queueMessageSerializer.ReadMessage<RequestMessage>(storedMessage.Message);
-            await storeDataStreamsForDistributedQueues.ReHydrateDataStreams(storedMessage.DataStreamMetadata, dataStreams, cancellationToken);
+            await storeDataStreamsForDistributedQueues.RehydrateDataStreams(storedMessage.DataStreamMetadata, dataStreams, cancellationToken);
             return request;
         }
         
@@ -41,7 +41,7 @@ namespace Halibut.Queue.Redis.MessageStorage
         public async Task<ResponseMessage> ReadResponse(RedisStoredMessage storedMessage, CancellationToken cancellationToken)
         {
             var (response, dataStreams) = queueMessageSerializer.ReadMessage<ResponseMessage>(storedMessage.Message);
-            await storeDataStreamsForDistributedQueues.ReHydrateDataStreams(storedMessage.DataStreamMetadata, dataStreams, cancellationToken);
+            await storeDataStreamsForDistributedQueues.RehydrateDataStreams(storedMessage.DataStreamMetadata, dataStreams, cancellationToken);
             return response;
         }
     }

--- a/source/Halibut/Queue/Redis/MessageStorage/MessageSerialiserAndDataStreamStorage.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/MessageSerialiserAndDataStreamStorage.cs
@@ -34,8 +34,8 @@ namespace Halibut.Queue.Redis.MessageStorage
         public async Task<RedisStoredMessage> PrepareResponse(ResponseMessage response, CancellationToken cancellationToken)
         {
             var (jsonResponseMessage, dataStreams) = queueMessageSerializer.WriteMessage(response);
-            var dataStreamMetaData = await storeDataStreamsForDistributedQueues.StoreDataStreams(dataStreams, cancellationToken);
-            return new RedisStoredMessage(jsonResponseMessage, dataStreamMetaData);
+            var dataStreamMetadata = await storeDataStreamsForDistributedQueues.StoreDataStreams(dataStreams, cancellationToken);
+            return new RedisStoredMessage(jsonResponseMessage, dataStreamMetadata);
         }
         
         public async Task<ResponseMessage> ReadResponse(RedisStoredMessage storedMessage, CancellationToken cancellationToken)

--- a/source/Halibut/Queue/Redis/MessageStorage/MessageSerialiserAndDataStreamStorage.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/MessageSerialiserAndDataStreamStorage.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Queue.QueuedDataStreams;
-using Halibut.Queue.Redis.RedisHelpers;
 using Halibut.Transport.Protocol;
 
 namespace Halibut.Queue.Redis.MessageStorage

--- a/source/Halibut/Queue/Redis/MessageStorage/RedisStoredMessage.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/RedisStoredMessage.cs
@@ -4,7 +4,7 @@ namespace Halibut.Queue.Redis.MessageStorage
 {
     public class RedisStoredMessage
     {
-        public RedisStoredMessage(string message, string dataStreamMetadata)
+        public RedisStoredMessage(byte[] message, byte[] dataStreamMetadata)
         {
             Message = message;
             DataStreamMetadata = dataStreamMetadata;
@@ -13,12 +13,12 @@ namespace Halibut.Queue.Redis.MessageStorage
         /// <summary>
         /// Either the Request or Response Message
         /// </summary>
-        public string Message { get; set; }
+        public byte[] Message { get; set; }
         
         /// <summary>
         /// Metadata returned by and given to IStoreDataStreamsForDistributedQueues.
         /// This will be stored in Redis alongside the Message. 
         /// </summary>
-        public string DataStreamMetadata { get; }
+        public byte[] DataStreamMetadata { get; }
     }
 }

--- a/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
+++ b/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
@@ -286,13 +286,13 @@ namespace Halibut.Queue.Redis.RedisHelpers
             
             // As it turns out Redis or our client seems to treat "" as null, which is insane
             // and results in us needing to deal with that here.
-            var dataStreamMetaData = Array.Empty<byte>();
-            if(dict.TryGetValue(DataStreamMetaDataField, out var dataStreamMetaDataFromRedis))
+            var dataStreamMetadata = Array.Empty<byte>();
+            if(dict.TryGetValue(DataStreamMetaDataField, out var dataStreamMetadataFromRedis))
             {
-                dataStreamMetaData = dataStreamMetaDataFromRedis ?? Array.Empty<byte>();
+                dataStreamMetadata = dataStreamMetadataFromRedis ?? Array.Empty<byte>();
             }
             
-            return new RedisStoredMessage(requestMessage, dataStreamMetaData);
+            return new RedisStoredMessage(requestMessage, dataStreamMetadata);
         }
         
         static Dictionary<string, byte[]> RedisStoredMessageToDictionary(RedisStoredMessage requestMessage)

--- a/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
+++ b/source/Halibut/Queue/Redis/RedisHelpers/HalibutRedisTransport.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Halibut.Queue.Redis.MessageStorage;
 using Halibut.Queue.Redis.NodeHeartBeat;
 using Halibut.Util;
-using Microsoft.VisualBasic.CompilerServices;
 using StackExchange.Redis;
 
 namespace Halibut.Queue.Redis.RedisHelpers
@@ -280,25 +279,25 @@ namespace Halibut.Queue.Redis.RedisHelpers
         static readonly string DataStreamMetaDataField = "DataStreamMetaDataField";
         static string[] RedisStoredMessageHashFields => new[] { RequestMessageField, DataStreamMetaDataField };
         
-        static RedisStoredMessage? DictionaryToRedisStoredMessage(Dictionary<string, string?>? dict)
+        static RedisStoredMessage? DictionaryToRedisStoredMessage(Dictionary<string, byte[]?>? dict)
         {
             if(dict == null) return null;
             var requestMessage = dict[RequestMessageField]!;
             
             // As it turns out Redis or our client seems to treat "" as null, which is insane
             // and results in us needing to deal with that here.
-            var dataStreamMetaData = "";
+            var dataStreamMetaData = Array.Empty<byte>();
             if(dict.TryGetValue(DataStreamMetaDataField, out var dataStreamMetaDataFromRedis))
             {
-                dataStreamMetaData = dataStreamMetaDataFromRedis ?? "";
+                dataStreamMetaData = dataStreamMetaDataFromRedis ?? Array.Empty<byte>();
             }
             
             return new RedisStoredMessage(requestMessage, dataStreamMetaData);
         }
         
-        static Dictionary<string, string> RedisStoredMessageToDictionary(RedisStoredMessage requestMessage)
+        static Dictionary<string, byte[]> RedisStoredMessageToDictionary(RedisStoredMessage requestMessage)
         {
-            var dict = new Dictionary<string, string>();
+            var dict = new Dictionary<string, byte[]>();
             dict[RequestMessageField] = requestMessage.Message;
             dict[DataStreamMetaDataField] = requestMessage.DataStreamMetadata;
             return dict;

--- a/source/Halibut/Queue/Redis/RedisHelpers/RedisFacade.cs
+++ b/source/Halibut/Queue/Redis/RedisHelpers/RedisFacade.cs
@@ -201,7 +201,7 @@ namespace Halibut.Queue.Redis.RedisHelpers
             }, cancellationToken);
         }
         
-        public async Task SetInHash(string key, Dictionary<string, string> values, TimeSpan ttl, CancellationToken cancellationToken)
+        public async Task SetInHash(string key, Dictionary<string, byte[]> values, TimeSpan ttl, CancellationToken cancellationToken)
         {
             var hashKey = ToHashKey(key);
 
@@ -231,11 +231,11 @@ namespace Halibut.Queue.Redis.RedisHelpers
             }, cancellationToken);
         }
 
-        public async Task<Dictionary<string, string?>?> TryGetAndDeleteFromHash(string key, string[] fields, CancellationToken cancellationToken)
+        public async Task<Dictionary<string, byte[]?>?> TryGetAndDeleteFromHash(string key, string[] fields, CancellationToken cancellationToken)
         {
             var hashKey = ToHashKey(key);
 
-            Dictionary<string, string?>? dict = await RawKeyReadHashFieldsToDictionary(hashKey, fields, cancellationToken);
+            Dictionary<string, byte[]?>? dict = await RawKeyReadHashFieldsToDictionary(hashKey, fields, cancellationToken);
             
             // Retry does make this non-idempotent, what can happen is the key is deleted on redis.
             // But we do not get a response saying it is deleted. We try again and get told
@@ -256,7 +256,7 @@ namespace Halibut.Queue.Redis.RedisHelpers
             return dict;
         }
         
-        public async Task<Dictionary<string, string?>?> TryGetFromHash(string key, string[] fields, CancellationToken cancellationToken)
+        public async Task<Dictionary<string, byte[]?>?> TryGetFromHash(string key, string[] fields, CancellationToken cancellationToken)
         {
             var hashKey = ToHashKey(key);
 
@@ -275,9 +275,9 @@ namespace Halibut.Queue.Redis.RedisHelpers
             }, cancellationToken);
         }
         
-        async Task<Dictionary<string, string?>?> RawKeyReadHashFieldsToDictionary(RedisKey hashKey, string[] fields, CancellationToken cancellationToken)
+        async Task<Dictionary<string, byte[]?>?> RawKeyReadHashFieldsToDictionary(RedisKey hashKey, string[] fields, CancellationToken cancellationToken)
         {
-            var dict = new Dictionary<string, string?>();
+            var dict = new Dictionary<string, byte[]?>();
             foreach (var field in fields)
             {
                 // Retry each operation independently


### PR DESCRIPTION
# Background

In the Redis PRQ, Request/Response messages and DataStreamMetadata is currently stored as strings.

This is in-efficient for DataStreamMetadata since we would like to be able to store that data as bytes and not need to base64 encode small DataStreams.

Storing the Messages as strings is also a problem for since it prevents:
- encryption of the data.
- compress of the data (e.g. zstd to help minimise the impact from large responses e.g. logs).

This PR changes how both of those are stored to be byte[], additionally support is added for manipulating how we store Request/Response messages in redis to allow for compression and encryption.

This is possible to configure this with `HalibutRuntimeBuilder` using:
```
.WithQueueMessageStreamWrappers(MessageStreamWrappersBuilder
                    .WrapStreamWith(new EncryptingStreamWrapper())
                    .AndThenWrapThatWith(GzipMessageStreamWrapper()))
```

This will result in the Request/Response messages being first gzip compressed/uncompressed and then encrypted/decrypted.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
