### PR TITLE
Add observer for secure connection info

### DIFF
--- a/source/Halibut.Tests/Transport/SecureClientFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureClientFixture.cs
@@ -80,7 +80,7 @@ namespace Halibut.Tests.Transport
                 Params = new object[] { "Fred" }
             };
 
-            var tcpConnectionFactory = new TcpConnectionFactory(Certificates.Octopus, halibutTimeoutsAndLimits, new StreamFactory());
+            var tcpConnectionFactory = new TcpConnectionFactory(Certificates.Octopus, halibutTimeoutsAndLimits, new StreamFactory(), NoOpSecureConnectionObserver.Instance);
             var secureClient = new SecureListeningClient(GetProtocol, endpoint, Certificates.Octopus, log, connectionManager, tcpConnectionFactory);
             ResponseMessage response = null!;
 

--- a/source/Halibut.Tests/Transport/SecureListenerFixture.cs
+++ b/source/Halibut.Tests/Transport/SecureListenerFixture.cs
@@ -73,7 +73,8 @@ namespace Halibut.Tests.Transport
                     (_, _) => UnauthorizedClientConnectResponse.BlockConnection,
                     timeoutsAndLimits,
                     new StreamFactory(),
-                    NoOpConnectionsObserver.Instance
+                    NoOpConnectionsObserver.Instance,
+                    NoOpSecureConnectionObserver.Instance
                 );
 
                 var idleAverage = CollectCounterValues(opsPerSec)

--- a/source/Halibut/HalibutRuntime.cs
+++ b/source/Halibut/HalibutRuntime.cs
@@ -43,6 +43,7 @@ namespace Halibut
         readonly IRpcObserver rpcObserver;
         readonly TcpConnectionFactory tcpConnectionFactory;
         readonly IConnectionsObserver connectionsObserver;
+        readonly ISecureConnectionObserver secureConnectionObserver;
         readonly IActiveTcpConnectionsLimiter activeTcpConnectionsLimiter;
         readonly IControlMessageObserver controlMessageObserver;
 
@@ -59,7 +60,9 @@ namespace Halibut
             IStreamFactory streamFactory,
             IRpcObserver rpcObserver,
             IConnectionsObserver connectionsObserver, 
-            IControlMessageObserver controlMessageObserver)
+            IControlMessageObserver controlMessageObserver,
+            ISecureConnectionObserver secureConnectionObserver
+        )
         {
             this.serverCertificate = serverCertificate;
             this.trustProvider = trustProvider;
@@ -73,10 +76,11 @@ namespace Halibut
             invoker = new ServiceInvoker(serviceFactory);
             TimeoutsAndLimits = halibutTimeoutsAndLimits;
             this.connectionsObserver = connectionsObserver;
+            this.secureConnectionObserver = secureConnectionObserver;
             this.controlMessageObserver = controlMessageObserver;
 
             connectionManager = new ConnectionManagerAsync();
-            this.tcpConnectionFactory = new TcpConnectionFactory(serverCertificate, TimeoutsAndLimits, streamFactory);
+            this.tcpConnectionFactory = new TcpConnectionFactory(serverCertificate, TimeoutsAndLimits, streamFactory, secureConnectionObserver);
             activeTcpConnectionsLimiter = new ActiveTcpConnectionsLimiter(TimeoutsAndLimits);
         }
 
@@ -130,7 +134,9 @@ namespace Halibut
                 HandleUnauthorizedClientConnect,
                 TimeoutsAndLimits,
                 streamFactory,
-                connectionsObserver);
+                connectionsObserver,
+                secureConnectionObserver
+            );
 
             listeners.DoWithExclusiveAccess(l =>
             {

--- a/source/Halibut/HalibutRuntimeBuilder.cs
+++ b/source/Halibut/HalibutRuntimeBuilder.cs
@@ -28,6 +28,7 @@ namespace Halibut
         IStreamFactory? streamFactory;
         IRpcObserver? rpcObserver;
         IConnectionsObserver? connectionsObserver;
+        ISecureConnectionObserver? secureConnectionObserver;
         IControlMessageObserver? controlMessageObserver;
         MessageStreamWrappers queueMessageStreamWrappers = new();
 
@@ -40,6 +41,12 @@ namespace Halibut
         public HalibutRuntimeBuilder WithConnectionsObserver(IConnectionsObserver connectionsObserver)
         {
             this.connectionsObserver = connectionsObserver;
+            return this;
+        }
+
+        public HalibutRuntimeBuilder WithSecureConnectionObserver(ISecureConnectionObserver secureConnectionsObserver)
+        {
+            this.secureConnectionObserver = secureConnectionsObserver;
             return this;
         }
 
@@ -175,6 +182,7 @@ namespace Halibut
             
             var streamFactory = this.streamFactory ?? new StreamFactory();
             var connectionsObserver = this.connectionsObserver ?? NoOpConnectionsObserver.Instance;
+            var secureConnectionObserver = this.secureConnectionObserver ?? NoOpSecureConnectionObserver.Instance;
             var rpcObserver = this.rpcObserver ?? new NoRpcObserver();
             var controlMessageObserver = this.controlMessageObserver ?? new NoOpControlMessageObserver();
 
@@ -191,7 +199,9 @@ namespace Halibut
                 streamFactory,
                 rpcObserver,
                 connectionsObserver,
-                controlMessageObserver);
+                controlMessageObserver,
+                secureConnectionObserver
+            );
 
             if (onUnauthorizedClientConnect is not null)
             {

--- a/source/Halibut/Transport/Observability/ConnectionDirection.cs
+++ b/source/Halibut/Transport/Observability/ConnectionDirection.cs
@@ -1,0 +1,22 @@
+// Copyright 2012-2013 Octopus Deploy Pty. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Halibut.Transport.Observability
+{
+    public enum ConnectionDirection
+    {
+        Incoming,
+        Outgoing
+    }
+}

--- a/source/Halibut/Transport/Observability/ISecureConnectionObserver.cs
+++ b/source/Halibut/Transport/Observability/ISecureConnectionObserver.cs
@@ -1,0 +1,23 @@
+// Copyright 2012-2013 Octopus Deploy Pty. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Security.Authentication;
+
+namespace Halibut.Transport.Observability
+{
+    public interface ISecureConnectionObserver
+    {
+        public void SecureConnectionEstablished(SecureConnectionInfo secureConnectionInfo);
+    }
+}

--- a/source/Halibut/Transport/Observability/NoOpSecureConnectionObserver.cs
+++ b/source/Halibut/Transport/Observability/NoOpSecureConnectionObserver.cs
@@ -1,0 +1,25 @@
+// Copyright 2012-2013 Octopus Deploy Pty. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Halibut.Transport.Observability
+{
+    public class NoOpSecureConnectionObserver : ISecureConnectionObserver
+    {
+        static NoOpSecureConnectionObserver? singleInstance;
+        public static NoOpSecureConnectionObserver Instance => singleInstance ??= new NoOpSecureConnectionObserver();
+        public void SecureConnectionEstablished(SecureConnectionInfo secureConnectionInfo)
+        {
+        }
+    }
+}

--- a/source/Halibut/Transport/Observability/SecureConnectionInfo.cs
+++ b/source/Halibut/Transport/Observability/SecureConnectionInfo.cs
@@ -18,7 +18,19 @@ namespace Halibut.Transport.Observability
 {
     public struct SecureConnectionInfo
     {
-        public SslProtocols SslProtocols { get; init; }
-        public ConnectionDirection ConnectionDirection { get; init; }
+        SecureConnectionInfo(
+            SslProtocols sslProtocols,
+            ConnectionDirection connectionDirection
+        )
+        {
+            SslProtocols = sslProtocols;
+            ConnectionDirection = connectionDirection;
+        }
+
+        public SslProtocols SslProtocols { get; }
+        public ConnectionDirection ConnectionDirection { get; }
+
+        public static SecureConnectionInfo CreateIncoming(SslProtocols sslProtocols) => new(sslProtocols, ConnectionDirection.Incoming);
+        public static SecureConnectionInfo CreateOutgoing(SslProtocols sslProtocols) => new(sslProtocols, ConnectionDirection.Outgoing);
     }
 }

--- a/source/Halibut/Transport/Observability/SecureConnectionInfo.cs
+++ b/source/Halibut/Transport/Observability/SecureConnectionInfo.cs
@@ -20,17 +20,33 @@ namespace Halibut.Transport.Observability
     {
         SecureConnectionInfo(
             SslProtocols sslProtocols,
-            ConnectionDirection connectionDirection
+            ConnectionDirection connectionDirection,
+            string thumbprint
         )
         {
             SslProtocols = sslProtocols;
             ConnectionDirection = connectionDirection;
+            Thumbprint = thumbprint;
         }
 
         public SslProtocols SslProtocols { get; }
         public ConnectionDirection ConnectionDirection { get; }
+        public string Thumbprint { get; }
 
-        public static SecureConnectionInfo CreateIncoming(SslProtocols sslProtocols) => new(sslProtocols, ConnectionDirection.Incoming);
-        public static SecureConnectionInfo CreateOutgoing(SslProtocols sslProtocols) => new(sslProtocols, ConnectionDirection.Outgoing);
+        public static SecureConnectionInfo CreateIncoming(
+            SslProtocols sslProtocols,
+            string thumbprint
+        )
+        {
+            return new SecureConnectionInfo(sslProtocols, ConnectionDirection.Incoming, thumbprint);
+        }
+
+        public static SecureConnectionInfo CreateOutgoing(
+            SslProtocols sslProtocols,
+            string thumbprint
+        )
+        {
+            return new(sslProtocols, ConnectionDirection.Outgoing, thumbprint);
+        }
     }
 }

--- a/source/Halibut/Transport/Observability/SecureConnectionInfo.cs
+++ b/source/Halibut/Transport/Observability/SecureConnectionInfo.cs
@@ -1,0 +1,24 @@
+// Copyright 2012-2013 Octopus Deploy Pty. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Security.Authentication;
+
+namespace Halibut.Transport.Observability
+{
+    public struct SecureConnectionInfo
+    {
+        public SslProtocols SslProtocols { get; init; }
+        public ConnectionDirection ConnectionDirection { get; init; }
+    }
+}

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -48,6 +48,7 @@ namespace Halibut.Transport
         readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
         readonly IStreamFactory streamFactory;
         readonly IConnectionsObserver connectionsObserver;
+        readonly ISecureConnectionObserver secureConnectionObserver;
         ILog log;
         TcpListener listener;
         Thread? backgroundThread;
@@ -67,7 +68,9 @@ namespace Halibut.Transport
             Func<string, string, UnauthorizedClientConnectResponse> unauthorizedClientConnect,
             HalibutTimeoutsAndLimits halibutTimeoutsAndLimits,
             IStreamFactory streamFactory,
-            IConnectionsObserver connectionsObserver)
+            IConnectionsObserver connectionsObserver,
+            ISecureConnectionObserver secureConnectionObserver
+        )
         {
             this.endPoint = endPoint;
             this.serverCertificate = serverCertificate;
@@ -81,6 +84,7 @@ namespace Halibut.Transport
             this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
             this.streamFactory = streamFactory;
             this.connectionsObserver = connectionsObserver;
+            this.secureConnectionObserver = secureConnectionObserver;
             this.cts = new CancellationTokenSource();
             this.cancellationToken = cts.Token;
 
@@ -336,6 +340,13 @@ namespace Halibut.Transport
                     {
                         connectionAuthorizedAndObserved = true;
                         connectionsObserver.ConnectionAccepted(true);
+                        secureConnectionObserver.SecureConnectionEstablished(
+                            new SecureConnectionInfo
+                            {
+                                ConnectionDirection = ConnectionDirection.Incoming,
+                                SslProtocols = ssl.SslProtocol
+                            }
+                        );
                         tcpClientManager.AddActiveClient(thumbprint, client);
                         errorEventType = EventType.Error;
                         await ExchangeMessages(ssl).ConfigureAwait(false);

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -340,13 +340,7 @@ namespace Halibut.Transport
                     {
                         connectionAuthorizedAndObserved = true;
                         connectionsObserver.ConnectionAccepted(true);
-                        secureConnectionObserver.SecureConnectionEstablished(
-                            new SecureConnectionInfo
-                            {
-                                ConnectionDirection = ConnectionDirection.Incoming,
-                                SslProtocols = ssl.SslProtocol
-                            }
-                        );
+                        secureConnectionObserver.SecureConnectionEstablished(SecureConnectionInfo.CreateIncoming(ssl.SslProtocol));
                         tcpClientManager.AddActiveClient(thumbprint, client);
                         errorEventType = EventType.Error;
                         await ExchangeMessages(ssl).ConfigureAwait(false);

--- a/source/Halibut/Transport/SecureListener.cs
+++ b/source/Halibut/Transport/SecureListener.cs
@@ -340,7 +340,7 @@ namespace Halibut.Transport
                     {
                         connectionAuthorizedAndObserved = true;
                         connectionsObserver.ConnectionAccepted(true);
-                        secureConnectionObserver.SecureConnectionEstablished(SecureConnectionInfo.CreateIncoming(ssl.SslProtocol));
+                        secureConnectionObserver.SecureConnectionEstablished(SecureConnectionInfo.CreateIncoming(ssl.SslProtocol, thumbprint));
                         tcpClientManager.AddActiveClient(thumbprint, client);
                         errorEventType = EventType.Error;
                         await ExchangeMessages(ssl).ConfigureAwait(false);

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -68,7 +68,7 @@ namespace Halibut.Transport
             await ssl.FlushAsync(cancellationToken);
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
-            secureConnectionObserver.SecureConnectionEstablished(SecureConnectionInfo.CreateOutgoing(ssl.SslProtocol));
+            secureConnectionObserver.SecureConnectionEstablished(SecureConnectionInfo.CreateOutgoing(ssl.SslProtocol, serviceEndpoint.RemoteThumbprint ?? "Unknown"));
 
             return new SecureConnection(client, ssl, exchangeProtocolBuilder, halibutTimeoutsAndLimits, log);
         }

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -68,13 +68,7 @@ namespace Halibut.Transport
             await ssl.FlushAsync(cancellationToken);
 
             log.Write(EventType.Security, "Secure connection established. Server at {0} identified by thumbprint: {1}, using protocol {2}", client.Client.RemoteEndPoint, serviceEndpoint.RemoteThumbprint, ssl.SslProtocol.ToString());
-            secureConnectionObserver.SecureConnectionEstablished(
-                new SecureConnectionInfo
-                {
-                    ConnectionDirection = ConnectionDirection.Outgoing,
-                    SslProtocols = ssl.SslProtocol
-                }
-            );
+            secureConnectionObserver.SecureConnectionEstablished(SecureConnectionInfo.CreateOutgoing(ssl.SslProtocol));
 
             return new SecureConnection(client, ssl, exchangeProtocolBuilder, halibutTimeoutsAndLimits, log);
         }


### PR DESCRIPTION
# Background

We want to be able to track the TLS protocol versions used in secure connections. This pull request adds an `ISecureConnectionObserver` which can be used to determine the protocol used for incoming and outgoing secure TCP connections.

# Results

When secure connections are established (and authorized), a call will be made to the observer providing key details of the connection:

- Whether the connection is incoming or outgoing
- The thumbprint associated with the connection
- The TLS protocol used by the connection

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
