### PR TITLE
Don't call RegisterType twice for each RPC and with the redis queue it was 4 times!

### DIFF
--- a/source/Halibut.Tests/Queue/QueueMessageSerializerBuilder.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerBuilder.cs
@@ -36,6 +36,7 @@ namespace Halibut.Tests.Queue
         public QueueMessageSerializer Build()
         {
             var typeRegistry = this.typeRegistry ?? new TypeRegistry();
+            RegisteredSerializationBinder.AddProtocolTupesToTypeRegistry(typeRegistry);
 
             StreamCapturingJsonSerializer StreamCapturingSerializer()
             {

--- a/source/Halibut.Tests/Queue/QueueMessageSerializerBuilder.cs
+++ b/source/Halibut.Tests/Queue/QueueMessageSerializerBuilder.cs
@@ -36,7 +36,7 @@ namespace Halibut.Tests.Queue
         public QueueMessageSerializer Build()
         {
             var typeRegistry = this.typeRegistry ?? new TypeRegistry();
-            RegisteredSerializationBinder.AddProtocolTupesToTypeRegistry(typeRegistry);
+            RegisteredSerializationBinder.AddProtocolTypesToTypeRegistry(typeRegistry);
 
             StreamCapturingJsonSerializer StreamCapturingSerializer()
             {

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -59,6 +59,8 @@ namespace Halibut.Transport.Protocol
                 configureSerializer?.Invoke(settings);
                 return new StreamCapturingJsonSerializer(settings);
             }
+            
+            RegisteredSerializationBinder.AddProtocolTupesToTypeRegistry(typeRegistry);
 
             var messageSerializerObserver = this.messageSerializerObserver ?? new NoMessageSerializerObserver();
 

--- a/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
+++ b/source/Halibut/Transport/Protocol/MessageSerializerBuilder.cs
@@ -60,7 +60,7 @@ namespace Halibut.Transport.Protocol
                 return new StreamCapturingJsonSerializer(settings);
             }
             
-            RegisteredSerializationBinder.AddProtocolTupesToTypeRegistry(typeRegistry);
+            RegisteredSerializationBinder.AddProtocolTypesToTypeRegistry(typeRegistry);
 
             var messageSerializerObserver = this.messageSerializerObserver ?? new NoMessageSerializerObserver();
 

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -23,7 +23,6 @@ namespace Halibut.Transport.Protocol
         internal RegisteredSerializationBinder(ITypeRegistry typeRegistry)
         {
             this.typeRegistry = typeRegistry;
-            
         }
 
         public Type BindToType(string? assemblyName, string typeName)

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -16,7 +16,10 @@ namespace Halibut.Transport.Protocol
 
         public static void AddProtocolTypesToTypeRegistry(ITypeRegistry typeRegistry)
         {
-            foreach (var protocolType in protocolTypes) typeRegistry.RegisterType(protocolType, protocolType.Name, true);
+            foreach (var protocolType in protocolTypes)
+            {
+                typeRegistry.RegisterType(protocolType, protocolType.Name, true);
+            }
         }
         // kept for backwards compatibility.
 

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -6,17 +6,24 @@ namespace Halibut.Transport.Protocol
     public class RegisteredSerializationBinder : ISerializationBinder
     {
         readonly ISerializationBinder baseBinder = new DefaultSerializationBinder();
-        readonly Type[] protocolTypes = { typeof(ResponseMessage), typeof(RequestMessage) };
+        static readonly Type[] protocolTypes = { typeof(ResponseMessage), typeof(RequestMessage) };
         readonly ITypeRegistry typeRegistry;
 
         public RegisteredSerializationBinder() : this(new TypeRegistry())
         {
-        } // kept for backwards compatibility.
+            AddProtocolTupesToTypeRegistry(this.typeRegistry);
+        }
+
+        public static void AddProtocolTupesToTypeRegistry(ITypeRegistry typeRegistry)
+        {
+            foreach (var protocolType in protocolTypes) typeRegistry.RegisterType(protocolType, protocolType.Name, true);
+        }
+        // kept for backwards compatibility.
 
         internal RegisteredSerializationBinder(ITypeRegistry typeRegistry)
         {
             this.typeRegistry = typeRegistry;
-            foreach (var protocolType in protocolTypes) typeRegistry.RegisterType(protocolType, protocolType.Name, true);
+            
         }
 
         public Type BindToType(string? assemblyName, string typeName)

--- a/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
+++ b/source/Halibut/Transport/Protocol/RegisteredSerializationBinder.cs
@@ -11,10 +11,10 @@ namespace Halibut.Transport.Protocol
 
         public RegisteredSerializationBinder() : this(new TypeRegistry())
         {
-            AddProtocolTupesToTypeRegistry(this.typeRegistry);
+            AddProtocolTypesToTypeRegistry(this.typeRegistry);
         }
 
-        public static void AddProtocolTupesToTypeRegistry(ITypeRegistry typeRegistry)
+        public static void AddProtocolTypesToTypeRegistry(ITypeRegistry typeRegistry)
         {
             foreach (var protocolType in protocolTypes) typeRegistry.RegisterType(protocolType, protocolType.Name, true);
         }


### PR DESCRIPTION
# Background

We would re-register the types each time the serializer was built, since that is built with this lambda each time we serialise or deserialize a message:

<img width="825" height="283" alt="image" src="https://github.com/user-attachments/assets/03191683-ec9d-4e83-9285-4e670918e5e8" />

With these changes we just register the types once, rather than over and over again.

This as a hot spot was somehow found with a profiler.

With this change we instead call register once for the Request and Response types rather than each time we serialise or deserialise a message (including in and out of the queue). This should have no impact other than improving performance.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
