### PR TITLE
Dont create ConcurrentBag within CancelOnDisposeCancellationToken unless required

### DIFF
--- a/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
+++ b/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
@@ -34,7 +34,7 @@ namespace Halibut.Util
         readonly CancellationTokenSource cancellationTokenSource;
         bool disposed;
 
-        readonly ConcurrentBag<Task> tasks = new();
+        ConcurrentBag<Task>? tasks = null;
         
         public CancelOnDisposeCancellationToken(params CancellationToken[] token)
             : this(CancellationTokenSource.CreateLinkedTokenSource(token))
@@ -64,7 +64,10 @@ namespace Halibut.Util
             await Try.IgnoringError(async () => await CancelAsync());
 
             // Wait for any tasks that are using the token, before disposal
-            await Task.WhenAll(tasks.Select(t => Try.IgnoringError(() => t)));
+            if (tasks != null)
+            {
+                await Task.WhenAll(tasks.Select(t => Try.IgnoringError(() => t)));
+            }
 
             Try.IgnoringError(() => cancellationTokenSource.Dispose());
         }
@@ -86,14 +89,19 @@ namespace Halibut.Util
 
         /// <summary>
         /// Tasks supplied here will be awaited on in the dispose method after
-        /// the Token is cancelled and before the token is disposed. 
+        /// the Token is cancelled and before the token is disposed.
+        /// Not thread safe. 
         /// </summary>
         /// <param name="tasksUsingToken"></param>
         public void AwaitTasksBeforeCTSDispose(params Task[] tasksUsingToken)
         {
+            if (tasks == null)
+            {
+                Interlocked.CompareExchange(ref tasks, new ConcurrentBag<Task>(), null);
+            }
             foreach (var task in tasksUsingToken)
             {
-                tasks.Add(task);
+                tasks!.Add(task);
             }
         }
     }

--- a/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
+++ b/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
@@ -97,7 +97,8 @@ namespace Halibut.Util
         {
             if (tasks == null)
             {
-                Interlocked.CompareExchange(ref tasks, new ConcurrentBag<Task>(), null);
+                var newBag = new ConcurrentBag<Task>();
+                Interlocked.CompareExchange(ref tasks, newBag, null);
             }
             foreach (var task in tasksUsingToken)
             {

--- a/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
+++ b/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
@@ -90,7 +90,7 @@ namespace Halibut.Util
         /// <summary>
         /// Tasks supplied here will be awaited on in the dispose method after
         /// the Token is cancelled and before the token is disposed.
-        /// Not thread safe. 
+        /// Thread safe: uses Interlocked.CompareExchange for initialization and ConcurrentBag for storage.
         /// </summary>
         /// <param name="tasksUsingToken"></param>
         public void AwaitTasksBeforeCTSDispose(params Task[] tasksUsingToken)


### PR DESCRIPTION
# Background

The profiler kept showing that within the ConcurrentBag was a place that time is spent, this PR removes that.
Its likely it showed up because of how many `CancelOnDisposeCancellationToken`s are created for each request in the Redis PRQ.

This should not have a functional change on the queue.

I don't think the resource drop will be in anyway significant, but if the profiler can stop showing this as a hot spot that might make it easier to find what is taking time.

# How to review this PR


Did I use the test and set correctly?
<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
