### PR TITLE
Reduce the number of calls made to Redis when the RPC is fast.

### DIFF
--- a/source/Halibut.Tests/Builders/IPendingRequestQueueBuilder.cs
+++ b/source/Halibut.Tests/Builders/IPendingRequestQueueBuilder.cs
@@ -8,6 +8,7 @@ namespace Halibut.Tests.Builders
         public IPendingRequestQueueBuilder WithEndpoint(string endpoint);
         public IPendingRequestQueueBuilder WithLog(ILog log);
         public IPendingRequestQueueBuilder WithPollingQueueWaitTimeout(TimeSpan? pollingQueueWaitTimeout);
+        public IPendingRequestQueueBuilder WithDelayBeforeCheckingForCancellation(TimeSpan defaultDelayBeforeSubscribingToRequestCancellation);
         public QueueHolder Build();
     }
 }

--- a/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
+++ b/source/Halibut.Tests/Builders/PendingRequestQueueBuilder.cs
@@ -32,6 +32,11 @@ namespace Halibut.Tests.Builders
             return this;
         }
 
+        public IPendingRequestQueueBuilder WithDelayBeforeCheckingForCancellation(TimeSpan defaultDelayBeforeSubscribingToRequestCancellation)
+        {
+            return this;
+        }
+
         public QueueHolder Build()
         {
             var endpoint = this.endpoint ?? "poll://endpoint001";

--- a/source/Halibut.Tests/Queue/QueuedDataStreams/HeartBeatMessageFixture.cs
+++ b/source/Halibut.Tests/Queue/QueuedDataStreams/HeartBeatMessageFixture.cs
@@ -108,3 +108,4 @@ namespace Halibut.Tests.Queue.QueuedDataStreams
         }
     }
 }
+

--- a/source/Halibut.Tests/Queue/QueuedDataStreams/HeartBeatMessageFixture.cs
+++ b/source/Halibut.Tests/Queue/QueuedDataStreams/HeartBeatMessageFixture.cs
@@ -108,4 +108,3 @@ namespace Halibut.Tests.Queue.QueuedDataStreams
         }
     }
 }
-

--- a/source/Halibut.Tests/Queue/Redis/NodeHeartBeat/NodeHeartBeatSenderFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/NodeHeartBeat/NodeHeartBeatSenderFixture.cs
@@ -24,6 +24,7 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
     [RedisTest]
     public class NodeHeartBeatSenderFixture : BaseTest
     {
+        static readonly HeartBeatInitialDelay ZeroDelay = new(TimeSpan.Zero);
         [Test]
         public async Task WhenCreated_ShouldStartSendingHeartbeats()
         {
@@ -45,7 +46,7 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 }, CancellationToken);
 
             // Act
-            await using var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1));
+            await using var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1), ZeroDelay);
             
             // Wait for a heart beat.
             await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(20), CancellationToken), anyHeartBeatReceived.WaitAsync());
@@ -84,7 +85,7 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                     }, CancellationToken);
 
             // Act
-            await using var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), TimeSpan.FromSeconds(1));
+            await using var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), TimeSpan.FromSeconds(1), ZeroDelay);
             
             // Wait for initial heartbeat
             await heartBeatReceivedEvent.WaitAsync(CancellationToken);
@@ -126,7 +127,7 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 }, CancellationToken);
 
             // Act
-            var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1));
+            var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1), ZeroDelay);
             
             // Wait for some heartbeats
             await anyHeartBeatReceived.WaitAsync(CancellationToken);
@@ -173,7 +174,8 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 log,
                 HalibutQueueNodeSendingPulses.RequestProcessorNode,
                 () => new HeartBeatMessage(),
-                defaultDelayBetweenPulses: TimeSpan.FromMilliseconds(200));
+                defaultDelayBetweenPulses: TimeSpan.FromMilliseconds(200),
+                ZeroDelay);
             
             // Mark request as collected so watcher proceeds to monitoring phase
             await pendingRequest.RequestHasBeenCollectedAndWillBeTransferred();
@@ -233,7 +235,8 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 log,
                 HalibutQueueNodeSendingPulses.RequestProcessorNode,
                 () => new HeartBeatMessage(),
-                defaultDelayBetweenPulses: TimeSpan.FromMilliseconds(200));
+                defaultDelayBetweenPulses: TimeSpan.FromMilliseconds(200),
+                ZeroDelay);
             
             // Mark request as collected so watcher proceeds to monitoring phase
             await pendingRequest.RequestHasBeenCollectedAndWillBeTransferred();
@@ -293,7 +296,8 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 log,
                 HalibutQueueNodeSendingPulses.RequestProcessorNode,
                 () => new HeartBeatMessage(),
-                defaultDelayBetweenPulses: TimeSpan.FromMilliseconds(200));
+                defaultDelayBetweenPulses: TimeSpan.FromMilliseconds(200),
+                ZeroDelay);
             
             // Mark request as collected so watcher proceeds to monitoring phase
             await pendingRequest.RequestHasBeenCollectedAndWillBeTransferred();
@@ -336,7 +340,7 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
             var pendingRequest = new RedisPendingRequest(request, log);
             await pendingRequest.RequestHasBeenCollectedAndWillBeTransferred();
             
-            await using var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), TimeSpan.FromSeconds(1));
+            await using var heartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), TimeSpan.FromSeconds(1), ZeroDelay);
             
             using var watcherCts = new CancellationTokenSource();
             var watcherTask = NodeHeartBeatWatcher.WatchThatNodeProcessingTheRequestIsStillAlive(
@@ -390,13 +394,13 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 }, CancellationToken);
 
             // Act - Create sender node heartbeat sender
-            await using var senderHeartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestSenderNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1));
+            await using var senderHeartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestSenderNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1), ZeroDelay);
             
             // Wait for sender heartbeat
             await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(5), CancellationToken), senderHeartbeatsReceived.WaitAsync());
 
             // Create receiver node heartbeat sender
-            await using var receiverHeartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1));
+            await using var receiverHeartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestProcessorNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1), ZeroDelay);
             
             // Wait for receiver heartbeat
             await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(5), CancellationToken), receiverHeartbeatsReceived.WaitAsync());
@@ -427,7 +431,7 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 }, CancellationToken);
 
             // Act - Create sender node heartbeat sender (should not trigger receiver subscription)
-            await using var senderHeartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestSenderNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1));
+            await using var senderHeartBeatSender = new NodeHeartBeatSender(endpoint, requestActivityId, redisTransport, log, HalibutQueueNodeSendingPulses.RequestSenderNode, () => new HeartBeatMessage(), defaultDelayBetweenPulses: TimeSpan.FromSeconds(1), ZeroDelay);
             
             // Wait to see if receiver subscription gets triggered (it shouldn't)
             await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(3), CancellationToken), receiverHeartbeatsReceived.WaitAsync());
@@ -472,7 +476,8 @@ namespace Halibut.Tests.Queue.Redis.NodeHeartBeat
                 log, 
                 HalibutQueueNodeSendingPulses.RequestProcessorNode, 
                 () => new HeartBeatMessage { DataStreamProgress = new Dictionary<Guid, long>(currentDataStreamProgress) }, 
-                TimeSpan.FromMilliseconds(500));
+                TimeSpan.FromMilliseconds(500),
+                ZeroDelay);
             
             // Start the watcher that will receive the heartbeat messages
             using var watcherCts = new CancellationTokenSource();

--- a/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisPendingRequestQueueFixture.cs
@@ -10,6 +10,7 @@ using Halibut.Logging;
 using Halibut.Queue;
 using Halibut.Queue.MessageStreamWrapping;
 using Halibut.Queue.Redis;
+using Halibut.Queue.Redis.Cancellation;
 using Halibut.Queue.Redis.Exceptions;
 using Halibut.Queue.Redis.MessageStorage;
 using Halibut.Queue.Redis.NodeHeartBeat;
@@ -120,6 +121,61 @@ namespace Halibut.Tests.Queue.Redis
             responseMessage.Result.Should().Be("Yay");
         }
         
+        [Test]
+        public async Task WhenTheRequestIsQuicklyProcessedTheNumberOfRequestToRedisShouldBeLimited()
+        {
+            // Arrange
+            var endpoint = new Uri("poll://" + Guid.NewGuid());
+            await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade();
+            var baseRedisTransport = new HalibutRedisTransport(redisFacade);
+            var callCountingTransport = new CallCountingHalibutRedisTransport(baseRedisTransport);
+
+            var request = new RequestMessageBuilder("poll://test-endpoint").Build();
+
+            var node1Sender = new RedisPendingRequestQueue(endpoint, new RedisNeverLosesData(), HalibutLog, callCountingTransport, CreateMessageSerialiserAndDataStreamStorage(), new HalibutTimeoutsAndLimits());
+            await node1Sender.WaitUntilQueueIsSubscribedToReceiveMessages();
+
+            // Act
+            var queueAndWaitAsync = node1Sender.QueueAndWaitAsync(request, CancellationToken.None);
+
+            var requestMessageWithCancellationToken = await node1Sender.DequeueAsync(CancellationToken);
+
+            requestMessageWithCancellationToken.Should().NotBeNull();
+            requestMessageWithCancellationToken!.RequestMessage.Id.Should().Be(request.Id);
+            requestMessageWithCancellationToken.RequestMessage.MethodName.Should().Be(request.MethodName);
+            requestMessageWithCancellationToken.RequestMessage.ServiceName.Should().Be(request.ServiceName);
+
+            var response = ResponseMessage.FromResult(requestMessageWithCancellationToken.RequestMessage, "Yay");
+            await node1Sender.ApplyResponse(response, requestMessageWithCancellationToken.RequestMessage.ActivityId);
+
+            var responseMessage = await queueAndWaitAsync;
+
+            // Assert
+            responseMessage.Result.Should().Be("Yay");
+            
+            // Verify that Redis calls are limited for a quickly processed request
+            // These are the expected calls for a successful request/response cycle:
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.SubscribeToRequestMessagePulseChannel)).Should().Be(1, "Should subscribe to pulse channel once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.PutRequest)).Should().Be(1, "Should put request once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.PushRequestGuidOnToQueue)).Should().Be(1, "Should push request GUID once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.PulseRequestPushedToEndpoint)).Should().Be(1, "Should pulse endpoint once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.TryGetAndRemoveRequest)).Should().Be(1, "Should get and remove request once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.SubscribeToResponseChannel)).Should().Be(1, "Should subscribe to response channel once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.SetResponseMessage)).Should().Be(1, "Should set response message once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.PublishThatResponseIsAvailable)).Should().Be(1, "Should publish response availability once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.GetResponseMessage)).Should().Be(1, "Should get response message once");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.DeleteResponseMessage)).Should().Be(1, "Should delete response message once");
+            
+            // These methods should NOT be called for a quickly processed successful request:
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.IsRequestStillOnQueue)).Should().Be(0, "Should not need to check if request is still on queue for quick processing");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.SubscribeToRequestCancellation)).Should().Be(0, "Should not need cancellation subscription for successful request");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.PublishCancellation)).Should().Be(0, "Should not publish cancellation for successful request");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.MarkRequestAsCancelled)).Should().Be(0, "Should not mark request as cancelled for successful request");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.IsRequestMarkedAsCancelled)).Should().Be(0, "Should not check if request is cancelled for successful request");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.SubscribeToNodeHeartBeatChannel)).Should().Be(0, "Should not need heartbeat subscription for quickly processed request");
+            callCountingTransport.GetCallCount(nameof(callCountingTransport.SendNodeHeartBeat)).Should().Be(0, "Should not send heartbeats for quickly processed request");
+        }
+        
         
         [Test]
         public async Task TheProcessingTimeOfARequestCanExceedWatcherTimeouts()
@@ -139,6 +195,8 @@ namespace Halibut.Tests.Queue.Redis
             
             node1Sender.RequestSenderNodeHeartBeatRate = TimeSpan.FromMilliseconds(100);
             node1Sender.RequestReceiverNodeHeartBeatRate = TimeSpan.FromMilliseconds(100);
+            node1Sender.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            node1Sender.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
             
             var queueAndWaitAsync = node1Sender.QueueAndWaitAsync(request, CancellationToken.None);
             var requestMessageWithCancellationToken = await node1Sender.DequeueAsync(CancellationToken);
@@ -219,6 +277,8 @@ namespace Halibut.Tests.Queue.Redis
             var queue = new RedisPendingRequestQueue(endpoint, new RedisNeverLosesData(), HalibutLog, redisTransport, messageReaderWriter, new HalibutTimeoutsAndLimits());
             queue.RequestReceiverNodeHeartBeatRate = TimeSpan.FromMilliseconds(100);
             queue.TimeBetweenCheckingIfRequestWasCollected = TimeSpan.FromMilliseconds(100);
+            queue.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            queue.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
             
             await queue.WaitUntilQueueIsSubscribedToReceiveMessages();
 
@@ -750,6 +810,10 @@ namespace Halibut.Tests.Queue.Redis
             node2Receiver.RequestReceiverNodeHeartBeatRate = TimeSpan.FromSeconds(1);
             node1Sender.RequestReceiverNodeHeartBeatTimeout = TimeSpan.FromSeconds(10);
             node2Receiver.RequestReceiverNodeHeartBeatTimeout = TimeSpan.FromSeconds(10);
+            node1Sender.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            node1Sender.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
+            node2Receiver.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            node2Receiver.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
 
             // Act
             var request = new RequestMessageBuilder("poll://test-endpoint").Build();
@@ -803,6 +867,10 @@ namespace Halibut.Tests.Queue.Redis
             node2Receiver.RequestSenderNodeHeartBeatTimeout = TimeSpan.FromSeconds(10);
             node1Sender.TimeBetweenCheckingIfRequestWasCollected = TimeSpan.FromSeconds(1);
             node2Receiver.TimeBetweenCheckingIfRequestWasCollected = TimeSpan.FromSeconds(1);
+            node1Sender.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            node1Sender.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
+            node2Receiver.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            node2Receiver.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
 
             var request = new RequestMessageBuilder("poll://test-endpoint").Build();
 
@@ -1008,6 +1076,8 @@ namespace Halibut.Tests.Queue.Redis
             request.Params = new[] { new ComplexObjectMultipleDataStreams(DataStream.FromString("hello"), DataStream.FromString("world")) };
 
             var node1Sender = new RedisPendingRequestQueue(endpoint, new RedisNeverLosesData(), log, redisTransport, messageReaderWriter, new HalibutTimeoutsAndLimits());
+            node1Sender.DelayBeforeSubscribingToRequestCancellation = new DelayBeforeSubscribingToRequestCancellation(TimeSpan.Zero);
+            node1Sender.HeartBeatInitialDelay = new HeartBeatInitialDelay(TimeSpan.Zero);
             await node1Sender.WaitUntilQueueIsSubscribedToReceiveMessages();
 
             using var cts = new CancellationTokenSource();

--- a/source/Halibut.Tests/Queue/Redis/Utils/CallCountingHalibutRedisTransport.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/CallCountingHalibutRedisTransport.cs
@@ -1,0 +1,137 @@
+#if NET8_0_OR_GREATER
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Queue.Redis.MessageStorage;
+using Halibut.Queue.Redis.NodeHeartBeat;
+using Halibut.Queue.Redis.RedisHelpers;
+using StackExchange.Redis;
+
+namespace Halibut.Tests.Queue.Redis.Utils
+{
+    public class CallCountingHalibutRedisTransport : IHalibutRedisTransport
+    {
+        readonly IHalibutRedisTransport inner;
+        readonly ConcurrentDictionary<string, int> callCounts = new();
+
+        public CallCountingHalibutRedisTransport(IHalibutRedisTransport inner)
+        {
+            this.inner = inner;
+        }
+
+        public int GetCallCount(string methodName) => callCounts.GetOrAdd(methodName, 0);
+
+        void IncrementCallCount(string methodName) => callCounts.AddOrUpdate(methodName, 1, (_, count) => count + 1);
+
+        public Task<IAsyncDisposable> SubscribeToRequestMessagePulseChannel(Uri endpoint, Action<ChannelMessage> onRequestMessagePulse, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(SubscribeToRequestMessagePulseChannel));
+            return inner.SubscribeToRequestMessagePulseChannel(endpoint, onRequestMessagePulse, cancellationToken);
+        }
+
+        public Task PulseRequestPushedToEndpoint(Uri endpoint, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(PulseRequestPushedToEndpoint));
+            return inner.PulseRequestPushedToEndpoint(endpoint, cancellationToken);
+        }
+
+        public Task PushRequestGuidOnToQueue(Uri endpoint, Guid guid, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(PushRequestGuidOnToQueue));
+            return inner.PushRequestGuidOnToQueue(endpoint, guid, cancellationToken);
+        }
+
+        public Task<Guid?> TryPopNextRequestGuid(Uri endpoint, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(TryPopNextRequestGuid));
+            return inner.TryPopNextRequestGuid(endpoint, cancellationToken);
+        }
+
+        public Task PutRequest(Uri endpoint, Guid requestId, RedisStoredMessage requestMessage, TimeSpan requestPickupTimeout, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(PutRequest));
+            return inner.PutRequest(endpoint, requestId, requestMessage, requestPickupTimeout, cancellationToken);
+        }
+
+        public Task<RedisStoredMessage?> TryGetAndRemoveRequest(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(TryGetAndRemoveRequest));
+            return inner.TryGetAndRemoveRequest(endpoint, requestId, cancellationToken);
+        }
+
+        public Task<bool> IsRequestStillOnQueue(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(IsRequestStillOnQueue));
+            return inner.IsRequestStillOnQueue(endpoint, requestId, cancellationToken);
+        }
+
+        public Task<IAsyncDisposable> SubscribeToRequestCancellation(Uri endpoint, Guid requestId, Func<Task> onRpcCancellation, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(SubscribeToRequestCancellation));
+            return inner.SubscribeToRequestCancellation(endpoint, requestId, onRpcCancellation, cancellationToken);
+        }
+
+        public Task PublishCancellation(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(PublishCancellation));
+            return inner.PublishCancellation(endpoint, requestId, cancellationToken);
+        }
+
+        public Task MarkRequestAsCancelled(Uri endpoint, Guid requestId, TimeSpan ttl, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(MarkRequestAsCancelled));
+            return inner.MarkRequestAsCancelled(endpoint, requestId, ttl, cancellationToken);
+        }
+
+        public Task<bool> IsRequestMarkedAsCancelled(Uri endpoint, Guid requestId, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(IsRequestMarkedAsCancelled));
+            return inner.IsRequestMarkedAsCancelled(endpoint, requestId, cancellationToken);
+        }
+
+        public Task<IAsyncDisposable> SubscribeToNodeHeartBeatChannel(Uri endpoint, Guid requestId, HalibutQueueNodeSendingPulses nodeSendingPulsesType, Func<string, Task> onHeartBeat, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(SubscribeToNodeHeartBeatChannel));
+            return inner.SubscribeToNodeHeartBeatChannel(endpoint, requestId, nodeSendingPulsesType, onHeartBeat, cancellationToken);
+        }
+
+        public Task SendNodeHeartBeat(Uri endpoint, Guid requestId, HalibutQueueNodeSendingPulses nodeSendingPulsesType, string nodeHeartBeatMessage, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(SendNodeHeartBeat));
+            return inner.SendNodeHeartBeat(endpoint, requestId, nodeSendingPulsesType, nodeHeartBeatMessage, cancellationToken);
+        }
+
+        public Task<IAsyncDisposable> SubscribeToResponseChannel(Uri endpoint, Guid identifier, Func<string, Task> onValueReceived, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(SubscribeToResponseChannel));
+            return inner.SubscribeToResponseChannel(endpoint, identifier, onValueReceived, cancellationToken);
+        }
+
+        public Task PublishThatResponseIsAvailable(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(PublishThatResponseIsAvailable));
+            return inner.PublishThatResponseIsAvailable(endpoint, identifier, cancellationToken);
+        }
+
+        public Task SetResponseMessage(Uri endpoint, Guid identifier, RedisStoredMessage responseMessage, TimeSpan ttl, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(SetResponseMessage));
+            return inner.SetResponseMessage(endpoint, identifier, responseMessage, ttl, cancellationToken);
+        }
+
+        public Task<RedisStoredMessage?> GetResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(GetResponseMessage));
+            return inner.GetResponseMessage(endpoint, identifier, cancellationToken);
+        }
+
+        public Task DeleteResponseMessage(Uri endpoint, Guid identifier, CancellationToken cancellationToken)
+        {
+            IncrementCallCount(nameof(DeleteResponseMessage));
+            return inner.DeleteResponseMessage(endpoint, identifier, cancellationToken);
+        }
+    }
+}
+#endif
+

--- a/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
+++ b/source/Halibut.Tests/ServiceModel/PendingRequestQueueFixture.cs
@@ -405,6 +405,7 @@ namespace Halibut.Tests.ServiceModel
             await using var queueHolder = queueTestCase.Builder
                 .WithEndpoint(endpoint)
                 .WithPollingQueueWaitTimeout(TimeSpan.Zero) // Remove delay, otherwise we wait the full 20 seconds for DequeueAsync at the end of the test
+                .WithDelayBeforeCheckingForCancellation(TimeSpan.Zero)
                 .Build();
             var sut = queueHolder.PendingRequestQueue;
 

--- a/source/Halibut/Queue/Redis/Cancellation/DelayBeforeSubscribingToRequestCancellation.cs
+++ b/source/Halibut/Queue/Redis/Cancellation/DelayBeforeSubscribingToRequestCancellation.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Queue.Redis.Cancellation
+{
+    public class DelayBeforeSubscribingToRequestCancellation
+    {
+        public DelayBeforeSubscribingToRequestCancellation(TimeSpan delay)
+        {
+            Delay = delay;
+        }
+
+        public TimeSpan Delay { get; }
+        
+        public async Task WaitBeforeHeartBeatSendingOrReceiving(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(Delay, cancellationToken);
+            }
+            catch
+            {
+                // If only Delay had an option to not throw.
+            }
+        }
+    }
+}

--- a/source/Halibut/Queue/Redis/NodeHeartBeat/HeartBeatInitialDelay.cs
+++ b/source/Halibut/Queue/Redis/NodeHeartBeat/HeartBeatInitialDelay.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Halibut.Queue.Redis.NodeHeartBeat
+{
+    public class HeartBeatInitialDelay
+    {
+        public HeartBeatInitialDelay(TimeSpan initialDelay)
+        {
+            InitialDelay = initialDelay;
+        }
+
+        public TimeSpan InitialDelay { get; }
+
+        public async Task WaitBeforeHeartBeatSendingOrReceiving(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(InitialDelay, cancellationToken);
+            }
+            catch
+            {
+                // If only Delay had an option to not throw.
+            }
+        }
+    }
+}

--- a/source/Halibut/Queue/Redis/RedisPendingRequest.cs
+++ b/source/Halibut/Queue/Redis/RedisPendingRequest.cs
@@ -234,6 +234,8 @@ namespace Halibut.Queue.Redis
         {
             transferLock?.Dispose();
         }
+
+        public bool HasResponseBeenSet() => responseWaiter.IsSet;
     }
     
 }

--- a/source/Halibut/Queue/Redis/RedisPendingRequestQueue.cs
+++ b/source/Halibut/Queue/Redis/RedisPendingRequestQueue.cs
@@ -394,7 +394,7 @@ namespace Halibut.Queue.Redis
                     () => HeartBeatMessage.Build(dataStreamsTransferProgress),
                     RequestReceiverNodeHeartBeatRate,
                     HeartBeatInitialDelay));
-                var watcher = new WatchForRequestCancellationOrSenderDisconnect(endpoint, pendingRequest.ActivityId, halibutRedisTransport, RequestSenderNodeHeartBeatTimeout, HeartBeatInitialDelay, DefaultDelayBeforeSubscribingToRequestCancellation, log);
+                var watcher = new WatchForRequestCancellationOrSenderDisconnect(endpoint, pendingRequest.ActivityId, halibutRedisTransport, RequestSenderNodeHeartBeatTimeout, HeartBeatInitialDelay, DelayBeforeSubscribingToRequestCancellation, log);
                 disposables.AddAsyncDisposable(watcher);
                 
                 var cts = new CancelOnDisposeCancellationToken(watcher.RequestProcessingCancellationToken, dataLossCT);


### PR DESCRIPTION
# Background

To reduce CPU usage mainly of the Halibut Queue (than Redis), with this PR we avoid as many calls as possible to Redis for fast RPC calls. Where fast is in the order of seconds or less.

With this change, for fast RPCs we:
- Don't send heart beats.
- Don't subscribe to hearts.
- Don't subscribe to the cancellation channel.

Our testing shows a reduction of about 10% in CPU usage with this type of change.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
