### PR TITLE
Concurrent collections in Dotnet are not as safe as they seem

### DIFF
--- a/source/Halibut.Tests/Queue/Redis/Utils/CallCountingHalibutRedisTransport.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/CallCountingHalibutRedisTransport.cs
@@ -20,9 +20,23 @@ namespace Halibut.Tests.Queue.Redis.Utils
             this.inner = inner;
         }
 
-        public int GetCallCount(string methodName) => callCounts.GetOrAdd(methodName, 0);
+        object mutex = new object();
 
-        void IncrementCallCount(string methodName) => callCounts.AddOrUpdate(methodName, 1, (_, count) => count + 1);
+        public int GetCallCount(string methodName)
+        {
+            lock (mutex)
+            {
+                return callCounts.GetOrAdd(methodName, 0);
+            }
+        }
+
+        void IncrementCallCount(string methodName)
+        {
+            lock (mutex)
+            {
+                callCounts.AddOrUpdate(methodName, 1, (_, count) => count + 1);
+            }
+        }
 
         public Task<IAsyncDisposable> SubscribeToRequestMessagePulseChannel(Uri endpoint, Action<ChannelMessage> onRequestMessagePulse, CancellationToken cancellationToken)
         {

--- a/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
+++ b/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
@@ -90,7 +90,7 @@ namespace Halibut.Util
         /// <summary>
         /// Tasks supplied here will be awaited on in the dispose method after
         /// the Token is cancelled and before the token is disposed.
-        /// Thread safe: uses Interlocked.CompareExchange for initialization and ConcurrentBag for storage.
+        /// Must be called before dispose is called.
         /// </summary>
         /// <param name="tasksUsingToken"></param>
         public void AwaitTasksBeforeCTSDispose(params Task[] tasksUsingToken)

--- a/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
+++ b/source/Halibut/Util/CancelOnDisposeCancellationToken.cs
@@ -97,10 +97,7 @@ namespace Halibut.Util
         {
             lock (tasks)
             {
-                foreach (var task in tasksUsingToken)
-                {
-                    tasks.Add(task);
-                }
+                tasks.AddRange(tasksUsingToken);
             }
         }
     }


### PR DESCRIPTION
# Background

Concurrent dictionary appears to be surprising in that `Func` passed to it are not executed in what one would consider to be "thread safe", so resort to manual locking.

ConcurrentBag does interesting things with thread locals, which has lead to strange memory leaks:
- https://github.com/autofac/Autofac/pull/1257

so lets just not use it.

For background read: https://octopusdeploy.slack.com/archives/CMESRJ1C3/p1703022896511849

This change is not because we have been seeing issues, but is done preemptively to prevent issues. 

The only non test change is the one done to the Redis PRQ.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
