### PR TITLE
Add TryGetTokenForDataLossDetection method to avoid unnecessary CancellationTokenSource creation and Timer creation on every RPC

### DIFF
--- a/source/Halibut.Tests/Queue/Redis/RedisDataLoseDetection/WatchForRedisLosingAllItsDataFixture.cs
+++ b/source/Halibut.Tests/Queue/Redis/RedisDataLoseDetection/WatchForRedisLosingAllItsDataFixture.cs
@@ -25,6 +25,18 @@ namespace Halibut.Tests.Queue.Redis.RedisDataLoseDetection
         }
         
         [Test]
+        public async Task WhenTheConnectionToRedisCanBeEstablished_AndSomeoneHasAlreadyGotTheCancellationToken_TryGetCancellationTokenReturnsTheCT()
+        {
+            await using var redisFacade = RedisFacadeBuilder.CreateRedisFacade();
+            await using var watcher = new WatchForRedisLosingAllItsData(redisFacade, HalibutLog, watchInterval:TimeSpan.FromSeconds(1));
+
+
+            await watcher.GetTokenForDataLossDetection(TimeSpan.FromSeconds(5), CancellationToken);
+
+            watcher.TryGetTokenForDataLossDetection().Should().NotBeNull();
+        }
+        
+        [Test]
         public async Task WhenTheConnectionToRedisIsInitiallyDown_WhenAskingForALostDataCancellationToken_AndTheConnectionToRedisReturns_TheCancellationTokenIsReturned()
         {
             using var portForwarder = PortForwardingToRedisBuilder.ForwardingToRedis(Logger);

--- a/source/Halibut.Tests/Queue/Redis/Utils/CancellableDataLossWatchForRedisLosingAllItsData.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/CancellableDataLossWatchForRedisLosingAllItsData.cs
@@ -37,5 +37,14 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return await TaskCompletionSource.Task;
 #pragma warning restore VSTHRD003
         }
+
+        public CancellationToken? TryGetTokenForDataLossDetection()
+        {
+            if (TaskCompletionSource.Task.IsCompleted && TaskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
+            {
+                return TaskCompletionSource.Task.Result;
+            }
+            return null;
+        }
     }
 }

--- a/source/Halibut.Tests/Queue/Redis/Utils/RedisNeverLosesData.cs
+++ b/source/Halibut.Tests/Queue/Redis/Utils/RedisNeverLosesData.cs
@@ -19,6 +19,11 @@ namespace Halibut.Tests.Queue.Redis.Utils
             return Task.FromResult(CancellationToken.None);
         }
 
+        public CancellationToken? TryGetTokenForDataLossDetection()
+        {
+            return CancellationToken.None;
+        }
+
         public ValueTask DisposeAsync()
         {
             return ValueTask.CompletedTask;

--- a/source/Halibut/Queue/Redis/RedisDataLossDetection/IWatchForRedisLosingAllItsData.cs
+++ b/source/Halibut/Queue/Redis/RedisDataLossDetection/IWatchForRedisLosingAllItsData.cs
@@ -14,5 +14,12 @@ namespace Halibut.Queue.Redis.RedisDataLossDetection
         /// <param name="cancellationToken"></param>
         /// <returns>A cancellation token which is triggered when data loss occurs.</returns>
         Task<CancellationToken> GetTokenForDataLossDetection(TimeSpan timeToWait, CancellationToken cancellationToken);
+        
+        /// <summary>
+        /// Tries to get a cancellation token for data loss detection if monitoring is already active.
+        /// This method returns immediately without waiting.
+        /// </summary>
+        /// <returns>A cancellation token if monitoring is active, null if monitoring is not yet ready.</returns>
+        CancellationToken? TryGetTokenForDataLossDetection();
     }
 }

--- a/source/Halibut/Queue/Redis/RedisDataLossDetection/WatchForRedisLosingAllItsData.cs
+++ b/source/Halibut/Queue/Redis/RedisDataLossDetection/WatchForRedisLosingAllItsData.cs
@@ -53,14 +53,15 @@ namespace Halibut.Queue.Redis.RedisDataLossDetection
         /// <returns>A cancellation token which is triggered when data lose occurs.</returns>
         public async Task<CancellationToken> GetTokenForDataLossDetection(TimeSpan timeToWait, CancellationToken cancellationToken)
         {
-            if (taskCompletionSource.Task.IsCompleted)
+            var localCopyOfTaskCompletionSource = taskCompletionSource;
+            if (localCopyOfTaskCompletionSource.Task.IsCompleted)
             {
-                return await taskCompletionSource.Task;
+                return await localCopyOfTaskCompletionSource.Task;
             }
             
             await using var cts = new CancelOnDisposeCancellationToken(cancellationToken);
             cts.CancelAfter(timeToWait);
-            return await taskCompletionSource.Task.WaitAsync(cts.Token);
+            return await localCopyOfTaskCompletionSource.Task.WaitAsync(cts.Token);
         }
         
 
@@ -74,7 +75,7 @@ namespace Halibut.Queue.Redis.RedisDataLossDetection
             var localCopyOfTaskCompletionSource = taskCompletionSource;
             if (localCopyOfTaskCompletionSource.Task.IsCompleted && localCopyOfTaskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
             {
-                return taskCompletionSource.Task.Result;
+                return localCopyOfTaskCompletionSource.Task.Result;
             }
             return null;
         }

--- a/source/Halibut/Queue/Redis/RedisDataLossDetection/WatchForRedisLosingAllItsData.cs
+++ b/source/Halibut/Queue/Redis/RedisDataLossDetection/WatchForRedisLosingAllItsData.cs
@@ -43,7 +43,7 @@ namespace Halibut.Queue.Redis.RedisDataLossDetection
             var _ = Task.Run(async () => await KeepWatchingForDataLoss(cts.Token));
         }
 
-        private TaskCompletionSource<CancellationToken> taskCompletionSource = new TaskCompletionSource<CancellationToken>();
+        TaskCompletionSource<CancellationToken> taskCompletionSource = new TaskCompletionSource<CancellationToken>();
         
         /// <summary>
         /// Will cause the caller to wait until we are connected to redis and so can detect datalose.
@@ -63,7 +63,6 @@ namespace Halibut.Queue.Redis.RedisDataLossDetection
             cts.CancelAfter(timeToWait);
             return await localCopyOfTaskCompletionSource.Task.WaitAsync(cts.Token);
         }
-        
 
         /// <summary>
         /// Tries to get a cancellation token for data loss detection if monitoring is already active.

--- a/source/Halibut/Queue/Redis/RedisDataLossDetection/WatchForRedisLosingAllItsData.cs
+++ b/source/Halibut/Queue/Redis/RedisDataLossDetection/WatchForRedisLosingAllItsData.cs
@@ -62,6 +62,22 @@ namespace Halibut.Queue.Redis.RedisDataLossDetection
             cts.CancelAfter(timeToWait);
             return await taskCompletionSource.Task.WaitAsync(cts.Token);
         }
+        
+
+        /// <summary>
+        /// Tries to get a cancellation token for data loss detection if monitoring is already active.
+        /// This method returns immediately without waiting.
+        /// </summary>
+        /// <returns>A cancellation token if monitoring is active, null if monitoring is not yet ready.</returns>
+        public CancellationToken? TryGetTokenForDataLossDetection()
+        {
+            var localCopyOfTaskCompletionSource = taskCompletionSource;
+            if (localCopyOfTaskCompletionSource.Task.IsCompleted && localCopyOfTaskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
+            {
+                return taskCompletionSource.Task.Result;
+            }
+            return null;
+        }
 
         private async Task KeepWatchingForDataLoss(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
# Background

This is a simple change to reduce the amount of work we do. In most cases we will already have a Data Loss CT which means we can avoid creating multiple CTS and delayed tasks that will immediately throw.

Additionally the methods are updated such that we work on a consistent TaskCompletionSource since that value is replaced.

We are aiming to reduce as much work as possible in the normal case, to reduce queue overhead.

The AI wrote this:

- Added TryGetTokenForDataLossDetection() method to IWatchForRedisLosingAllItsData interface
- Implemented the method in WatchForRedisLosingAllItsData to return token immediately if monitoring is active
- Updated RedisPendingRequestQueue to use try method first, falling back to GetTokenForDataLossDetection
- Updated test implementations (RedisNeverLosesData and CancellableDataLossWatchForRedisLosingAllItsData)
- Improves performance by avoiding CancellationTokenSource allocation when monitoring is already ready
- Maintains backward compatibility with existing GetTokenForDataLossDetection method


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
