### PR TITLE
Don't use concurrent bag it is slow

### DIFF
--- a/source/Halibut/Queue/QueuedDataStreams/HeartBeatDrivenDataStreamProgressReporter.cs
+++ b/source/Halibut/Queue/QueuedDataStreams/HeartBeatDrivenDataStreamProgressReporter.cs
@@ -60,17 +60,18 @@ namespace Halibut.Queue.QueuedDataStreams
 
         public async ValueTask DisposeAsync()
         {
+            if(dataStreamsToReportProgressOn.IsEmpty) return;
             // Since we may not get a HeartBeatMessage stating that the DataStreams have been completely transferred,
             // this object is disposable and on dispose we note that file will no longer be uploading. Which
             // for the normal percentage based file transfer progress will result in marking the DataStreams as 100% uploaded.
             // If we don't do this at the end of a successful call we may find DataStream progress is reported as less than 100%.
-            var localCopyCompletedDataStreams = new List<Guid>();
+            HashSet<Guid> localCopyCompletedDataStreams;
             
             // Because of where this is used, it is hard to be sure the completedDataStreams won't be modified while disposing,
             // so take a copy of streams to work with.
             lock (completedDataStreams)
             {
-                localCopyCompletedDataStreams.AddRange(completedDataStreams);
+                localCopyCompletedDataStreams = new HashSet<Guid>(completedDataStreams);
             }
             foreach (var keyValuePair in dataStreamsToReportProgressOn)
             {


### PR DESCRIPTION
# Background
See:
- https://github.com/OctopusDeploy/Halibut/pull/688
For some context on concurrent collections.

This removes a usage of ConcurrentBag that was detected by the profiler, because it was taking enough CPU time to be detected. We replace it with a much faster to create HashSet.

Ordinarily we do not have any DataStreams to report on so we will never actually need to make use of mutex.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
