### PR TITLE
Don't log messages, this could cause a memory leak

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -191,7 +191,7 @@ namespace Halibut.Transport.Protocol
             var serializedStreams = await serializer.WriteMessageAsync(stream, message, cancellationToken);
             await WriteEachStreamAsync(serializedStreams, cancellationToken);
             
-            log.Write(EventType.Diagnostic, "Sent: {0}", message);
+            log.Write(EventType.Diagnostic, "Sent message");
         }
 
         public async Task<RequestMessage?> ReceiveRequestAsync(TimeSpan timeoutForReceivingTheFirstByte, CancellationToken cancellationToken)
@@ -217,7 +217,7 @@ namespace Halibut.Transport.Protocol
         {
             var (result, dataStreams) = await serializer.ReadMessageAsync<T>(stream, cancellationToken);
             await ReadStreamsAsync(dataStreams, cancellationToken);
-            log.Write(EventType.Diagnostic, "Received: {0}", result);
+            log.Write(EventType.Diagnostic, "Received Message");
             return result;
         }
 


### PR DESCRIPTION
# Background

We have an in memory logger that retains the last n (I think 100) messages in memory. If that logger is configured to be used (which is something we do) then we would be holding on to sent and received messages in memory.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
