### PR TITLE
Collected requests do not fail in a connecting state

### DIFF
--- a/source/Halibut/Queue/Redis/RedisPendingRequest.cs
+++ b/source/Halibut/Queue/Redis/RedisPendingRequest.cs
@@ -145,8 +145,7 @@ namespace Halibut.Queue.Redis
                         log.Write(EventType.MessageExchange, "Request {0} was cancelled before a response was received", request);
                         SetResponseNoLock(ResponseMessage.FromException(
                                 request,
-                                new TimeoutException("A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded."),
-                                ConnectionState.Connecting),
+                                new TimeoutException("A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded.")),
                             requestWasCollected: false);
                         await Try.IgnoringError(async () => await pendingRequestCancellationTokenSource.CancelAsync());
                     }

--- a/source/Halibut/Queue/Redis/RedisPendingRequest.cs
+++ b/source/Halibut/Queue/Redis/RedisPendingRequest.cs
@@ -146,7 +146,7 @@ namespace Halibut.Queue.Redis
                         SetResponseNoLock(ResponseMessage.FromException(
                                 request,
                                 new TimeoutException("A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded.")),
-                            requestWasCollected: false);
+                            requestWasCollected: true);
                         await Try.IgnoringError(async () => await pendingRequestCancellationTokenSource.CancelAsync());
                     }
                 }

--- a/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
+++ b/source/Halibut/ServiceModel/PendingRequestQueueAsync.cs
@@ -273,8 +273,7 @@ namespace Halibut.ServiceModel
                             log.Write(EventType.MessageExchange, "Request {0} was cancelled before a response was received", request);
                             SetResponse(ResponseMessage.FromException(
                                 request, 
-                                new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded."),
-                                ConnectionState.Connecting));
+                                new TimeoutException($"A request was sent to a polling endpoint, the polling endpoint collected it but the request was cancelled before the polling endpoint responded.")));
                         }
                         else
                         {


### PR DESCRIPTION
# Background

If polling tentacle has collected the request then we are NOT in the state of connecting. The tentacle has potentially received and processed the request, we don't know and:

-> we can't know.

<img width="230" height="193" alt="image" src="https://github.com/user-attachments/assets/fa4349d3-0f09-4046-9087-bf70b8b33819" />


# Results

It is not clear if the code paths changed can ever be reached! At least I could not see how to craft a test that reaches them. In any case if they can be reached then this fixes cases where TentacleClient is wrongly assuming the request has not been collected and so is assuming the request has not started.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
