### PR TITLE
Include the length of time we have spent downloading DataStreams in the error message raised when we can't get the entire DataStream

### DIFF
--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -363,7 +363,7 @@ namespace Halibut.Transport.Protocol
 
             public string MessageId { get; }
             public Stopwatch Stopwatch { get; }
-            public long TotalSizeOfAllDataStreams { get; init; }
+            public long TotalSizeOfAllDataStreams { get; set; }
         }
 
         static DataStream FindStreamById(IReadOnlyList<DataStream> deserializedStreams, Guid id)

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -265,24 +265,26 @@ namespace Halibut.Transport.Protocol
 
         async Task ReadStreamsAsync(string messageId, IReadOnlyList<DataStream> deserializedStreams, CancellationToken cancellationToken)
         {
-            var stopWatchForDownloadingAllStreams = Stopwatch.StartNew();
+            var context = new DataStreamTransferContext(messageId)
+            {
+                TotalSizeOfAllDataStreams = deserializedStreams.Select(d => d.Length).Sum()
+            };
             var expected = deserializedStreams.Count;
 
             for (var i = 0; i < expected; i++)
             {
-                await ReadStreamAsync(messageId, deserializedStreams, stopWatchForDownloadingAllStreams, cancellationToken);
+                await ReadStreamAsync(context, deserializedStreams, cancellationToken);
             }
         }
 
-        async Task ReadStreamAsync(string messageId, IReadOnlyList<DataStream> deserializedStreams, Stopwatch stopWatchForDownloadingAllStreams, CancellationToken cancellationToken)
+        async Task ReadStreamAsync(DataStreamTransferContext context, IReadOnlyList<DataStream> deserializedStreams, CancellationToken cancellationToken)
         {
             var id = new Guid(await stream.ReadBytesAsync(16, cancellationToken));
             var length = await stream.ReadInt64Async(cancellationToken);
             var dataStream = FindStreamById(deserializedStreams, id);
-            long totalSizeOfAllDataStreams = deserializedStreams.Select(d => d.Length).Sum();
-            
-            var tempFile = await CopyStreamToFileAsync(id, length, stream, messageId, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams, cancellationToken);
-            
+
+            var tempFile = await CopyStreamToFileAsync(id, length, stream, context, cancellationToken);
+
             var lengthAgain = await stream.ReadInt64Async(cancellationToken);
             if (lengthAgain != length)
             {
@@ -290,17 +292,17 @@ namespace Halibut.Transport.Protocol
                                            "Expected length: {2}, Actual length claimed at end: {3}. " +
                                            "Total length of all DataStreams to be sent is {4}. " +
                                            "Time elapsed downloading all streams: {5}ms",
-                                            messageId, id, length, lengthAgain, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams.ElapsedMilliseconds);
-                throw new ProtocolException($"Data stream size mismatch detected. Message Id: {messageId}, Stream ID: {id}, " +
+                                            context.MessageId, id, length, lengthAgain, context.TotalSizeOfAllDataStreams, context.Stopwatch.ElapsedMilliseconds);
+                throw new ProtocolException($"Data stream size mismatch detected. Message Id: {context.MessageId}, Stream ID: {id}, " +
                                             $"Expected length: {length}, Actual length claimed at end: {lengthAgain}. " +
-                                            $"Total length of all DataStreams to be sent is {totalSizeOfAllDataStreams}. " +
-                                            $"Time elapsed downloading all streams: {stopWatchForDownloadingAllStreams.ElapsedMilliseconds}ms");
+                                            $"Total length of all DataStreams to be sent is {context.TotalSizeOfAllDataStreams}. " +
+                                            $"Time elapsed downloading all streams: {context.Stopwatch.ElapsedMilliseconds}ms");
             }
 
             ((IDataStreamInternal)dataStream).Received(tempFile);
         }
-        
-        async Task<TemporaryFileStream> CopyStreamToFileAsync(Guid dataStreamId, long dataSteamLength, Stream networkStream, string messageId, long totalSizeOfAllDataStreams, Stopwatch stopWatchForDownloadingAllStreams, CancellationToken cancellationToken)
+
+        async Task<TemporaryFileStream> CopyStreamToFileAsync(Guid dataStreamId, long dataSteamLength, Stream networkStream, DataStreamTransferContext context, CancellationToken cancellationToken)
         {
             var path = Path.Combine(Path.GetTempPath(), string.Format("{0}_{1}", dataStreamId.ToString(), Interlocked.Increment(ref streamCount)));
             long bytesLeftToRead = dataSteamLength;
@@ -324,10 +326,10 @@ namespace Halibut.Transport.Protocol
                                                             "Total length of all DataStreams to be sent is {4}. " +
                                                             "Time elapsed downloading all streams: {5}ms.",
                                                     ex,
-                                                   messageId, dataStreamId, dataSteamLength, dataSteamLength - bytesLeftToRead, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams.ElapsedMilliseconds);
+                                                   context.MessageId, dataStreamId, dataSteamLength, dataSteamLength - bytesLeftToRead, context.TotalSizeOfAllDataStreams, context.Stopwatch.ElapsedMilliseconds);
                         throw;
                     }
-                    
+
                     if (read == 0)
                     {
                         var bytesRead = dataSteamLength - bytesLeftToRead;
@@ -336,19 +338,32 @@ namespace Halibut.Transport.Protocol
                                                    "Expected length: {2}, Actual bytes read: {3}. " +
                                                    "Total length of all DataStreams to be sent is {4}. " +
                                                    "Time elapsed downloading all streams: {5}ms.",
-                                                   messageId, dataStreamId, dataSteamLength, bytesRead, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams.ElapsedMilliseconds);
-                        throw new ProtocolException($"Data stream reading failed. Message Id: {messageId}, Stream ID: {dataStreamId}, " +
+                                                   context.MessageId, dataStreamId, dataSteamLength, bytesRead, context.TotalSizeOfAllDataStreams, context.Stopwatch.ElapsedMilliseconds);
+                        throw new ProtocolException($"Data stream reading failed. Message Id: {context.MessageId}, Stream ID: {dataStreamId}, " +
                                                     $"Expected length: {dataSteamLength}, Actual bytes read: {bytesRead}. " +
-                                                    $"Total length of all DataStreams to be sent is {totalSizeOfAllDataStreams}. " +
+                                                    $"Total length of all DataStreams to be sent is {context.TotalSizeOfAllDataStreams}. " +
                                                     $"Stream with length {dataSteamLength} was closed after only reading {bytesRead} bytes. " +
-                                                    $"Time elapsed downloading all streams: {stopWatchForDownloadingAllStreams.ElapsedMilliseconds}ms.");
+                                                    $"Time elapsed downloading all streams: {context.Stopwatch.ElapsedMilliseconds}ms.");
                     }
-                    
+
                     bytesLeftToRead -= read;
                     await fileStream.WriteAsync(buffer, 0, read, cancellationToken);
                 }
             }
             return new TemporaryFileStream(path, log);
+        }
+
+        class DataStreamTransferContext
+        {
+            public DataStreamTransferContext(string messageId)
+            {
+                MessageId = messageId;
+                Stopwatch = Stopwatch.StartNew();
+            }
+
+            public string MessageId { get; }
+            public Stopwatch Stopwatch { get; }
+            public long TotalSizeOfAllDataStreams { get; init; }
         }
 
         static DataStream FindStreamById(IReadOnlyList<DataStream> deserializedStreams, Guid id)
@@ -366,8 +381,11 @@ namespace Halibut.Transport.Protocol
         async Task WriteEachStreamAsync(string messageId, IEnumerable<DataStream> streams, CancellationToken cancellationToken)
         {
             var streamsList = streams.ToList();
-            var totalDataStreamLength = streamsList.Select(d => d.Length).Sum();
-            
+            var context = new DataStreamTransferContext(messageId)
+            {
+                TotalSizeOfAllDataStreams = streamsList.Select(d => d.Length).Sum()
+            };
+
             foreach (var dataStream in streamsList)
             {
                 await stream.WriteByteArrayAsync(dataStream.Id.ToByteArray(), cancellationToken);
@@ -383,13 +401,13 @@ namespace Halibut.Transport.Protocol
                     log.Write(EventType.Error, "Data stream size mismatch detected during send. Message ID: {0}, Stream ID: {1}, " +
                                                "Declared length: {2}, Actual bytes written: {3}. " +
                                                "Total length of all DataStreams to be sent is {4}",
-                                               messageId, dataStream.Id, dataStream.Length, byteCountingStream.BytesWritten, totalDataStreamLength);
-                    
+                                               context.MessageId, dataStream.Id, dataStream.Length, byteCountingStream.BytesWritten, context.TotalSizeOfAllDataStreams);
+
                     if (halibutTimeoutsAndLimits.ThrowOnDataStreamSizeMismatch)
                     {
-                        throw new ProtocolException($"Data stream size mismatch detected during send. Message Id: {messageId}, Stream ID: {dataStream.Id}, " +
+                        throw new ProtocolException($"Data stream size mismatch detected during send. Message Id: {context.MessageId}, Stream ID: {dataStream.Id}, " +
                                                     $"Declared length: {dataStream.Length}, Actual bytes written: {byteCountingStream.BytesWritten}. " +
-                                                    $"Total length of all DataStreams to be sent is {totalDataStreamLength}.");
+                                                    $"Total length of all DataStreams to be sent is {context.TotalSizeOfAllDataStreams}.");
                     }
                 }
 

--- a/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
+++ b/source/Halibut/Transport/Protocol/MessageExchangeStream.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Authentication;
@@ -220,7 +221,8 @@ namespace Halibut.Transport.Protocol
             var (result, dataStreams) = await serializer.ReadMessageAsync<T>(stream, cancellationToken);
             if (dataStreams.Count > 0)
             {
-                await ReadStreamsAsync(result?.Id ?? "", dataStreams, cancellationToken);
+                var messageId = result?.Id ?? "Unknown";
+                await ReadStreamsAsync(messageId, dataStreams, cancellationToken);
             }
             log.Write(EventType.Diagnostic, "Received Message");
             return result;
@@ -263,40 +265,42 @@ namespace Halibut.Transport.Protocol
 
         async Task ReadStreamsAsync(string messageId, IReadOnlyList<DataStream> deserializedStreams, CancellationToken cancellationToken)
         {
+            var stopWatchForDownloadingAllStreams = Stopwatch.StartNew();
             var expected = deserializedStreams.Count;
 
             for (var i = 0; i < expected; i++)
             {
-                await ReadStreamAsync(messageId, deserializedStreams, cancellationToken);
+                await ReadStreamAsync(messageId, deserializedStreams, stopWatchForDownloadingAllStreams, cancellationToken);
             }
         }
 
-        async Task ReadStreamAsync(string messageId, IReadOnlyList<DataStream> deserializedStreams, CancellationToken cancellationToken)
+        async Task ReadStreamAsync(string messageId, IReadOnlyList<DataStream> deserializedStreams, Stopwatch stopWatchForDownloadingAllStreams, CancellationToken cancellationToken)
         {
-            
             var id = new Guid(await stream.ReadBytesAsync(16, cancellationToken));
             var length = await stream.ReadInt64Async(cancellationToken);
             var dataStream = FindStreamById(deserializedStreams, id);
             long totalSizeOfAllDataStreams = deserializedStreams.Select(d => d.Length).Sum();
             
-            var tempFile = await CopyStreamToFileAsync(id, length, stream, messageId, totalSizeOfAllDataStreams, cancellationToken);
+            var tempFile = await CopyStreamToFileAsync(id, length, stream, messageId, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams, cancellationToken);
             
             var lengthAgain = await stream.ReadInt64Async(cancellationToken);
             if (lengthAgain != length)
             {
                 log.Write(EventType.Error, "Data stream size mismatch detected. Message ID: {0}, Stream ID: {1}, " +
                                            "Expected length: {2}, Actual length claimed at end: {3}. " +
-                                           "Total length of all DataStreams to be sent is {4}", 
-                                            messageId, id, length, lengthAgain, totalSizeOfAllDataStreams);
+                                           "Total length of all DataStreams to be sent is {4}. " +
+                                           "Time elapsed downloading all streams: {5}ms",
+                                            messageId, id, length, lengthAgain, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams.ElapsedMilliseconds);
                 throw new ProtocolException($"Data stream size mismatch detected. Message Id: {messageId}, Stream ID: {id}, " +
                                             $"Expected length: {length}, Actual length claimed at end: {lengthAgain}. " +
-                                            $"Total length of all DataStreams to be sent is {totalSizeOfAllDataStreams}");
+                                            $"Total length of all DataStreams to be sent is {totalSizeOfAllDataStreams}. " +
+                                            $"Time elapsed downloading all streams: {stopWatchForDownloadingAllStreams.ElapsedMilliseconds}ms");
             }
 
             ((IDataStreamInternal)dataStream).Received(tempFile);
         }
         
-        async Task<TemporaryFileStream> CopyStreamToFileAsync(Guid dataStreamId, long dataSteamLength, Stream networkStream, string messageId, long totalSizeOfAllDataStreams, CancellationToken cancellationToken)
+        async Task<TemporaryFileStream> CopyStreamToFileAsync(Guid dataStreamId, long dataSteamLength, Stream networkStream, string messageId, long totalSizeOfAllDataStreams, Stopwatch stopWatchForDownloadingAllStreams, CancellationToken cancellationToken)
         {
             var path = Path.Combine(Path.GetTempPath(), string.Format("{0}_{1}", dataStreamId.ToString(), Interlocked.Increment(ref streamCount)));
             long bytesLeftToRead = dataSteamLength;
@@ -317,9 +321,10 @@ namespace Halibut.Transport.Protocol
                     {
                         log.WriteException(EventType.Error, "Data stream reading failed. Message ID: {0}, Stream ID: {1}, " +
                                                             "Expected length: {2}, Actual bytes read: {3}. " +
-                                                            "Total length of all DataStreams to be sent is {4}.",
+                                                            "Total length of all DataStreams to be sent is {4}. " +
+                                                            "Time elapsed downloading all streams: {5}ms.",
                                                     ex,
-                                                   messageId, dataStreamId, dataSteamLength, dataSteamLength - bytesLeftToRead, totalSizeOfAllDataStreams);
+                                                   messageId, dataStreamId, dataSteamLength, dataSteamLength - bytesLeftToRead, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams.ElapsedMilliseconds);
                         throw;
                     }
                     
@@ -329,12 +334,14 @@ namespace Halibut.Transport.Protocol
                         log.Write(EventType.Error, "Data stream reading failed, we read zero bytes from the stream which implies EOF." +
                                                    "Message ID: {0}, Stream ID: {1}, " +
                                                    "Expected length: {2}, Actual bytes read: {3}. " +
-                                                   "Total length of all DataStreams to be sent is {4}.", 
-                                                   messageId, dataStreamId, dataSteamLength, bytesRead, totalSizeOfAllDataStreams);
+                                                   "Total length of all DataStreams to be sent is {4}. " +
+                                                   "Time elapsed downloading all streams: {5}ms.",
+                                                   messageId, dataStreamId, dataSteamLength, bytesRead, totalSizeOfAllDataStreams, stopWatchForDownloadingAllStreams.ElapsedMilliseconds);
                         throw new ProtocolException($"Data stream reading failed. Message Id: {messageId}, Stream ID: {dataStreamId}, " +
                                                     $"Expected length: {dataSteamLength}, Actual bytes read: {bytesRead}. " +
                                                     $"Total length of all DataStreams to be sent is {totalSizeOfAllDataStreams}. " +
-                                                    $"Stream with length {dataSteamLength} was closed after only reading {bytesRead} bytes.");
+                                                    $"Stream with length {dataSteamLength} was closed after only reading {bytesRead} bytes. " +
+                                                    $"Time elapsed downloading all streams: {stopWatchForDownloadingAllStreams.ElapsedMilliseconds}ms.");
                     }
                     
                     bytesLeftToRead -= read;


### PR DESCRIPTION
# Background

ref CLOUDPT-11160
ref EFT-3141

In the issue we are looking at, it would be ideal to understand how long the service has been receiving DataStreams for. Since the client has given up waiting for the service to download the data streams.

# Results

## After

 ---> Halibut.Transport.Protocol.ProtocolException: Data stream reading failed. Message Id: IReadDataStreamService::SendDataAsync[1] / 0441e6e9-8aa4-4b57-b1ce-0925340cb159, Stream ID: e517a67d-e8ad-4af7-be18-f9748110fbc0, Expected length: 100, Actual bytes read: 18. Total length of all DataStreams to be sent is 100. Stream with length 100 was closed after only reading 18 bytes. Time elapsed downloading all streams: 44999ms.
 
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
