### PR TITLE
Add SNI support

### DIFF
--- a/source/Halibut/Queue/Redis/MessageStorage/IRehydrateDataStream.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/IRehydrateDataStream.cs
@@ -80,12 +80,12 @@ namespace Halibut.Queue.Redis.MessageStorage
             }
         }
 
-        /*public async Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken)
+        public async Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken)
         {
             await using var dataStreamRehydrationData = DataStreamRehydrationDataSupplier();
             
             await readerAsync(dataStreamRehydrationData.Data, cancellationToken);
              
-        }*/
+        }
     }
 }

--- a/source/Halibut/Queue/Redis/MessageStorage/IRehydrateDataStream.cs
+++ b/source/Halibut/Queue/Redis/MessageStorage/IRehydrateDataStream.cs
@@ -80,12 +80,12 @@ namespace Halibut.Queue.Redis.MessageStorage
             }
         }
 
-        public async Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken)
+        /*public async Task ReadAsync(Func<Stream, CancellationToken, Task> readerAsync, CancellationToken cancellationToken)
         {
             await using var dataStreamRehydrationData = DataStreamRehydrationDataSupplier();
             
             await readerAsync(dataStreamRehydrationData.Data, cancellationToken);
              
-        }
+        }*/
     }
 }

--- a/source/Halibut/ServiceEndPoint.cs
+++ b/source/Halibut/ServiceEndPoint.cs
@@ -77,12 +77,12 @@ namespace Halibut
         public ProxyDetails? Proxy { get; }
 
         /// <summary>
-        /// When set, TCP connections will be made to this host instead of the host in <see cref="BaseUri"/>,
-        /// while the original <see cref="BaseUri"/> host is still used for TLS SNI. This is equivalent to
-        /// curl's --resolve flag and is useful when routing through a local proxy (e.g. Toxiproxy) while
-        /// preserving the correct TLS handshake.
+        /// When set, TCP connections will be made to the host and port of this URI instead of those in
+        /// <see cref="BaseUri"/>, while the original <see cref="BaseUri"/> host is still used for TLS SNI.
+        /// This is equivalent to curl's --resolve flag and is useful when routing through a local proxy
+        /// (e.g. Toxiproxy) while preserving the correct TLS handshake.
         /// </summary>
-        public string? ForceResolveHost { get; set; }
+        public Uri? ForceResolveHost { get; set; }
 
         public bool IsWebSocketEndpoint => IsWebSocketAddress(BaseUri);
 

--- a/source/Halibut/ServiceEndPoint.cs
+++ b/source/Halibut/ServiceEndPoint.cs
@@ -76,6 +76,14 @@ namespace Halibut
 
         public ProxyDetails? Proxy { get; }
 
+        /// <summary>
+        /// When set, TCP connections will be made to this host and port instead of the host and port
+        /// in <see cref="BaseUri"/>, while the original <see cref="BaseUri"/> host is still used for
+        /// TLS SNI. This is equivalent to curl's --resolve flag and is useful when routing through a
+        /// local proxy (e.g. Toxiproxy) while preserving the correct TLS handshake.
+        /// </summary>
+        public (string Host, int Port)? ForceResolveAddress { get; set; }
+
         public bool IsWebSocketEndpoint => IsWebSocketAddress(BaseUri);
 
         public override string ToString() => baseUriString;

--- a/source/Halibut/ServiceEndPoint.cs
+++ b/source/Halibut/ServiceEndPoint.cs
@@ -77,12 +77,12 @@ namespace Halibut
         public ProxyDetails? Proxy { get; }
 
         /// <summary>
-        /// When set, TCP connections will be made to this host and port instead of the host and port
-        /// in <see cref="BaseUri"/>, while the original <see cref="BaseUri"/> host is still used for
-        /// TLS SNI. This is equivalent to curl's --resolve flag and is useful when routing through a
-        /// local proxy (e.g. Toxiproxy) while preserving the correct TLS handshake.
+        /// When set, TCP connections will be made to this host instead of the host in <see cref="BaseUri"/>,
+        /// while the original <see cref="BaseUri"/> host is still used for TLS SNI. This is equivalent to
+        /// curl's --resolve flag and is useful when routing through a local proxy (e.g. Toxiproxy) while
+        /// preserving the correct TLS handshake.
         /// </summary>
-        public (string Host, int Port)? ForceResolveAddress { get; set; }
+        public string? ForceResolveHost { get; set; }
 
         public bool IsWebSocketEndpoint => IsWebSocketAddress(BaseUri);
 

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -79,19 +79,21 @@ namespace Halibut.Transport
         internal static async Task<TcpClient> CreateConnectedTcpClientAsync(ServiceEndPoint endPoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, IStreamFactory streamFactory, ILog log, CancellationToken cancellationToken)
         {
             TcpClient client;
+            var connectHost = endPoint.ForceResolveAddress?.Host ?? endPoint.BaseUri.Host;
+            var connectPort = endPoint.ForceResolveAddress?.Port ?? endPoint.BaseUri.Port;
             if (endPoint.Proxy is null)
             {
                 client = CreateTcpClientAsync(halibutTimeoutsAndLimits);
-                await client.ConnectWithTimeoutAsync(endPoint.BaseUri, endPoint.TcpClientConnectTimeout, cancellationToken);
+                await client.ConnectWithTimeoutAsync(connectHost, connectPort, endPoint.TcpClientConnectTimeout, cancellationToken);
             }
             else
             {
                 log.Write(EventType.Diagnostic, "Creating a proxy client");
-                
+
                 client = await new ProxyClientFactory(streamFactory)
                     .CreateProxyClient(log, endPoint.Proxy)
                     .WithTcpClientFactory(() => CreateTcpClientAsync(halibutTimeoutsAndLimits))
-                    .CreateConnectionAsync(endPoint.BaseUri.Host, endPoint.BaseUri.Port, endPoint.TcpClientConnectTimeout, cancellationToken);
+                    .CreateConnectionAsync(connectHost, connectPort, endPoint.TcpClientConnectTimeout, cancellationToken);
             }
             return client;
         }

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -79,12 +79,11 @@ namespace Halibut.Transport
         internal static async Task<TcpClient> CreateConnectedTcpClientAsync(ServiceEndPoint endPoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, IStreamFactory streamFactory, ILog log, CancellationToken cancellationToken)
         {
             TcpClient client;
-            var connectHost = endPoint.ForceResolveAddress?.Host ?? endPoint.BaseUri.Host;
-            var connectPort = endPoint.ForceResolveAddress?.Port ?? endPoint.BaseUri.Port;
+            var connectHost = endPoint.ForceResolveHost ?? endPoint.BaseUri.Host;
             if (endPoint.Proxy is null)
             {
                 client = CreateTcpClientAsync(halibutTimeoutsAndLimits);
-                await client.ConnectWithTimeoutAsync(connectHost, connectPort, endPoint.TcpClientConnectTimeout, cancellationToken);
+                await client.ConnectWithTimeoutAsync(connectHost, endPoint.BaseUri.Port, endPoint.TcpClientConnectTimeout, cancellationToken);
             }
             else
             {
@@ -93,7 +92,7 @@ namespace Halibut.Transport
                 client = await new ProxyClientFactory(streamFactory)
                     .CreateProxyClient(log, endPoint.Proxy)
                     .WithTcpClientFactory(() => CreateTcpClientAsync(halibutTimeoutsAndLimits))
-                    .CreateConnectionAsync(connectHost, connectPort, endPoint.TcpClientConnectTimeout, cancellationToken);
+                    .CreateConnectionAsync(connectHost, endPoint.BaseUri.Port, endPoint.TcpClientConnectTimeout, cancellationToken);
             }
             return client;
         }

--- a/source/Halibut/Transport/TcpConnectionFactory.cs
+++ b/source/Halibut/Transport/TcpConnectionFactory.cs
@@ -79,11 +79,12 @@ namespace Halibut.Transport
         internal static async Task<TcpClient> CreateConnectedTcpClientAsync(ServiceEndPoint endPoint, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits, IStreamFactory streamFactory, ILog log, CancellationToken cancellationToken)
         {
             TcpClient client;
-            var connectHost = endPoint.ForceResolveHost ?? endPoint.BaseUri.Host;
+            var connectHost = endPoint.ForceResolveHost?.Host ?? endPoint.BaseUri.Host;
+            var connectPort = endPoint.ForceResolveHost?.Port ?? endPoint.BaseUri.Port;
             if (endPoint.Proxy is null)
             {
                 client = CreateTcpClientAsync(halibutTimeoutsAndLimits);
-                await client.ConnectWithTimeoutAsync(connectHost, endPoint.BaseUri.Port, endPoint.TcpClientConnectTimeout, cancellationToken);
+                await client.ConnectWithTimeoutAsync(connectHost, connectPort, endPoint.TcpClientConnectTimeout, cancellationToken);
             }
             else
             {
@@ -92,7 +93,7 @@ namespace Halibut.Transport
                 client = await new ProxyClientFactory(streamFactory)
                     .CreateProxyClient(log, endPoint.Proxy)
                     .WithTcpClientFactory(() => CreateTcpClientAsync(halibutTimeoutsAndLimits))
-                    .CreateConnectionAsync(connectHost, endPoint.BaseUri.Port, endPoint.TcpClientConnectTimeout, cancellationToken);
+                    .CreateConnectionAsync(connectHost, connectPort, endPoint.TcpClientConnectTimeout, cancellationToken);
             }
             return client;
         }


### PR DESCRIPTION
# AI Background

ref CLOUDPT-11160
ref EFT-3141

Add ForceResolveHost to ServiceEndPoint for SNI-preserving address override                                                                                                                                                                                                
                                                                                                                                                                                                                                                                           
  **Background: TLS and SNI**                                                                                                                                                                                                                                                    
   
  When a client opens a TLS (HTTPS) connection, it performs a handshake before any application data is exchanged. Part of that handshake is the client announcing — in plaintext — which hostname it wants to talk to. This field is called Server Name Indication (SNI). The
   server uses SNI to decide which TLS certificate to present, which is essential when many hostnames are served from the same IP address.                                                                                                                                   
                                                                                                                                                                                                                                                                             
  The key point: the hostname used for SNI is separate from the IP address the TCP connection is made to. DNS normally ties these together (you look up the hostname, get an IP, connect, and also use that hostname for SNI), but they are fundamentally independent.       
                                                                                                                                                                                                                                                                             
  **Background: curl's --resolve**                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
  curl has a flag that exploits this separation:                                                                                                                                                                                                                             
   
  curl --resolve polling.example.com:10943:127.0.0.1 https://polling.example.com:10943                                                                                                                                                                                       
                                                                                                                                                                                                                                                                             
  This tells curl: "when you need to TCP-connect to polling.example.com:10943, use 127.0.0.1 instead of doing a real DNS lookup — but still send polling.example.com as the SNI hostname in the TLS handshake."                                                              
                                                                                                                                                                                                                                                                             
  This is useful when you want to route traffic through a local tool (like a proxy or traffic shaper) while ensuring the remote server still sees the correct SNI and can respond with the right certificate.                                                                
                                                                      
  **The problem**                                                                                                                                                                                                                                                                
                                                                      
  Halibut derives both the TCP connect address and the TLS SNI hostname from ServiceEndPoint.BaseUri. There was no way to connect to a different address (e.g. a local Toxiproxy instance) while keeping the correct SNI hostname, without corrupting BaseUri to point at the
   proxy — which misrepresents the real remote endpoint.
                                                                                                                                                                                                                                                                             
  This matters in testing scenarios where Toxiproxy sits in front of a remote server to simulate network conditions (latency, disconnects, bandwidth limits). The TLS layer is still terminated at the real remote server, so SNI must match the real hostname.              
   
  **This change**                                                                                                                                                                                                                                                                
                                                                      
  Adds a ForceResolveHost property to ServiceEndPoint:

  var endpoint = new ServiceEndPoint(
      "https://polling.example.com:10943",  // real remote — used for SNI                                                                                                                                                                                                    
      remoteThumbprint,
      halibutTimeoutsAndLimits);                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                             
  endpoint.ForceResolveHost = new Uri("https://127.0.0.1:7778");  // connect here instead
                                                                                                                                                                                                                                                                             
  When set, TcpConnectionFactory uses ForceResolveHost's host and port for the TCP connection, while the TLS SNI target remains BaseUri.Host. BaseUri continues to accurately represent the real remote endpoint for logging, identification, and certificate validation     
  purposes.
                                                                                                                                                                                                                                                                             
  This is the Halibut equivalent of curl --resolve.                                                                                                                                                                                                                          

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
