### PR TITLE
Classify Windows TCP connect timeout as a network error

### DIFF
--- a/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
+++ b/source/Halibut/Diagnostics/ExceptionReturnedByHalibutProxyExtensionMethod.cs
@@ -115,7 +115,8 @@ namespace Halibut.Diagnostics
                 if (exception.Message.Contains("The remote party closed the WebSocket connection without completing the close handshake.")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("Unable to read data from the transport connection: Operation timed out.")) return HalibutNetworkExceptionType.IsNetworkError;
                 if (exception.Message.Contains("Unable to write data to the transport connection: Operation timed out.")) return HalibutNetworkExceptionType.IsNetworkError;
-                
+                if (exception.Message.Contains("The client was unable to establish the initial connection within the timeout")) return HalibutNetworkExceptionType.IsNetworkError;
+
             }
 
             return HalibutNetworkExceptionType.UnknownError;


### PR DESCRIPTION
## Summary

- On Windows 2019, connecting to a port with no listener often returns a connection timeout rather than an immediate RST, producing the message "The client was unable to establish the initial connection within the timeout".
- This message was missing from the `IsNetworkError` recogniser in `ExceptionReturnedByHalibutProxyExtensionMethod.cs`, causing it to fall through to `UnknownError` instead of `IsNetworkError`.
- Adds the missing string match so Windows TCP connect timeouts are correctly classified as network errors.

## Test plan

- [ ] `ExceptionReturnedByHalibutProxyExtensionMethodFixture` — all 24 tests pass locally (verified before commit)
- [ ] CI run on Windows 2019 net8.0 — fixes `BecauseTheProxyIsNotResponding_TheExceptionShouldBeANetworkError` and `WhenTheConnectionTerminatesWaitingForAResponse` failures seen in nightly builds 4709 and 4710

Identified via analysis of two consecutive failing nightly builds on Windows 2019 (`8.1.4709` and `8.1.4710`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
