### PR TITLE
Accept Windows TCP connect timeout in ExceptionContractFixture

### DIFF
--- a/source/Halibut.Tests/ExceptionContractFixture.cs
+++ b/source/Halibut.Tests/ExceptionContractFixture.cs
@@ -125,7 +125,9 @@ namespace Halibut.Tests
             (await AssertException.Throws<HalibutClientException>(async () => await client.SayHelloAsync("Hello", new(CancellationToken))))
                 .And.Message.Should().ContainAny(
                     $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: No connection could be made because the target machine actively refused it",
-                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Connection refused");
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: Connection refused",
+                    // On Windows, a disposed port forwarder causes a TCP connect timeout rather than an immediate RST
+                    $"An error occurred when sending a request to '{clientAndService.ServiceUri}', before the request could begin: The client was unable to establish the initial connection within the timeout");
         }
 
         [Test]


### PR DESCRIPTION
﻿## Summary

- On Windows 2019, when the port forwarder is disposed (no longer listening), TCP SYN packets are dropped rather than immediately refused with RST. The client gets `"The client was unable to establish the initial connection within the timeout"` instead of `"Connection refused"` or `"actively refused it"`.
- `WhenTheListeningRequestFailsToBeSent_AsTheServiceDoesNotAcceptTheConnection` was asserting only on Linux/Windows-RST message strings, causing it to fail on Windows 2019.
- Adds the Windows timeout message as a valid `ContainAny` alternative so the test passes on both platforms.

## Test plan

- [ ] `WhenTheListeningRequestFailsToBeSent_AsTheServiceDoesNotAcceptTheConnection` and the two related variants — 3/3 pass locally
- [ ] CI run on Windows 2019 net8.0 — fixes the `ExceptionContractFixture` failure seen in nightly builds 4709 and 4710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
