### PR TITLE
Mark resource-intensive test fixtures as NonParallelizable

### DIFF
--- a/source/Halibut.Tests/BadCertificatesTests.cs
+++ b/source/Halibut.Tests/BadCertificatesTests.cs
@@ -18,6 +18,7 @@ using NUnit.Framework;
 
 namespace Halibut.Tests
 {
+    [NonParallelizable]
     public class BadCertificatesTests : BaseTest
     {
         [Test]

--- a/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
+++ b/source/Halibut.Tests/CancellationViaClientProxyFixture.cs
@@ -17,6 +17,7 @@ using NUnit.Framework;
 
 namespace Halibut.Tests
 {
+    [NonParallelizable]
     public class CancellationViaClientProxyFixture : BaseTest
     {
         [Test]

--- a/source/Halibut.Tests/ProxyFixture.cs
+++ b/source/Halibut.Tests/ProxyFixture.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 
 namespace Halibut.Tests
 {
+    [NonParallelizable]
     public class ProxyFixture : BaseTest
     {
         [Test]


### PR DESCRIPTION
## Summary

The test suite runs with `[assembly: Parallelizable(ParallelScope.All)]`, meaning all fixtures execute concurrently by default. Three fixtures deliberately hold sockets, TLS connections, and threads open for extended periods as part of their test design. When run alongside the full suite they compete for ports and thread-pool threads, causing spurious failures in unrelated tests. This change marks them `[NonParallelizable]` so they run in isolation.

### ProxyFixture

Two of the three tests dispose or pause a real HTTP/SOCKS proxy mid-test and then drive the client through its retry loop (`RetryCountLimit = 2`, `TcpClientConnectTimeout = 5s`, `PollingRequestQueueTimeout = 10s`). Each attempt opens a socket and waits for a connect or read timeout before giving up. The sequence of retries holds file descriptors and OS socket state for ~10–20 seconds per test invocation, a long window during which concurrent tests can exhaust the available ephemeral port range.

### BadCertificatesTests

Tests repeatedly establish TLS handshakes with mismatched certificates, causing the SSL layer to reject and retry connections in a tight loop. Several tests set `PollingRequestQueueTimeout = TimeSpan.FromSeconds(2000)` and use `Wait.UntilActionSucceeds` loops of up to 20 seconds while the wrong-cert client keeps reconnecting. This produces a sustained burst of TLS negotiation work (certificate parsing, crypto operations) and open sockets that can saturate the thread pool and port space when competing with the rest of the suite.

### CancellationViaClientProxyFixture

Tests use `EnterKillNewAndExistingConnectionsMode()` combined with `TryAndConnectForALongTime()` to hold the client in a connecting loop, and separately hold an RPC call in-flight (blocking on a sentinel file) before cancelling it. Both patterns keep connections and thread-pool work items live for several seconds by design. The in-flight cancellation test also introduces a deliberate `Task.Delay(2s)` after cancellation to allow propagation, adding to the window of resource contention.

## Test plan

- [ ] Verify existing tests in all three fixtures still pass (no assertions were changed)
- [ ] Confirm CI run shows reduced port/thread contention failures in unrelated fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)