### PR TITLE
Fix race condition in ObserveUnauthorizedPollingConnections test

### DIFF
--- a/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientAndLatestServiceBuilder.cs
@@ -297,6 +297,12 @@ namespace Halibut.Tests.Support
             return this;
         }
 
+        public LatestClientAndLatestServiceBuilder WithClientTrustingNoThumbprints()
+        {
+            clientBuilder.WithClientTrustingNoThumbprints();
+            return this;
+        }
+
         public LatestClientAndLatestServiceBuilder WithServiceTrustingTheWrongCertificate()
         {
             serviceBuilder.WithServiceTrustingTheWrongCertificate();

--- a/source/Halibut.Tests/Support/LatestClientBuilder.cs
+++ b/source/Halibut.Tests/Support/LatestClientBuilder.cs
@@ -24,7 +24,8 @@ namespace Halibut.Tests.Support
         CertAndThumbprint clientCertAndThumbprint;
         readonly PollingQueueTestCase? pollingQueueTestCase;
 
-        string clientTrustsThumbprint; 
+        string clientTrustsThumbprint;
+        bool clientTrustsNoThumbprints;
         IRpcObserver? clientRpcObserver;
         Func<int, PortForwarder>? portForwarderFactory;
         Reference<PortForwarder>? portForwarderReference;
@@ -181,6 +182,12 @@ namespace Halibut.Tests.Support
             clientTrustsThumbprint = CertAndThumbprint.Wrong.Thumbprint;
             return this;
         }
+
+        public LatestClientBuilder WithClientTrustingNoThumbprints()
+        {
+            clientTrustsNoThumbprints = true;
+            return this;
+        }
         
         public LatestClientBuilder WithClientRpcObserver(IRpcObserver? clientRpcObserver)
         {
@@ -215,7 +222,10 @@ namespace Halibut.Tests.Support
             }
 
             var client = clientBuilder.Build();
-            client.Trust(clientTrustsThumbprint);
+            if (!clientTrustsNoThumbprints)
+            {
+                client.Trust(clientTrustsThumbprint);
+            }
             
             var disposableCollection = new DisposableCollection();
             PortForwarder? portForwarder = null;

--- a/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
+++ b/source/Halibut.Tests/Transport/Observability/ConnectionObserverFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -83,10 +82,10 @@ namespace Halibut.Tests.Transport.Observability
             await using (var clientAndBuilder = await clientAndServiceTestCase.CreateTestCaseBuilder()
                              .WithStandardServices()
                              .AsLatestClientAndLatestServiceBuilder()
+                             .WithClientTrustingNoThumbprints()
                              .WithConnectionObserverOnTcpServer(connectionsObserver)
                              .Build(CancellationToken))
             {
-                clientAndBuilder.Client.TrustOnly(new List<string>());
 
                 using var cts = new CancellationTokenSource();
                 var token = cts.Token;


### PR DESCRIPTION
## Summary

Fixes a flaky test failure in `ObserveUnauthorizedPollingConnections` (Polling, InMemory queue) observed in CI build `8.1.4994-pull-712` on Windows Server 2012 R2 / net48.

## Root cause

The test was calling `clientAndBuilder.Client.TrustOnly(new List<string>())` **after** `Build()` returned, relying on that call to prevent any authorized connections from being observed. However, `Build()` starts the polling service immediately, and the service begins connecting to the client's TCP listener within milliseconds — creating a race window where the first polling connection could be fully authorized before `TrustOnly` was called.

When that happened, the sequence in `SecureListener` was:

1. Polling service connects and TLS handshake completes
2. `Authorize()` calls `verifyClientThumbprint` — cert **still trusted** at this point → returns `true`
3. `connectionAuthorizedAndObserved = true`; `ConnectionAccepted(true)` fires
4. `ExchangeMessages` begins
5. **`TrustOnly(new List<string>())` runs** — but too late for this connection
6. Connection eventually closes → `ConnectionClosed(connectionAuthorizedAndObserved)` fires as `true`
7. Assertion `ConnectionClosedAuthorized.AllSatisfy(a => a.BeFalse())` fails

The race was intermittent because the window is only a few milliseconds wide. It was more likely to trigger under load (e.g. when multiple `ConnectionObserverFixture` tests ran concurrently), as seen in the CI log where `ObserveAuthorizedConnections(Polling)` and `ObserveUnauthorizedPollingConnections(Polling)` overlapped in time.

The listening variant of this test (`ObserveUnauthorizedListeningConnections`) has never had this issue because it uses `WithServiceTrustingTheWrongCertificate()`, which configures the wrong certificate **before** `Build()` — so connections are unauthorized from the very first attempt.

## Fix

Adds `WithClientTrustingNoThumbprints()` to `LatestClientBuilder` and `LatestClientAndLatestServiceBuilder`. When set, the builder skips the `client.Trust(thumbprint)` call, leaving the client's trust provider empty before `Build()` starts the polling service. This eliminates the race entirely: no connection can ever be authorized because trust is never established.

The test now mirrors the pattern used by the listening variant — unauthorized behaviour is configured at builder time rather than mutated post-build.

## Test results

- `net48`: 2 passed (InMemory + Redis queue variants) — the target framework from the failing CI run
- `net8.0`: Redis variant skipped due to Docker not available locally; InMemory variant passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)